### PR TITLE
docs: update Cursor setup to use .mdc format with frontmatter guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ claude --plugin-dir /path/to/agent-skills
 <details>
 <summary><b>Cursor</b></summary>
 
-Copy any `SKILL.md` into `.cursor/rules/`, or reference the full `skills/` directory. See [docs/cursor-setup.md](docs/cursor-setup.md).
+Copy any `SKILL.md` into `.cursor/rules/`, or reference the full `skills/` directory. Use the `.mdc` extension and update the YAML frontmatter (`description`, `globs`, `alwaysApply`). See [docs/cursor-setup.md](docs/cursor-setup.md).
 
 </details>
 

--- a/docs/cursor-setup.md
+++ b/docs/cursor-setup.md
@@ -4,19 +4,39 @@
 
 ### Option 1: Rules Directory (Recommended)
 
-Cursor supports a `.cursor/rules/` directory for project-specific rules:
+Cursor uses [`.mdc` files](https://cursor.com/docs/rules) in `.cursor/rules/` for project-specific rules. Each `.mdc` file has YAML frontmatter that controls when the rule is loaded into context.
 
 ```bash
 # Create the rules directory
 mkdir -p .cursor/rules
 
-# Copy skills you want as rules
-cp /path/to/agent-skills/skills/test-driven-development/SKILL.md .cursor/rules/test-driven-development.md
-cp /path/to/agent-skills/skills/code-review-and-quality/SKILL.md .cursor/rules/code-review-and-quality.md
-cp /path/to/agent-skills/skills/incremental-implementation/SKILL.md .cursor/rules/incremental-implementation.md
+# Copy skills you want as rules (note the .mdc extension)
+cp /path/to/agent-skills/skills/test-driven-development/SKILL.md .cursor/rules/test-driven-development.mdc
+cp /path/to/agent-skills/skills/code-review-and-quality/SKILL.md .cursor/rules/code-review-and-quality.mdc
+cp /path/to/agent-skills/skills/incremental-implementation/SKILL.md .cursor/rules/incremental-implementation.mdc
 ```
 
-Rules in this directory are automatically loaded into Cursor's context.
+After copying, update the YAML frontmatter in each `.mdc` file. Each `SKILL.md` ships with `name` and `description` fields, but Cursor expects `description`, `globs`, and optionally `alwaysApply`. Replace the frontmatter block so Cursor picks it up correctly:
+
+```yaml
+---
+description: "Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior."
+globs: 
+alwaysApply: false
+---
+```
+
+> **Example `globs` values:** `**/*.ts` for TypeScript, `**/*.rb` for Ruby, `**/*.rs` for Rust, `**/*.cs` for C#. Set this to match your project's language so the rule only activates on relevant files.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `description` | string | What the rule does (shown in the Cursor rule picker) |
+| `globs` | string | File pattern that activates the rule when matching files are open |
+| `alwaysApply` | boolean | If `true`, rule is loaded into every conversation regardless of open files |
+
+> **Tip:** Prefer `globs` over `alwaysApply: true`. Glob-scoped rules only activate when relevant files are open, keeping context usage efficient. Use `alwaysApply` sparingly for universal project standards.
+
+Rules in this directory are automatically loaded into Cursor's context. When `globs` are set, rules only activate when matching files are open.
 
 ### Option 2: .cursorrules File
 
@@ -44,9 +64,9 @@ Cursor's Notepads feature lets you store reusable context. Create a notepad for 
 
 Add these to `.cursor/rules/`:
 
-1. `test-driven-development.md` — TDD workflow and Prove-It pattern
-2. `code-review-and-quality.md` — Five-axis review
-3. `incremental-implementation.md` — Build in small verifiable slices
+1. `test-driven-development.mdc` — TDD workflow and Prove-It pattern
+2. `code-review-and-quality.mdc` — Five-axis review
+3. `incremental-implementation.mdc` — Build in small verifiable slices
 
 ### Phase-Specific Skills (Load as Notepads)
 


### PR DESCRIPTION
Cursor rules can use richer `.mdc` files (see: https://cursor.com/docs/rules#rule-file-structure) with a YAML _frontmatter_ (description, globs, alwaysApply), rather than plain `.md` files for a better Cursor experience and precisely for more targeted usage of the rules.

This PR updates docs/cursor-setup.md to document the better `.mdc` file extension, adds a before/after frontmatter example, ands explain the available frontmatter fields. Also updates the file references in Recommended Configuration from `.md` to `.mdc`, and adjusts the README Cursor blurb to mention `.mdc` and frontmatter.

In overall, this PR aims to improve the experience for Cursor users.

V.

(Dear Addy, unrelated to PR, much, **much** respect for your work, talks, online presence, thx for everything, really, esp the JavaScript Design Patterns book I read a while while ago... stay awesome <3)