### PR TITLE
docs: fix Gemini CLI installation path for skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,16 @@ Copy any `SKILL.md` into `.cursor/rules/`, or reference the full `skills/` direc
 
 Install as native skills for auto-discovery, or add to `GEMINI.md` for persistent context. See [docs/gemini-cli-setup.md](docs/gemini-cli-setup.md).
 
+**Install from the repo:**
+
 ```bash
-gemini skills install https://github.com/addyosmani/agent-skills.git
+gemini skills install https://github.com/addyosmani/agent-skills.git --path skills
+```
+
+**Install from a local clone:**
+
+```bash
+gemini skills install ./agent-skills/skills/
 ```
 
 </details>

--- a/docs/gemini-cli-setup.md
+++ b/docs/gemini-cli-setup.md
@@ -9,20 +9,20 @@ Gemini CLI has a native skills system that auto-discovers `SKILL.md` files in `.
 **Install from the repo:**
 
 ```bash
-gemini skills install https://github.com/addyosmani/agent-skills.git
+gemini skills install https://github.com/addyosmani/agent-skills.git --path skills
 ```
 
 **Or install from a local clone:**
 
 ```bash
 git clone https://github.com/addyosmani/agent-skills.git
-gemini skills install /path/to/agent-skills
+gemini skills install /path/to/agent-skills/skills/
 ```
 
 **Install for a specific workspace only:**
 
 ```bash
-gemini skills install /path/to/agent-skills --scope workspace
+gemini skills install /path/to/agent-skills/skills/ --scope workspace
 ```
 
 Skills installed at workspace scope go into `.gemini/skills/` (or `.agents/skills/`). User-level skills go into `~/.gemini/skills/`.


### PR DESCRIPTION
Issue: Fixes #28 

  **Problem:**
  The gemini skills install command only searches one level deep from the provided path for SKILL.md files. In this repository, skills are organized
  in subdirectories under skills/ (e.g., skills/skill-name/SKILL.md). When users pointed the installer to the root or just the folder name, it would
  fail to find any valid skills.

  **Solution:**
  Updated the documentation in README.md and docs/gemini-cli-setup.md to:
   1. Add the --path skills flag for remote repository installations.
   2. Point to the skills/ subdirectory for local installations from a clone.

  **Verification:**
  Confirmed that with these changes, the Gemini CLI correctly identifies and installs all 19 skills:
   - Remote: gemini skills install https://github.com/addyosmani/agent-skills.git --path skills
   - Local: gemini skills install ./agent-skills/skills/