### PR TITLE
Add CI workflow to validate plugin installation

### DIFF
--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -1,0 +1,41 @@
+name: Test Plugin Installation
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Validate plugin structure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Validate marketplace and plugin manifests
+        run: claude plugin validate .
+
+  test-install:
+    name: Test plugin installation
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Configure git to use HTTPS
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
+      - name: Add marketplace
+        run: claude plugin marketplace add ./
+
+      - name: List marketplaces
+        run: claude plugin marketplace list
+
+      - name: Install plugin
+        run: claude plugin install agent-skills@addy-agent-skills --scope user


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that validates the plugin structure and tests end-to-end installation on every push and PR
- Two jobs: `validate` (runs `claude plugin validate .`) and `test-install` (runs `marketplace add` + `plugin install`)
- No `ANTHROPIC_API_KEY` needed — plugin CLI commands are filesystem/git operations, not LLM calls
- Proven on fork CI: https://github.com/federicobartoli/agent-skills/actions/runs/23965001977

## What it catches
- Broken `marketplace.json` or `plugin.json` schema
- Invalid skill/agent/command frontmatter
- Plugin installation failures (e.g. the `/install github:...` syntax issue from #11)

## References
- [Plugin marketplace CLI docs](https://code.claude.com/docs/en/plugin-marketplaces#manage-marketplaces-from-the-cli)
- [Plugin validation docs](https://code.claude.com/docs/en/plugins-reference#debugging-and-development-tools)
- [Discover and install plugins](https://code.claude.com/docs/en/discover-plugins)