### PR TITLE
Add SSH troubleshooting hint to marketplace install

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Skills also activate automatically based on what you're doing — designing an A
 /plugin install agent-skills@addy-agent-skills
 ```
 
+> **SSH errors?** The marketplace clones repos via SSH. If you don't have SSH keys set up on GitHub, either [add your SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) or switch to HTTPS for fetches only:
+> ```bash
+> git config --global url."https://github.com/".insteadOf "git@github.com:"
+> ```
+
 **Local / development:**
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a short note under the Claude Code marketplace install instructions explaining why the install can fail with `Permission denied (publickey)` and how to fix it.

**The problem:** The marketplace clones repos via SSH by default. Users without SSH keys configured on GitHub hit a `Permission denied (publickey)` error (see #32).

**The fix:** A one-liner `git config` command that tells Git to use HTTPS for GitHub fetches, or a link to GitHub's SSH key setup guide.

Closes #32