### PR TITLE
Fix simplify-ignore bugs from PR #7 review

### DIFF
--- a/hooks/SIMPLIFY-IGNORE.md
+++ b/hooks/SIMPLIFY-IGNORE.md
@@ -73,8 +73,10 @@ Any comment style works (`//`, `/*`, `#`, `<!--`). Multiple blocks per file and 
 If Claude Code crashes without triggering the Stop hook, files on disk may still have `BLOCK_<hash>` placeholders. To restore manually:
 
 ```bash
-echo '{}' | bash hooks/simplify-ignore.sh
+bash hooks/simplify-ignore.sh
 ```
+
+Run from your project root, or set `CLAUDE_PROJECT_DIR` to the project path.
 
 Backups are stored in `.claude/.simplify-ignore-cache/` within your project directory.
 

--- a/hooks/simplify-ignore-test.sh
+++ b/hooks/simplify-ignore-test.sh
@@ -241,6 +241,83 @@ printf '\nTest 10: Malformed JSON input produces warning\n'
 warning_out=$(echo 'NOT_JSON{{{' | bash hooks/simplify-ignore.sh 2>&1) || true
 assert_eq "warning on bad JSON" "1" "$(printf '%s' "$warning_out" | grep -c 'Warning.*failed to parse')"
 
+# ── Test 11: Empty JSON {} from pipe does NOT trigger restore (Bug 3) ───
+printf '\nTest 11: Empty JSON from pipe does not silently restore\n'
+
+BUG3_DIR="$TMPDIR/bug3-test"
+mkdir -p "$BUG3_DIR/.claude/.simplify-ignore-cache"
+BUG3_CACHE="$BUG3_DIR/.claude/.simplify-ignore-cache"
+BUG3_ID="testfile12345678"
+printf 'original content\n' > "$BUG3_DIR/target.js"
+cp "$BUG3_DIR/target.js" "$BUG3_CACHE/${BUG3_ID}.bak"
+printf '%s' "$BUG3_DIR/target.js" > "$BUG3_CACHE/${BUG3_ID}.path"
+printf 'model changed this\n' > "$BUG3_DIR/target.js"
+
+bug3_stderr=$(echo '{}' | CLAUDE_PROJECT_DIR="$BUG3_DIR" bash hooks/simplify-ignore.sh 2>&1) || true
+bug3_content=$(cat "$BUG3_DIR/target.js")
+assert_eq "empty JSON from pipe does not revert file" "model changed this" "$bug3_content"
+assert_eq "warning emitted for empty tool_name from pipe" "1" \
+  "$(printf '%s' "$bug3_stderr" | grep -c 'Warning.*empty tool_name')"
+
+# ── Test 12: Piped Stop event restores correctly ────────────────────────
+printf '\nTest 12: Piped Stop event restores correctly\n'
+
+STOP_DIR="$TMPDIR/stop-test"
+mkdir -p "$STOP_DIR/.claude/.simplify-ignore-cache"
+STOP_CACHE="$STOP_DIR/.claude/.simplify-ignore-cache"
+STOP_ID="testfile78901234"
+printf 'original content\n' > "$STOP_DIR/target.js"
+cp "$STOP_DIR/target.js" "$STOP_CACHE/${STOP_ID}.bak"
+printf '%s' "$STOP_DIR/target.js" > "$STOP_CACHE/${STOP_ID}.path"
+printf 'BLOCK_deadbeef placeholder\n' > "$STOP_DIR/target.js"
+mkdir -p "$STOP_CACHE/${STOP_ID}.lock"
+
+echo '{"hook_event_name":"Stop","stop_reason":"end_turn"}' \
+  | CLAUDE_PROJECT_DIR="$STOP_DIR" bash hooks/simplify-ignore.sh 2>/dev/null
+stop_content=$(cat "$STOP_DIR/target.js")
+assert_eq "stop_reason input restores file" "original content" "$stop_content"
+
+# ── Test 13: tool_name present but file_path missing exits cleanly ──────
+printf '\nTest 13: tool_name present but file_path missing\n'
+
+PART_DIR="$TMPDIR/partial-test"
+mkdir -p "$PART_DIR/.claude/.simplify-ignore-cache"
+PART_CACHE="$PART_DIR/.claude/.simplify-ignore-cache"
+PART_ID="testfiledef01234"
+printf 'original\n' > "$PART_DIR/target.js"
+cp "$PART_DIR/target.js" "$PART_CACHE/${PART_ID}.bak"
+printf '%s' "$PART_DIR/target.js" > "$PART_CACHE/${PART_ID}.path"
+printf 'model work\n' > "$PART_DIR/target.js"
+
+rc=0
+echo '{"hook_event_name":"PreToolUse","tool_name":"Read"}' \
+  | CLAUDE_PROJECT_DIR="$PART_DIR" bash hooks/simplify-ignore.sh 2>/dev/null || rc=$?
+part_content=$(cat "$PART_DIR/target.js")
+assert_eq "missing file_path exits without restore" "model work" "$part_content"
+assert_eq "exit code 0" "0" "$rc"
+
+# ── Test 14: Single-line block hash computed exactly once (Bug 1) ───────
+printf '\nTest 14: Single-line block hash unique count\n'
+rm -f "$CACHE"/*
+
+SRC="$TMPDIR/hash-once.js"
+DEST="$TMPDIR/hash-once-filtered.js"
+cat > "$SRC" <<'EOF'
+/* simplify-ignore-start */ secret(); /* simplify-ignore-end */
+EOF
+
+FID="test_hash_once"
+filter_file "$SRC" "$DEST" "$FID"
+
+block_files=$(ls "$CACHE/${FID}".block.* 2>/dev/null | wc -l | tr -d ' ')
+assert_eq "single-line: exactly one block file (hash computed once)" "1" "$block_files"
+
+placeholder_lines=$(grep -c 'BLOCK_' "$DEST")
+assert_eq "single-line: exactly one placeholder line (no double-write)" "1" "$placeholder_lines"
+
+output_lines=$(wc -l < "$DEST" | tr -d ' ')
+assert_eq "single-line: output line count matches" "1" "$output_lines"
+
 # ── Summary ──────────────────────────────────────────────────────────────
 printf '\n══════════════════════════════════════════\n'
 printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/hooks/simplify-ignore.sh
+++ b/hooks/simplify-ignore.sh
@@ -18,7 +18,9 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 CACHE="${CLAUDE_PROJECT_DIR:-.}/.claude/.simplify-ignore-cache"
-if [ -t 0 ]; then INPUT="{}"; else INPUT=$(cat); fi
+IS_TTY=0
+if [ -t 0 ]; then INPUT="{}"; IS_TTY=1; else INPUT=$(cat); fi
+HOOK_EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null) || HOOK_EVENT=""
 
 # Parse hook input — trap errors explicitly so set -e doesn't cause
 # a silent exit on malformed JSON, and surface a useful diagnostic.
@@ -61,9 +63,10 @@ filter_file() {
   : > "$dest"
   rm -f "$CACHE/${fid}".block.* "$CACHE/${fid}".reason.* "$CACHE/${fid}".prefix.* "$CACHE/${fid}".suffix.*
 
-  local count=0 in_block=0 buf="" reason="" prefix="" suffix=""
+  local count=0 in_block=0 handled=0 buf="" reason="" prefix="" suffix=""
 
   while IFS= read -r line || [ -n "$line" ]; do
+    handled=0
     # Check for start marker (no fork — uses bash case)
     if [ $in_block -eq 0 ]; then
       case "$line" in *simplify-ignore-start*)
@@ -92,6 +95,7 @@ filter_file() {
             printf '%s\n' "${prefix}BLOCK_${h}${suffix}" >> "$dest"
           fi
           buf=""; reason=""; prefix=""; suffix=""
+          handled=1
           continue
           ;; *)
           continue
@@ -104,26 +108,28 @@ filter_file() {
       buf="${buf}
 ${line}"
     fi
-    # Check for end marker
-    case "$line" in *simplify-ignore-end*)
-      if [ $in_block -eq 1 ]; then
-        local h; h=$(block_hash "$buf")
-        count=$((count + 1))
-        printf '%s' "$buf" > "$CACHE/${fid}.block.${h}"
-        [ -n "$reason" ] && printf '%s' "$reason" > "$CACHE/${fid}.reason.${h}"
-        printf '%s' "$prefix" > "$CACHE/${fid}.prefix.${h}"
-        printf '%s' "$suffix" > "$CACHE/${fid}.suffix.${h}"
-        if [ -n "$reason" ]; then
-          printf '%s\n' "${prefix}BLOCK_${h}: ${reason}${suffix}" >> "$dest"
-        else
-          printf '%s\n' "${prefix}BLOCK_${h}${suffix}" >> "$dest"
+    # Check for end marker (skipped if single-line block already handled above)
+    if [ $handled -eq 0 ]; then
+      case "$line" in *simplify-ignore-end*)
+        if [ $in_block -eq 1 ]; then
+          local h; h=$(block_hash "$buf")
+          count=$((count + 1))
+          printf '%s' "$buf" > "$CACHE/${fid}.block.${h}"
+          [ -n "$reason" ] && printf '%s' "$reason" > "$CACHE/${fid}.reason.${h}"
+          printf '%s' "$prefix" > "$CACHE/${fid}.prefix.${h}"
+          printf '%s' "$suffix" > "$CACHE/${fid}.suffix.${h}"
+          if [ -n "$reason" ]; then
+            printf '%s\n' "${prefix}BLOCK_${h}: ${reason}${suffix}" >> "$dest"
+          else
+            printf '%s\n' "${prefix}BLOCK_${h}${suffix}" >> "$dest"
+          fi
+          in_block=0; buf=""; reason=""; prefix=""; suffix=""
+          continue
         fi
-        in_block=0; buf=""; reason=""; prefix=""; suffix=""
-        continue
-      fi
-      ;;
-    esac
-    [ $in_block -eq 0 ] && printf '%s\n' "$line" >> "$dest"
+        ;;
+      esac
+    fi
+    [ $in_block -eq 0 ] && [ $handled -eq 0 ] && printf '%s\n' "$line" >> "$dest"
   done < "$src"
 
   # Unclosed block → flush as-is
@@ -142,7 +148,9 @@ ${line}"
 }
 
 # ── Stop: restore all files from backup ───────────────────────────────────────
-if [ -z "$TOOL_NAME" ]; then
+# Detect Stop event explicitly via hook_event_name (sent by Claude Code),
+# or via interactive TTY invocation (manual crash recovery).
+if [ "$HOOK_EVENT" = "Stop" ] || { [ "$IS_TTY" -eq 1 ] && [ -z "$TOOL_NAME" ]; }; then
   [ -d "$CACHE" ] || exit 0
   for bak in "$CACHE"/*.bak; do
     [ -f "$bak" ] || continue
@@ -168,6 +176,15 @@ if [ -z "$TOOL_NAME" ]; then
     [ -d "$lockdir" ] || continue
     rmdir "$lockdir" 2>/dev/null
   done
+  exit 0
+fi
+
+# Guard: empty TOOL_NAME from piped input without Stop event = malformed input.
+# Don't silently proceed — warn and exit to prevent accidental data loss.
+if [ -z "$TOOL_NAME" ] && [ "$IS_TTY" -eq 0 ]; then
+  if [ -d "$CACHE" ] && ls "$CACHE"/*.bak >/dev/null 2>&1; then
+    printf 'Warning: empty tool_name with no Stop event; skipping to prevent data loss (input: %.120s)\n' "$INPUT" >&2
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

Addresses the three issues @addyosmani flagged in the [PR #7 review](https://github.com/addyosmani/agent-skills/pull/7#issuecomment-4146310951):

- **Silent file restoration (data-loss bug):** piping `{}` or any JSON without `tool_name` triggered the Stop/restore block, silently reverting all protected files. Fixed by parsing `hook_event_name` explicitly and adding a guard that warns instead of restoring on ambiguous input.
- **Single-line block fragility:** the nested `case` + `continue` pattern worked but relied on a non-obvious control flow. Added a `handled` flag as defense-in-depth so the end-marker check and the normal-line write are both skipped when a single-line block was already processed.
- **Trailing newline (`dd`):** already fixed before merge (uses`perl -pe 'chomp if eof'`). No changes needed.

## Test plan

- [x] 29 assertions pass on macOS Bash 3.2 and default bash
- [x] Manual verification: `echo '{}' | hook` no longer restores files
- [x] Manual verification: `{"hook_event_name":"Stop"}` still restores
- [x] Manual verification: TTY crash recovery (`bash hooks/simplify-ignore.sh`) still works
