### PR TITLE
feat: source-driven-development skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ docs/         → Setup guides for different tools
 
 **Define:** spec-driven-development
 **Plan:** planning-and-task-breakdown
-**Build:** incremental-implementation, test-driven-development, context-engineering, frontend-ui-engineering, api-and-interface-design
+**Build:** incremental-implementation, test-driven-development, context-engineering, source-driven-development, frontend-ui-engineering, api-and-interface-design
 **Verify:** browser-testing-with-devtools, debugging-and-error-recovery
 **Review:** code-review-and-quality, code-simplification, security-and-hardening, performance-optimization
 **Ship:** git-workflow-and-versioning, ci-cd-and-automation, deprecation-and-migration, documentation-and-adrs, shipping-and-launch

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ Skills are plain Markdown - they work with any agent that accepts system prompts
 
 ---
 
-## All 19 Skills
+## All 20 Skills
 
-The commands above are the entry points. Under the hood, they activate these 19 skills — each one a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
+The commands above are the entry points. Under the hood, they activate these 20 skills — each one a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
 
 ### Define - Clarify what to build
 
@@ -141,6 +141,7 @@ The commands above are the entry points. Under the hood, they activate these 19 
 | [incremental-implementation](skills/incremental-implementation/SKILL.md) | Thin vertical slices - implement, test, verify, commit. Feature flags, safe defaults, rollback-friendly changes | Any change touching more than one file |
 | [test-driven-development](skills/test-driven-development/SKILL.md) | Red-Green-Refactor, test pyramid (80/15/5), test sizes, DAMP over DRY, Beyonce Rule, browser testing | Implementing logic, fixing bugs, or changing behavior |
 | [context-engineering](skills/context-engineering/SKILL.md) | Feed agents the right information at the right time - rules files, context packing, MCP integrations | Starting a session, switching tasks, or when output quality drops |
+| [source-driven-development](skills/source-driven-development/SKILL.md) | Ground every framework decision in official documentation - verify, cite sources, flag what's unverified | You want authoritative, source-cited code for any framework or library |
 | [frontend-ui-engineering](skills/frontend-ui-engineering/SKILL.md) | Component architecture, design systems, state management, responsive design, WCAG 2.1 AA accessibility | Building or modifying user-facing interfaces |
 | [api-and-interface-design](skills/api-and-interface-design/SKILL.md) | Contract-first design, Hyrum's Law, One-Version Rule, error semantics, boundary validation | Designing APIs, module boundaries, or public interfaces |
 
@@ -232,12 +233,13 @@ Every skill follows a consistent anatomy:
 
 ```
 agent-skills/
-├── skills/                            # 19 core skills (SKILL.md per directory)
+├── skills/                            # 20 core skills (SKILL.md per directory)
 │   ├── idea-refine/                   #   Define
 │   ├── spec-driven-development/       #   Define
 │   ├── planning-and-task-breakdown/   #   Plan
 │   ├── incremental-implementation/    #   Build
 │   ├── context-engineering/           #   Build
+│   ├── source-driven-development/     #   Build
 │   ├── frontend-ui-engineering/       #   Build
 │   ├── test-driven-development/       #   Build
 │   ├── api-and-interface-design/      #   Build

--- a/skills/source-driven-development/SKILL.md
+++ b/skills/source-driven-development/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: source-driven-development
+description: Grounds every implementation decision in official documentation. Use when you want authoritative, source-cited code free from outdated patterns. Use when building with any framework or library where correctness matters.
+---
+
+# Source-Driven Development
+
+## Overview
+
+Every framework-specific code decision must be backed by official documentation. Don't implement from memory — verify, cite, and let the user see your sources. Training data goes stale, APIs get deprecated, best practices evolve. This skill ensures the user gets code they can trust because every pattern traces back to an authoritative source they can check.
+
+## When to Use
+
+- The user wants code that follows current best practices for a given framework
+- Building boilerplate, starter code, or patterns that will be copied across a project
+- The user explicitly asks for documented, verified, or "correct" implementation
+- Implementing features where the framework's recommended approach matters (forms, routing, data fetching, state management, auth)
+- Reviewing or improving code that uses framework-specific patterns
+- Any time you are about to write framework-specific code from memory
+
+**When NOT to use:**
+
+- Renaming variables, fixing typos, moving files
+- Language-level patterns that don't depend on any library (loops, conditionals, data structures)
+- Code that doesn't touch any external framework or library
+- The user explicitly wants speed over verification ("just do it quickly")
+
+## The Process
+
+```
+DETECT ──→ FETCH ──→ IMPLEMENT ──→ CITE
+  │          │           │            │
+  ▼          ▼           ▼            ▼
+ What       Get the    Follow the   Show your
+ stack?     relevant   documented   sources
+            docs       patterns
+```
+
+### Step 1: Detect Stack and Versions
+
+Read the project's dependency file to identify exact versions:
+
+```
+package.json    → Node/React/Vue/Angular/Svelte
+composer.json   → PHP/Symfony/Laravel
+requirements.txt / pyproject.toml → Python/Django/Flask
+go.mod          → Go
+Cargo.toml      → Rust
+Gemfile         → Ruby/Rails
+```
+
+State what you found explicitly:
+
+```
+STACK DETECTED:
+- React 19.1.0 (from package.json)
+- Vite 6.2.0
+- Tailwind CSS 4.0.3
+→ Fetching official docs for the relevant patterns.
+```
+
+If versions are missing or ambiguous, **ask the user**. Don't guess — the version determines which patterns are correct.
+
+### Step 2: Fetch Official Documentation
+
+Fetch the specific documentation page for the feature you're implementing. Not the homepage, not the full docs — the relevant page.
+
+**Source hierarchy (in order of authority):**
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 | Official documentation | react.dev, docs.djangoproject.com, symfony.com/doc |
+| 2 | Official blog / changelog | react.dev/blog, nextjs.org/blog |
+| 3 | Web standards references | MDN, web.dev, html.spec.whatwg.org |
+| 4 | Browser/runtime compatibility | caniuse.com, node.green |
+
+**Not authoritative — never cite as primary sources:**
+
+- Stack Overflow answers
+- Blog posts or tutorials (even popular ones)
+- AI-generated documentation or summaries
+- Your own training data (that is the whole point — verify it)
+
+**Be precise with what you fetch:**
+
+```
+BAD:  Fetch the React homepage
+GOOD: Fetch react.dev/reference/react/useActionState
+
+BAD:  Search "django authentication best practices"
+GOOD: Fetch docs.djangoproject.com/en/6.0/topics/auth/
+```
+
+After fetching, extract the key patterns and note any deprecation warnings or migration guidance.
+
+### Step 3: Implement Following Documented Patterns
+
+Write code that matches what the documentation shows:
+
+- Use the API signatures from the docs, not from memory
+- If the docs show a new way to do something, use the new way
+- If the docs deprecate a pattern, don't use the deprecated version
+- If the docs don't cover something, flag it as unverified
+
+**When docs conflict with existing project code:**
+
+```
+CONFLICT DETECTED:
+The existing codebase uses useState for form loading state,
+but React 19 docs recommend useActionState for this pattern.
+(Source: react.dev/reference/react/useActionState)
+
+Options:
+A) Use the modern pattern (useActionState) — consistent with current docs
+B) Match existing code (useState) — consistent with codebase
+→ Which approach do you prefer?
+```
+
+Surface the conflict. Don't silently pick one.
+
+### Step 4: Cite Your Sources
+
+Every framework-specific pattern gets a citation. The user must be able to verify every decision.
+
+**In code comments:**
+
+```typescript
+// React 19 form handling with useActionState
+// Source: https://react.dev/reference/react/useActionState
+const [state, formAction, isPending] = useActionState(submitOrder, initialState);
+```
+
+**In conversation:**
+
+```
+I'm using useActionState instead of manual useState for the
+form submission state. React 19 replaced the manual
+isPending/setIsPending pattern with this hook.
+
+Source: https://react.dev/blog/2024/12/05/react-19
+"useTransition now supports async functions [...] to handle
+pending states automatically"
+```
+
+**Citation rules:**
+
+- Full URLs, not shortened
+- Quote the relevant passage when it supports a non-obvious decision
+- Include browser/runtime support data when recommending platform features
+- If you cannot find documentation for a pattern, say so explicitly:
+
+```
+UNVERIFIED: I could not find official documentation for this
+pattern. This is based on training data and may be outdated.
+Verify before using in production.
+```
+
+Honesty about what you couldn't verify is more valuable than false confidence.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'm confident about this API" | Confidence is not evidence. Training data contains outdated patterns that look correct but break against current versions. Verify. |
+| "Fetching docs wastes tokens" | Hallucinating an API wastes more. The user debugs for an hour, then discovers the function signature changed. One fetch prevents hours of rework. |
+| "The docs won't have what I need" | If the docs don't cover it, that's valuable information — the pattern may not be officially recommended. |
+| "I'll just mention it might be outdated" | A disclaimer doesn't help. Either verify and cite, or clearly flag it as unverified. Hedging is the worst option. |
+| "This is a simple task, no need to check" | Simple tasks with wrong patterns become templates. The user copies your deprecated form handler into ten components before discovering the modern approach exists. |
+
+## Red Flags
+
+- Writing framework-specific code without checking the docs for that version
+- Using "I believe" or "I think" about an API instead of citing the source
+- Implementing a pattern without knowing which version it applies to
+- Citing Stack Overflow or blog posts instead of official documentation
+- Using deprecated APIs because they appear in training data
+- Not reading `package.json` / dependency files before implementing
+- Delivering code without source citations for framework-specific decisions
+- Fetching an entire docs site when only one page is relevant
+
+## Verification
+
+After implementing with source-driven development:
+
+- [ ] Framework and library versions were identified from the dependency file
+- [ ] Official documentation was fetched for framework-specific patterns
+- [ ] All sources are official documentation, not blog posts or training data
+- [ ] Code follows the patterns shown in the current version's documentation
+- [ ] Non-trivial decisions include source citations with full URLs
+- [ ] No deprecated APIs are used (checked against migration guides)
+- [ ] Conflicts between docs and existing code were surfaced to the user
+- [ ] Anything that could not be verified is explicitly flagged as unverified

--- a/skills/source-driven-development/SKILL.md
+++ b/skills/source-driven-development/SKILL.md
@@ -20,9 +20,8 @@ Every framework-specific code decision must be backed by official documentation.
 
 **When NOT to use:**
 
-- Renaming variables, fixing typos, moving files
-- Language-level patterns that don't depend on any library (loops, conditionals, data structures)
-- Code that doesn't touch any external framework or library
+- Correctness does not depend on a specific version (renaming variables, fixing typos, moving files)
+- Pure logic that works the same across all versions (loops, conditionals, data structures)
 - The user explicitly wants speed over verification ("just do it quickly")
 
 ## The Process
@@ -93,6 +92,8 @@ GOOD: Fetch docs.djangoproject.com/en/6.0/topics/auth/
 
 After fetching, extract the key patterns and note any deprecation warnings or migration guidance.
 
+When official sources conflict with each other (e.g. a migration guide contradicts the API reference), surface the discrepancy to the user and verify which pattern actually works against the detected version.
+
 ### Step 3: Implement Following Documented Patterns
 
 Write code that matches what the documentation shows:
@@ -126,7 +127,7 @@ Every framework-specific pattern gets a citation. The user must be able to verif
 
 ```typescript
 // React 19 form handling with useActionState
-// Source: https://react.dev/reference/react/useActionState
+// Source: https://react.dev/reference/react/useActionState#usage
 const [state, formAction, isPending] = useActionState(submitOrder, initialState);
 ```
 
@@ -137,7 +138,7 @@ I'm using useActionState instead of manual useState for the
 form submission state. React 19 replaced the manual
 isPending/setIsPending pattern with this hook.
 
-Source: https://react.dev/blog/2024/12/05/react-19
+Source: https://react.dev/blog/2024/12/05/react-19#actions
 "useTransition now supports async functions [...] to handle
 pending states automatically"
 ```
@@ -145,6 +146,7 @@ pending states automatically"
 **Citation rules:**
 
 - Full URLs, not shortened
+- Prefer deep links with anchors where possible (e.g. `/useActionState#usage` over `/useActionState`) — anchors survive doc restructuring better than top-level pages
 - Quote the relevant passage when it supports a non-obvious decision
 - Include browser/runtime support data when recommending platform features
 - If you cannot find documentation for a pattern, say so explicitly:

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -22,7 +22,8 @@ Task arrives
     ├── Implementing code? ────────────→ incremental-implementation
     │   ├── UI work? ─────────────────→ frontend-ui-engineering
     │   ├── API work? ────────────────→ api-and-interface-design
-    │   └── Need better context? ─────→ context-engineering
+    │   ├── Need better context? ─────→ context-engineering
+    │   └── Need doc-verified code? ───→ source-driven-development
     ├── Writing/running tests? ────────→ test-driven-development
     │   └── Browser-based? ───────────→ browser-testing-with-devtools
     ├── Something broke? ──────────────→ debugging-and-error-recovery
@@ -138,12 +139,13 @@ For a complete feature, the typical skill sequence is:
 2. spec-driven-development     → Define what we're building
 3. planning-and-task-breakdown → Break into verifiable chunks
 4. context-engineering         → Load the right context
-5. incremental-implementation  → Build slice by slice
-6. test-driven-development     → Prove each slice works
-7. code-review-and-quality     → Review before merge
-8. git-workflow-and-versioning → Clean commit history
-9. documentation-and-adrs      → Document decisions
-10. shipping-and-launch        → Deploy safely
+5. source-driven-development   → Verify against official docs
+6. incremental-implementation  → Build slice by slice
+7. test-driven-development     → Prove each slice works
+8. code-review-and-quality     → Review before merge
+9. git-workflow-and-versioning → Clean commit history
+10. documentation-and-adrs     → Document decisions
+11. shipping-and-launch        → Deploy safely
 ```
 
 Not every task needs every skill. A bug fix might only need: `debugging-and-error-recovery` → `test-driven-development` → `code-review-and-quality`.
@@ -156,6 +158,7 @@ Not every task needs every skill. A bug fix might only need: `debugging-and-erro
 | Define | spec-driven-development | Requirements and acceptance criteria before code |
 | Plan | planning-and-task-breakdown | Decompose into small, verifiable tasks |
 | Build | incremental-implementation | Thin vertical slices, test each before expanding |
+| Build | source-driven-development | Verify against official docs before implementing |
 | Build | context-engineering | Right context at the right time |
 | Build | frontend-ui-engineering | Production-quality UI with accessibility |
 | Build | api-and-interface-design | Stable interfaces with clear contracts |


### PR DESCRIPTION
## What this adds

A new **source-driven-development** skill that grounds every framework-specific implementation decision in official documentation.

The core idea: agents shouldn't implement from memory. They should verify, cite, and let the user see the sources behind every non-trivial pattern.

## The problem it solves

AI agents confidently produce code that looks correct but uses outdated patterns — because training data goes stale. The agent doesn't know it's wrong, and neither does the user until they hit a deprecation warning or a subtle runtime bug.

This is especially painful with fast-moving frameworks: the agent writes React 18-style code in a React 19 project, Django 4 patterns in a Django 5 project. The code runs, the tests pass, and the problem surfaces six months later.

## How it works

Four-step process: **DETECT → FETCH → IMPLEMENT → CITE**

1. Read the dependency file to identify exact versions (`package.json`, `go.mod`, `Cargo.toml`, etc.)
2. Fetch the specific documentation page for the feature — not the homepage, the relevant page
3. Implement following the documented patterns, surfacing conflicts with existing code
4. Cite every non-trivial decision with a full URL

Every pattern in the output traces back to a source the user can verify.

## What makes it different from just "read the docs"

- Framework-agnostic — works the same for React, Django, Rails, Go, Rust, Laravel
- Structured citation format in both code comments and conversation
- Explicit `UNVERIFIED:` flag when documentation can't be found
- `CONFLICT DETECTED:` surfacing when docs differ from existing codebase patterns
- Clear "When NOT to use" — doesn't slow down variable renames and file moves

## Integration

- Added to the `using-agent-skills` flowchart and lifecycle sequence
- Added to `CLAUDE.md` Build phase
- Added to `README.md` Build table (20 skills total)

## Demo

Built a SpaceX launch dashboard POC with the skill active. The agent:
- Detected React 19.1.0 from `package.json`
- Fetched `react.dev/reference/react/use` and `react.dev/blog/2024/12/05/react-19`
- Used `use()` for data fetching (not `useEffect`), `<Context>` without `.Provider` (React 19), `useOptimistic` for favorites
- Cited every pattern inline

The same prompt without the skill produces `useEffect` + `useState` — valid React 18 code, wrong for React 19.

## Future work

An earlier version included a local documentation cache (`.agent-sources/`) for reusing fetched docs across sessions. Removed from this PR to keep the skill focused on verification and citation. A caching mechanism could live in a dedicated skill or as an extension to `context-engineering`.