### PR TITLE
Fix: revert install command to working plugin syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Skills also activate automatically based on what you're doing — designing an A
 **Marketplace install:**
 
 ```
-/install github:addyosmani/agent-skills
+/plugin marketplace add addyosmani/agent-skills
+/plugin install agent-skills@addy-agent-skills
 ```
 
 **Local / development:**


### PR DESCRIPTION
## Summary
- Reverts the install command from `/install github:addyosmani/agent-skills` (which throws "Args from unknown skill" errors) back to the working two-step syntax:
  ```
  /plugin marketplace add addyosmani/agent-skills
  /plugin install agent-skills@addy-agent-skills
  ```

Fixes #11