### PR TITLE
feat: introduce evaluation framework for skill testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,37 @@ Every skill should include these sections:
 - Don't create supporting files unless content exceeds 100 lines
 - Don't put reference material inside skill directories — use `references/` instead
 
+## Testing Your Changes
+
+Before submitting a PR, validate your skill:
+
+```bash
+# Structural validation — checks format, sections, description
+bash test/validate-skills.sh
+```
+
+If you modified a skill's workflow, run the relevant evaluation scenario:
+
+```bash
+# List available scenarios
+bash test/run-all.sh --list
+
+# Fast check: does the skill activate on a neutral prompt?
+bash test/run-test.sh <scenario>.json --triggering
+
+# Full test: run agent with skill and grade the result
+bash test/run-test.sh <scenario>.json
+
+# Compare with-skill vs without-skill (measures the skill's value)
+bash test/run-test.sh <scenario>.json --baseline
+
+# Grade an existing workspace without re-running Claude
+bash test/run-test.sh <scenario>.json --grade-only
+
+# Test with a specific model (Anthropic recommends Haiku, Sonnet, and Opus)
+EVAL_MODEL=haiku bash test/run-test.sh <scenario>.json
+```
+
 ## Modifying Existing Skills
 
 - Keep changes focused and minimal

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,121 @@
+# Evaluation Framework
+
+Measures whether agent-skills actually improve agent performance. Aligned with [superpowers](https://github.com/obra/superpowers/tree/main/tests) testing patterns, [Anthropic's evaluation methodology](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices), and [SkillsBench](https://arxiv.org/abs/2602.12670).
+
+## Components
+
+### 1. Structural Validator
+
+Validates SKILL.md files against repo conventions that `claude plugin validate` does not check.
+
+```bash
+bash test/validate-skills.sh          # warnings don't fail
+bash test/validate-skills.sh --strict  # warnings = failures
+```
+
+Checks: description <250 chars, "Use when" trigger conditions, required sections (When to Use, Common Rationalizations, Red Flags, Verification), table format.
+
+### 2. Scenario-Based Evaluation
+
+Test scenarios for skills, using `claude -p` in headless mode. Two tiers:
+
+**Fast — Skill triggering (~2 min):** Does a neutral prompt activate the right skill?
+```bash
+bash test/run-test.sh tdd-new-feature.json --triggering
+```
+
+**Full — Integration + grading:** Does the agent produce correct results with the skill?
+```bash
+bash test/run-test.sh tdd-new-feature.json
+```
+
+**Full + baseline delta:** Compare with-skill vs without-skill.
+```bash
+bash test/run-test.sh tdd-new-feature.json --baseline
+```
+
+**Grade only:** Grade an existing workspace without re-running Claude.
+```bash
+bash test/run-test.sh tdd-new-feature.json --grade-only
+```
+
+**Model-specific testing:** Anthropic recommends testing skills with all models.
+```bash
+EVAL_MODEL=haiku bash test/run-test.sh tdd-new-feature.json    # enough guidance?
+EVAL_MODEL=sonnet bash test/run-test.sh tdd-new-feature.json   # clear and efficient?
+EVAL_MODEL=opus bash test/run-test.sh tdd-new-feature.json     # avoids over-explaining?
+```
+Source: "Test your Skill with all the models you plan to use it with." — platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+
+**Run all scenarios:**
+```bash
+bash test/run-all.sh                  # all with skill
+bash test/run-all.sh --triggering     # fast skill activation check
+bash test/run-all.sh --baseline       # all with delta
+bash test/run-all.sh --list           # list scenarios
+bash test/run-all.sh --validate       # validate JSON + prompt files
+```
+
+### 3. Process Graders
+
+Deterministic checks on the workspace after the agent finishes:
+
+```bash
+bash test/graders/process-checks.sh <workspace> <scenario.json>
+```
+
+Check types: `file_order`, `test_result`, `file_contains`, `file_exists`, `no_code_changes`.
+
+## Directory Structure
+
+```
+test/
+├── validate-skills.sh      # Repo convention validator
+├── test-helpers.sh          # Shared assertions + Claude execution helpers
+├── run-test.sh              # Run single scenario
+├── run-all.sh               # Run all scenarios
+├── scenarios/               # Scenario definitions (JSON metadata + checks)
+├── prompts/                 # One .txt file per scenario (neutral task prompt)
+├── fixtures/                # Mini-apps for agent to work on
+│   ├── feature-app/         # Clean app for TDD/spec scenarios
+│   └── buggy-app/           # App with known bugs for debugging scenarios
+└── graders/
+    └── process-checks.sh    # Deterministic grading
+```
+
+## Prompt Design
+
+Prompts in `prompts/*.txt` are **intentionally neutral** — they describe only the task, never the process. The skill is the sole source of process guidance.
+
+Sources:
+- Anthropic skill-creator: "Same prompt, no skill path" for baseline
+- SkillsBench: "Instructions must not reference which Skills to use"
+- agentskills.io: Baseline and with-skill runs use identical prompts
+
+## CLI Flags
+
+| Flag | Purpose | Used in |
+|------|---------|---------|
+| `--plugin-dir <path>` | Load agent-skills as plugin | With-skill run |
+| `--disable-slash-commands` | Disable all slash commands | Baseline run |
+| `--disallowedTools "Skill"` | Remove Skill tool entirely | Baseline run |
+| `--dangerously-skip-permissions` | Bypass permission prompts (safe in /tmp/) | Both runs |
+| `-p` | Non-interactive print mode | Both runs |
+| `--output-format stream-json --verbose` | Structured output for parsing | Both runs |
+| `claude plugin disable --all` | Disable installed plugins | Before runs |
+
+## Methodology
+
+Based on:
+- **Superpowers** (github.com/obra/superpowers/tree/main/tests): Bash + `claude -p` + stream-json, two test tiers, skill triggering, premature action detection
+- **Anthropic** (platform.claude.com best-practices): "Create evaluations BEFORE writing documentation", baseline comparison, iterative testing
+- **SkillsBench** (arxiv.org/abs/2602.12670): Curated skills +16.2pp, neutral prompts, 3-5 trials for statistical rigor
+- **agentskills.io** (agentskills.io/skill-creation/evaluating-skills): JSON scenario format, verification scripts
+
+## Adding New Scenarios
+
+1. Create `scenarios/<name>.json` with id, skill, description, prompt, expected_behaviors, process_checks
+2. Create `prompts/<name>.txt` with the neutral task prompt
+3. Add fixtures in `fixtures/` if needed
+4. Run: `bash test/run-all.sh --validate`
+5. Test: `bash test/run-test.sh <name>.json --triggering`

--- a/test/fixtures/buggy-app/index.js
+++ b/test/fixtures/buggy-app/index.js
@@ -1,0 +1,33 @@
+// Buggy app — evaluation fixture
+// Contains intentional bugs for debugging skill evaluation.
+// Each bug is documented in comments for grading purposes.
+
+// BUG 1: Off-by-one in pagination — returns one fewer item than requested
+function paginate(items, page, pageSize) {
+  const start = page * pageSize;
+  const end = start + pageSize - 1; // BUG: should be start + pageSize
+  return items.slice(start, end);
+}
+
+// BUG 2: Null reference — doesn't handle missing nested property
+function getUserDisplayName(user) {
+  return user.profile.displayName || user.name; // BUG: user.profile may be undefined
+}
+
+// BUG 3: Race condition pattern — shared mutable state without synchronization
+let requestCount = 0;
+function trackRequest() {
+  const current = requestCount;
+  // Simulated async gap where race condition occurs
+  requestCount = current + 1;
+  return requestCount;
+}
+
+// This function works correctly — baseline for regression testing
+function formatCurrency(amount, currency) {
+  if (typeof amount !== 'number' || isNaN(amount)) return '$0.00';
+  const prefix = currency === 'EUR' ? '\u20AC' : '$';
+  return `${prefix}${amount.toFixed(2)}`;
+}
+
+module.exports = { paginate, getUserDisplayName, trackRequest, formatCurrency };

--- a/test/fixtures/buggy-app/index.test.js
+++ b/test/fixtures/buggy-app/index.test.js
@@ -1,0 +1,41 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { paginate, getUserDisplayName, formatCurrency } = require('./index');
+
+describe('paginate', () => {
+  const items = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
+
+  it('returns correct page size', () => {
+    // This test EXPOSES BUG 1: returns 2 items instead of 3
+    const result = paginate(items, 0, 3);
+    assert.strictEqual(result.length, 3);
+  });
+
+  it('returns correct page offset', () => {
+    const result = paginate(items, 1, 3);
+    assert.deepStrictEqual(result, ['d', 'e', 'f']);
+  });
+});
+
+describe('getUserDisplayName', () => {
+  it('returns display name when present', () => {
+    const user = { name: 'Alice', profile: { displayName: 'alice123' } };
+    assert.strictEqual(getUserDisplayName(user), 'alice123');
+  });
+
+  it('handles missing profile', () => {
+    // This test EXPOSES BUG 2: throws TypeError
+    const user = { name: 'Bob' };
+    assert.strictEqual(getUserDisplayName(user), 'Bob');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('formats USD correctly', () => {
+    assert.strictEqual(formatCurrency(42.5, 'USD'), '$42.50');
+  });
+
+  it('handles invalid input', () => {
+    assert.strictEqual(formatCurrency(NaN, 'USD'), '$0.00');
+  });
+});

--- a/test/fixtures/buggy-app/package.json
+++ b/test/fixtures/buggy-app/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "eval-buggy-app",
+  "version": "1.0.0",
+  "description": "App with known bugs for debugging evaluation scenarios",
+  "scripts": {
+    "test": "node --test",
+    "start": "node server.js"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/feature-app/index.js
+++ b/test/fixtures/feature-app/index.js
@@ -1,0 +1,14 @@
+// Feature app — evaluation fixture
+// Provides a minimal codebase for TDD and spec-driven scenarios.
+// Agents are asked to add functionality here following skill workflows.
+
+function greet(name) {
+  if (!name || typeof name !== 'string') return 'Hello, stranger!';
+  return `Hello, ${name}!`;
+}
+
+function add(a, b) {
+  return a + b;
+}
+
+module.exports = { greet, add };

--- a/test/fixtures/feature-app/index.test.js
+++ b/test/fixtures/feature-app/index.test.js
@@ -1,0 +1,19 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { greet, add } = require('./index');
+
+describe('greet', () => {
+  it('returns greeting with name', () => {
+    assert.strictEqual(greet('World'), 'Hello, World!');
+  });
+
+  it('returns default for empty input', () => {
+    assert.strictEqual(greet(''), 'Hello, stranger!');
+  });
+});
+
+describe('add', () => {
+  it('adds two numbers', () => {
+    assert.strictEqual(add(2, 3), 5);
+  });
+});

--- a/test/fixtures/feature-app/package.json
+++ b/test/fixtures/feature-app/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "eval-feature-app",
+  "version": "1.0.0",
+  "description": "Minimal app for TDD and spec-driven evaluation scenarios",
+  "scripts": {
+    "test": "node --test"
+  },
+  "license": "MIT"
+}

--- a/test/graders/process-checks.sh
+++ b/test/graders/process-checks.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# process-checks.sh — Deterministic grading for evaluation scenarios
+#
+# Runs process checks defined in scenario JSON files against a workspace.
+# Checks whether the agent followed the skill's workflow (not just the outcome).
+#
+# Usage: bash test/graders/process-checks.sh <workspace> <scenario-json>
+#
+# Exit: 0 if all checks pass, 1 if any fail
+
+set -uo pipefail
+
+if [ $# -lt 2 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+  printf 'Usage: %s <workspace-dir> <scenario-json-file>\n\n' "$(basename "$0")"
+  printf 'Check types:\n'
+  printf '  file_order     — verify file modification order (e.g., test before impl)\n'
+  printf '  test_result    — run a command and check exit code\n'
+  printf '  file_contains  — check if file matches a regex pattern\n'
+  printf '  file_exists    — check if a file matching a glob exists\n'
+  printf '  no_code_changes — verify specific files were NOT modified\n'
+  exit 0
+fi
+
+WORKSPACE="$1"
+SCENARIO="$2"
+
+if [ ! -d "$WORKSPACE" ]; then
+  printf 'Error: workspace directory not found: %s\n' "$WORKSPACE" >&2
+  exit 1
+fi
+if [ ! -f "$SCENARIO" ]; then
+  printf 'Error: scenario file not found: %s\n' "$SCENARIO" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'Error: jq is required\n' >&2
+  exit 1
+fi
+
+PASS=0 FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '  PASS: %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL: %s\n' "$1" >&2
+  [ -n "${2:-}" ] && printf '    %s\n' "$2" >&2
+}
+
+SCENARIO_ID=$(jq -r '.id' "$SCENARIO")
+SKILL=$(jq -r '.skill' "$SCENARIO")
+CHECK_COUNT=$(jq '.process_checks | length' "$SCENARIO")
+
+printf '══════════════════════════════════════════\n'
+printf 'Process Checks: %s (%s)\n' "$SCENARIO_ID" "$SKILL"
+printf '══════════════════════════════════════════\n'
+
+i=0
+while [ "$i" -lt "$CHECK_COUNT" ]; do
+  check_type=$(jq -r ".process_checks[$i].type" "$SCENARIO")
+  expect=$(jq -r ".process_checks[$i].expect" "$SCENARIO")
+
+  case "$check_type" in
+
+    file_order)
+      test_glob=$(jq -r ".process_checks[$i].test_glob" "$SCENARIO")
+      impl_file=$(jq -r ".process_checks[$i].impl_file" "$SCENARIO")
+
+      # Compare modification times: test file should be newer than or same as impl
+      test_file=$(find "$WORKSPACE" -name "$test_glob" -type f 2>/dev/null | head -1)
+      impl_path="$WORKSPACE/$impl_file"
+
+      if [ -z "$test_file" ]; then
+        fail "file_order: no test file matching '$test_glob' found"
+      elif [ ! -f "$impl_path" ]; then
+        fail "file_order: implementation file '$impl_file' not found"
+      else
+        # Git-based check: look at commit order if available
+        if [ -d "$WORKSPACE/.git" ]; then
+          test_first_commit=$(git -C "$WORKSPACE" log --diff-filter=AM --format='%H' -- "$test_glob" 2>/dev/null | tail -1)
+          impl_first_commit=$(git -C "$WORKSPACE" log --diff-filter=AM --format='%H' -- "$impl_file" 2>/dev/null | tail -1)
+          if [ -n "$test_first_commit" ] && [ -n "$impl_first_commit" ]; then
+            if git -C "$WORKSPACE" merge-base --is-ancestor "$test_first_commit" "$impl_first_commit" 2>/dev/null; then
+              pass "file_order: test created/modified before implementation (git)"
+            else
+              fail "file_order: implementation modified before test (git)"
+            fi
+          else
+            pass "file_order: files exist (git history inconclusive, manual review needed)"
+          fi
+        else
+          # Fallback: mtime comparison
+          if [ "$test_file" -nt "$impl_path" ] || [ "$test_file" -ot "$impl_path" ]; then
+            pass "file_order: both files present (mtime check, manual review recommended)"
+          fi
+        fi
+      fi
+      ;;
+
+    test_result)
+      command_str=$(jq -r ".process_checks[$i].command" "$SCENARIO")
+      if (set +o pipefail 2>/dev/null; cd "$WORKSPACE" && eval "$command_str") >/dev/null 2>&1; then
+        if [ "$expect" = "pass" ]; then
+          pass "test_result: '$command_str' passed"
+        else
+          fail "test_result: '$command_str' passed but expected failure"
+        fi
+      else
+        if [ "$expect" = "fail" ]; then
+          pass "test_result: '$command_str' failed as expected"
+        else
+          fail "test_result: '$command_str' failed" "Run manually to see errors"
+        fi
+      fi
+      ;;
+
+    file_contains)
+      file_pattern=$(jq -r ".process_checks[$i].file" "$SCENARIO")
+      pattern=$(jq -r ".process_checks[$i].pattern" "$SCENARIO")
+
+      # Resolve file pattern (may contain glob)
+      target=$(find "$WORKSPACE" -name "$file_pattern" -type f 2>/dev/null | head -1)
+      if [ -z "$target" ]; then
+        target="$WORKSPACE/$file_pattern"
+      fi
+
+      if [ ! -f "$target" ]; then
+        fail "file_contains: file '$file_pattern' not found"
+      elif grep -qE "$pattern" "$target" 2>/dev/null; then
+        if [ "$expect" = "true" ]; then
+          pass "file_contains: '$file_pattern' matches /$pattern/"
+        else
+          fail "file_contains: '$file_pattern' should NOT match /$pattern/"
+        fi
+      else
+        if [ "$expect" = "true" ]; then
+          fail "file_contains: '$file_pattern' does not match /$pattern/"
+        else
+          pass "file_contains: '$file_pattern' correctly does not match /$pattern/"
+        fi
+      fi
+      ;;
+
+    file_exists)
+      pattern=$(jq -r ".process_checks[$i].pattern" "$SCENARIO")
+      found=$(find "$WORKSPACE" -name "$pattern" -type f 2>/dev/null | head -1)
+      if [ -n "$found" ]; then
+        if [ "$expect" = "true" ]; then
+          pass "file_exists: found file matching '$pattern'"
+        else
+          fail "file_exists: file matching '$pattern' should not exist"
+        fi
+      else
+        if [ "$expect" = "true" ]; then
+          fail "file_exists: no file matching '$pattern' found"
+        else
+          pass "file_exists: correctly no file matching '$pattern'"
+        fi
+      fi
+      ;;
+
+    no_code_changes)
+      files=$(jq -r ".process_checks[$i].files[]" "$SCENARIO")
+      all_unchanged=1
+      for f in $files; do
+        if [ -d "$WORKSPACE/.git" ]; then
+          if git -C "$WORKSPACE" diff --name-only HEAD 2>/dev/null | grep -q "$f"; then
+            all_unchanged=0
+            fail "no_code_changes: '$f' was modified"
+          fi
+        fi
+      done
+      if [ "$all_unchanged" -eq 1 ]; then
+        pass "no_code_changes: implementation files unchanged (spec-only)"
+      fi
+      ;;
+
+    *)
+      fail "unknown check type: $check_type"
+      ;;
+  esac
+
+  i=$((i + 1))
+done
+
+printf '\n══════════════════════════════════════════\n'
+printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+printf '══════════════════════════════════════════\n'
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/test/graders/process-checks.sh
+++ b/test/graders/process-checks.sh
@@ -164,10 +164,11 @@ while [ "$i" -lt "$CHECK_COUNT" ]; do
 
     no_code_changes)
       files=$(jq -r ".process_checks[$i].files[]" "$SCENARIO")
+      initial=$(git -C "$WORKSPACE" rev-list --max-parents=0 HEAD 2>/dev/null)
       all_unchanged=1
       for f in $files; do
-        if [ -d "$WORKSPACE/.git" ]; then
-          if git -C "$WORKSPACE" diff --name-only HEAD 2>/dev/null | grep -q "$f"; then
+        if [ -d "$WORKSPACE/.git" ] && [ -n "$initial" ]; then
+          if git -C "$WORKSPACE" diff --name-only "$initial" 2>/dev/null | grep -q "^${f}$"; then
             all_unchanged=0
             fail "no_code_changes: '$f' was modified"
           fi
@@ -175,6 +176,25 @@ while [ "$i" -lt "$CHECK_COUNT" ]; do
       done
       if [ "$all_unchanged" -eq 1 ]; then
         pass "no_code_changes: implementation files unchanged (spec-only)"
+      fi
+      ;;
+
+    files_modified)
+      files=$(jq -r ".process_checks[$i].files[]" "$SCENARIO")
+      initial=$(git -C "$WORKSPACE" rev-list --max-parents=0 HEAD 2>/dev/null)
+      if [ -z "$initial" ]; then
+        fail "files_modified: no git history in workspace"
+      else
+        for f in $files; do
+          if git -C "$WORKSPACE" diff --name-only "$initial" 2>/dev/null | grep -q "^${f}$"; then
+            pass "files_modified: '$f' was changed by the agent"
+            printf '    ── diff %s ──\n' "$f"
+            git -C "$WORKSPACE" diff "$initial" -- "$f" 2>/dev/null
+            printf '    ── end diff ──\n'
+          else
+            fail "files_modified: '$f' was NOT modified (no-op agent?)"
+          fi
+        done
       fi
       ;;
 

--- a/test/prompts/debugging-null-ref.txt
+++ b/test/prompts/debugging-null-ref.txt
@@ -1,0 +1,1 @@
+Running the tests with 'node --test' produces a TypeError in getUserDisplayName when a user has no profile property. Fix it so the tests pass.

--- a/test/prompts/debugging-race-condition.txt
+++ b/test/prompts/debugging-race-condition.txt
@@ -1,0 +1,1 @@
+The trackRequest function in index.js has a potential issue with how it increments requestCount. Fix it and add a test.

--- a/test/prompts/spec-feature-request.txt
+++ b/test/prompts/spec-feature-request.txt
@@ -1,0 +1,1 @@
+A user requested: 'We need search functionality for our app.' Figure out what we should build.

--- a/test/prompts/spec-new-api.txt
+++ b/test/prompts/spec-new-api.txt
@@ -1,0 +1,1 @@
+We need to add a POST /api/tasks endpoint to create new tasks. Each task has a title (required, string, max 100 chars), description (optional, string), and priority (required, enum: low/medium/high). Define what this endpoint should look like before building it.

--- a/test/prompts/tdd-bugfix.txt
+++ b/test/prompts/tdd-bugfix.txt
@@ -1,0 +1,1 @@
+The paginate function in index.js has a bug: paginate(['a','b','c','d','e'], 0, 3) returns only 2 items instead of 3. Fix the bug and make sure it doesn't regress.

--- a/test/prompts/tdd-new-feature.txt
+++ b/test/prompts/tdd-new-feature.txt
@@ -1,0 +1,1 @@
+Add a validateEmail function to index.js. It should return true for valid emails like user@example.com, and false for: missing @ symbol, empty string, strings without a TLD (user@domain), and strings with spaces.

--- a/test/run-all.sh
+++ b/test/run-all.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# run-all.sh — Run all evaluation scenarios
+#
+# Usage:
+#   bash test/run-all.sh                  # Run all with skill
+#   bash test/run-all.sh --baseline        # Run all with delta
+#   bash test/run-all.sh --triggering      # Fast: just check skill activation
+#   bash test/run-all.sh --validate        # Validate all scenario JSON + prompts
+#   bash test/run-all.sh --list            # List all scenarios
+
+set -uo pipefail
+
+EVAL_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODE="${1:-}"
+
+# ── List ────────────────────────────────────────────────────────────────────
+if [ "$MODE" = "--list" ]; then
+  printf '%-35s %-25s %s\n' "SCENARIO" "SKILL" "DESCRIPTION"
+  printf '%-35s %-25s %s\n' "--------" "-----" "-----------"
+  for f in "$EVAL_DIR"/scenarios/*.json; do
+    [ -f "$f" ] || continue
+    printf '%-35s %-25s %s\n' \
+      "$(jq -r '.id' "$f")" \
+      "$(jq -r '.skill' "$f")" \
+      "$(jq -r '.description' "$f")"
+  done
+  exit 0
+fi
+
+# ── Validate ────────────────────────────────────────────────────────────────
+if [ "$MODE" = "--validate" ]; then
+  pass=0 fail=0
+  for f in "$EVAL_DIR"/scenarios/*.json; do
+    [ -f "$f" ] || continue
+    name=$(basename "$f" .json)
+
+    # JSON valid?
+    if ! jq empty "$f" 2>/dev/null; then
+      printf '  FAIL: %s.json — invalid JSON\n' "$name" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+
+    # Required fields?
+    missing=""
+    for field in id skill description prompt expected_behaviors process_checks; do
+      val=$(jq -r ".$field // empty" "$f")
+      [ -z "$val" ] && missing="$missing $field"
+    done
+    if [ -n "$missing" ]; then
+      printf '  FAIL: %s.json — missing:%s\n' "$name" "$missing" >&2
+      fail=$((fail + 1))
+      continue
+    fi
+
+    # Matching prompt file?
+    if [ -f "$EVAL_DIR/prompts/${name}.txt" ]; then
+      printf '  PASS: %s.json (prompt: %s.txt)\n' "$name" "$name"
+    else
+      printf '  PASS: %s.json (no prompt .txt — will use JSON prompt)\n' "$name"
+    fi
+    pass=$((pass + 1))
+  done
+  printf '\nResults: %d passed, %d failed\n' "$pass" "$fail"
+  [ "$fail" -eq 0 ] && exit 0 || exit 1
+fi
+
+# ── Run all scenarios ───────────────────────────────────────────────────────
+total=0 passed=0 failed=0
+
+for f in "$EVAL_DIR"/scenarios/*.json; do
+  [ -f "$f" ] || continue
+  total=$((total + 1))
+  name=$(basename "$f")
+
+  printf '\n────────────────────────────────────────\n'
+  printf 'Scenario %d: %s\n' "$total" "$name"
+  printf '────────────────────────────────────────\n'
+
+  if bash "$EVAL_DIR/run-test.sh" "$f" "$MODE"; then
+    passed=$((passed + 1))
+  else
+    failed=$((failed + 1))
+  fi
+done
+
+printf '\n══════════════════════════════════════════\n'
+printf 'All Scenarios: %d/%d passed\n' "$passed" "$total"
+printf '══════════════════════════════════════════\n'
+
+[ "$failed" -eq 0 ] && exit 0 || exit 1

--- a/test/run-all.sh
+++ b/test/run-all.sh
@@ -6,6 +6,7 @@
 #   bash test/run-all.sh --baseline        # Run all with delta
 #   bash test/run-all.sh --triggering      # Fast: just check skill activation
 #   bash test/run-all.sh --validate        # Validate all scenario JSON + prompts
+#   bash test/run-all.sh --null-test       # Verify assertions fail on untouched fixtures
 #   bash test/run-all.sh --list            # List all scenarios
 
 set -uo pipefail
@@ -62,6 +63,39 @@ if [ "$MODE" = "--validate" ]; then
     pass=$((pass + 1))
   done
   printf '\nResults: %d passed, %d failed\n' "$pass" "$fail"
+  [ "$fail" -eq 0 ] && exit 0 || exit 1
+fi
+
+# ── Null-test: verify assertions fail on untouched fixtures ────────────────
+# Catches false-positive assertions by running the grader on clean fixtures.
+# Every scenario MUST return overall FAIL — if it passes, assertions are too loose.
+# Inspired by SkillsBench "oracle execution" validation (arXiv:2602.12670).
+if [ "$MODE" = "--null-test" ]; then
+  pass=0 fail=0
+
+  for f in "$EVAL_DIR"/scenarios/*.json; do
+    [ -f "$f" ] || continue
+    name=$(basename "$f" .json)
+    scenario_id=$(jq -r '.id' "$f")
+
+    # Copy fixture to temp workspace
+    fixture_dir=$(jq -r '.fixtures[0]' "$f")
+    tmpdir=$(mktemp -d)
+    cp -r "$EVAL_DIR/$fixture_dir"* "$tmpdir/" 2>/dev/null
+
+    # Run grader — expect FAIL (exit 1)
+    if bash "$EVAL_DIR/graders/process-checks.sh" "$tmpdir" "$f" >/dev/null 2>&1; then
+      printf '  FAIL: %s — grader PASSED on untouched fixture (false positive!)\n' "$scenario_id" >&2
+      fail=$((fail + 1))
+    else
+      printf '  PASS: %s — grader correctly rejects untouched fixture\n' "$scenario_id"
+      pass=$((pass + 1))
+    fi
+
+    rm -rf "$tmpdir"
+  done
+
+  printf '\nNull-test: %d/%d scenarios correctly rejected\n' "$pass" "$((pass + fail))"
   [ "$fail" -eq 0 ] && exit 0 || exit 1
 fi
 

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# run-test.sh — Run a single evaluation scenario
+#
+# Usage:
+#   bash test/run-test.sh <scenario.json>               # With skill, grade
+#   bash test/run-test.sh <scenario.json> --baseline     # With + without, delta
+#   bash test/run-test.sh <scenario.json> --triggering   # Fast: just check skill activates
+#   bash test/run-test.sh <scenario.json> --grade-only   # Grade existing workspace
+#
+# Model selection (Anthropic recommends testing with Haiku, Sonnet, and Opus):
+#   EVAL_MODEL=haiku bash test/run-test.sh <scenario.json>
+#   EVAL_MODEL=sonnet bash test/run-test.sh <scenario.json>
+#   EVAL_MODEL=opus bash test/run-test.sh <scenario.json>
+
+set -uo pipefail
+
+source "$(dirname "$0")/test-helpers.sh"
+
+if [ $# -lt 1 ]; then
+  printf 'Usage: %s <scenario.json> [--baseline|--triggering|--grade-only]\n' "$(basename "$0")"
+  exit 1
+fi
+
+# ── Resolve scenario ────────────────────────────────────────────────────────
+SCENARIO="$1"
+case "$SCENARIO" in
+  /*) ;;
+  *) SCENARIO="$EVAL_DIR/scenarios/$SCENARIO"
+     [ ! -f "$SCENARIO" ] && SCENARIO="$1"
+     ;;
+esac
+
+[ ! -f "$SCENARIO" ] && { printf 'Error: %s not found\n' "$SCENARIO" >&2; exit 1; }
+
+SCENARIO_ID=$(jq -r '.id' "$SCENARIO")
+SKILL=$(jq -r '.skill' "$SCENARIO")
+WORKSPACE="/tmp/eval-${SCENARIO_ID}"
+MODE="${2:-}"
+
+# Resolve prompt: prefer .txt file, fallback to JSON
+PROMPT_FILE="$EVAL_DIR/prompts/$(basename "$SCENARIO" .json).txt"
+if [ -f "$PROMPT_FILE" ]; then
+  PROMPT=$(cat "$PROMPT_FILE")
+else
+  PROMPT=$(jq -r '.prompt' "$SCENARIO")
+fi
+
+# ── Grade-only mode ─────────────────────────────────────────────────────────
+if [ "$MODE" = "--grade-only" ]; then
+  [ ! -d "$WORKSPACE" ] && { printf 'Error: workspace %s not found\n' "$WORKSPACE" >&2; exit 1; }
+  exec bash "$EVAL_DIR/graders/process-checks.sh" "$WORKSPACE" "$SCENARIO"
+fi
+
+# ── Triggering mode (fast ~2 min) ──────────────────────────────────────────
+if [ "$MODE" = "--triggering" ]; then
+  printf '══════════════════════════════════════════\n'
+  printf 'Skill Triggering Test: %s\n' "$SCENARIO_ID"
+  printf '══════════════════════════════════════════\n\n'
+
+  LOG="/tmp/eval-triggering-${SCENARIO_ID}.jsonl"
+  setup_workspace "$SCENARIO" "$WORKSPACE"
+  cd "$WORKSPACE"
+
+  printf '▸ Running with neutral prompt...\n'
+  run_claude "$PROMPT" "$LOG"
+
+  printf '\n'
+  assert_plugin_loaded "$LOG"
+  assert_skill_triggered "$LOG" "$SKILL"
+  assert_no_premature_action "$LOG"
+
+  print_results
+  [ "$FAIL" -eq 0 ] && exit 0 || exit 1
+fi
+
+# ── Full test mode ──────────────────────────────────────────────────────────
+printf '══════════════════════════════════════════\n'
+printf 'Evaluation: %s (%s)\n' "$SCENARIO_ID" "$SKILL"
+printf '══════════════════════════════════════════\n\n'
+
+# Save plugins and disable all for clean environment
+printf '▸ Saving plugin state...\n'
+save_plugins
+printf '▸ Disabling all plugins...\n'
+claude plugin disable --all >/dev/null 2>&1
+
+# ── WITH SKILL ──────────────────────────────────────────────────────────────
+printf '\n▸ Running WITH skill...\n'
+setup_workspace "$SCENARIO" "$WORKSPACE"
+cd "$WORKSPACE"
+
+WITH_LOG="/tmp/eval-with-${SCENARIO_ID}.jsonl"
+run_claude "$PROMPT" "$WITH_LOG"
+cd "$EVAL_DIR/.."
+
+# Verify plugin loaded
+assert_plugin_loaded "$WITH_LOG"
+
+# Grade
+printf '\n── WITH SKILL ──\n'
+with_output=$(bash "$EVAL_DIR/graders/process-checks.sh" "$WORKSPACE" "$SCENARIO" 2>&1)
+echo "$with_output"
+with_pass=$(echo "$with_output" | grep -c "PASS:" || true)
+with_fail=$(echo "$with_output" | grep -c "FAIL:" || true)
+with_total=$((with_pass + with_fail))
+
+# ── WITHOUT SKILL (only if --baseline) ──────────────────────────────────────
+if [ "$MODE" = "--baseline" ]; then
+  printf '\n▸ Running WITHOUT skill (baseline)...\n'
+  setup_workspace "$SCENARIO" "$WORKSPACE"
+  cd "$WORKSPACE"
+
+  WITHOUT_LOG="/tmp/eval-without-${SCENARIO_ID}.jsonl"
+  run_claude_baseline "$PROMPT" "$WITHOUT_LOG"
+  cd "$EVAL_DIR/.."
+
+  # Grade
+  printf '\n── WITHOUT SKILL ──\n'
+  without_output=$(bash "$EVAL_DIR/graders/process-checks.sh" "$WORKSPACE" "$SCENARIO" 2>&1)
+  echo "$without_output"
+  without_pass=$(echo "$without_output" | grep -c "PASS:" || true)
+
+  # Delta
+  delta=$((with_pass - without_pass))
+  printf '\n══════════════════════════════════════════\n'
+  printf 'DELTA: %s\n' "$SCENARIO_ID"
+  printf '  With skill:    %d/%d PASS\n' "$with_pass" "$with_total"
+  printf '  Without skill: %d/%d PASS\n' "$without_pass" "$with_total"
+  printf '  Delta:         %+d\n' "$delta"
+  printf '══════════════════════════════════════════\n'
+fi
+
+# Restore plugins
+printf '\n▸ Restoring plugins...\n'
+restore_plugins
+
+[ "$with_fail" -eq 0 ] && exit 0 || exit 1

--- a/test/scenarios/debugging-null-ref.json
+++ b/test/scenarios/debugging-null-ref.json
@@ -13,9 +13,10 @@
     "Fix does not change unrelated code (scope discipline)"
   ],
   "process_checks": [
-    {"type": "test_result", "command": "node --test 2>&1 | grep -q getUserDisplayName", "expect": "pass"},
-    {"type": "file_contains", "file": "index.js", "pattern": "profile", "expect": true},
-    {"type": "file_contains", "file": "index.test.js", "pattern": "missing profile", "expect": true}
+    {"type": "test_result", "command": "node --test", "expect": "pass"},
+    {"type": "file_contains", "file": "index.js", "pattern": "profile\\?\\.|profile\\s*&&|profile\\s*!==|profile\\s*!=|typeof.*profile", "expect": true},
+    {"type": "file_contains", "file": "index.test.js", "pattern": "null|undefined|no profile|without profile|missing.*profile.*Bob|profile.*missing.*Bob", "expect": true},
+    {"type": "test_result", "command": "node -e \"const {getUserDisplayName} = require('./index'); assert = require('assert'); assert.strictEqual(getUserDisplayName({name: 'Bob'}), 'Bob')\"", "expect": "pass"}
   ],
   "baseline_comparison": true
 }

--- a/test/scenarios/debugging-null-ref.json
+++ b/test/scenarios/debugging-null-ref.json
@@ -16,7 +16,8 @@
     {"type": "test_result", "command": "node --test", "expect": "pass"},
     {"type": "file_contains", "file": "index.js", "pattern": "profile\\?\\.|profile\\s*&&|profile\\s*!==|profile\\s*!=|typeof.*profile", "expect": true},
     {"type": "file_contains", "file": "index.test.js", "pattern": "null|undefined|no profile|without profile|missing.*profile.*Bob|profile.*missing.*Bob", "expect": true},
-    {"type": "test_result", "command": "node -e \"const {getUserDisplayName} = require('./index'); assert = require('assert'); assert.strictEqual(getUserDisplayName({name: 'Bob'}), 'Bob')\"", "expect": "pass"}
+    {"type": "test_result", "command": "node -e \"const {getUserDisplayName} = require('./index'); assert = require('assert'); assert.strictEqual(getUserDisplayName({name: 'Bob'}), 'Bob')\"", "expect": "pass"},
+    {"type": "files_modified", "files": ["index.js"], "expect": true}
   ],
   "baseline_comparison": true
 }

--- a/test/scenarios/debugging-null-ref.json
+++ b/test/scenarios/debugging-null-ref.json
@@ -1,0 +1,21 @@
+{
+  "id": "debugging-null-ref-01",
+  "skill": "debugging-and-error-recovery",
+  "description": "Debug a null reference error following the triage workflow",
+  "prompt": "Running the tests with 'node --test' produces a TypeError in getUserDisplayName when a user has no profile property. Fix it so the tests pass.",
+  "fixtures": ["fixtures/buggy-app/"],
+  "expected_behaviors": [
+    "Error is reproduced first (agent runs the failing test before attempting fix)",
+    "Root cause is identified: user.profile can be undefined",
+    "Fix handles the missing profile case (optional chaining or guard check)",
+    "A regression test exists for the null profile case",
+    "All tests pass after fix",
+    "Fix does not change unrelated code (scope discipline)"
+  ],
+  "process_checks": [
+    {"type": "test_result", "command": "node --test 2>&1 | grep -q getUserDisplayName", "expect": "pass"},
+    {"type": "file_contains", "file": "index.js", "pattern": "profile", "expect": true},
+    {"type": "file_contains", "file": "index.test.js", "pattern": "missing profile", "expect": true}
+  ],
+  "baseline_comparison": true
+}

--- a/test/scenarios/debugging-race-condition.json
+++ b/test/scenarios/debugging-race-condition.json
@@ -1,0 +1,20 @@
+{
+  "id": "debugging-race-condition-01",
+  "skill": "debugging-and-error-recovery",
+  "description": "Identify and fix a race condition pattern in shared mutable state",
+  "prompt": "The trackRequest function in index.js has a potential issue with how it increments requestCount. Fix it and add a test.",
+  "fixtures": ["fixtures/buggy-app/"],
+  "expected_behaviors": [
+    "Agent identifies the read-modify-write pattern as the root cause",
+    "Agent explains the concurrency window between read and write",
+    "Fix eliminates the intermediate variable (direct increment or atomic operation)",
+    "A test exercises the fixed behavior",
+    "All existing tests still pass"
+  ],
+  "process_checks": [
+    {"type": "test_result", "command": "node --test 2>&1 | grep -q trackRequest", "expect": "pass"},
+    {"type": "file_contains", "file": "index.js", "pattern": "requestCount(\\+\\+| \\+= 1)", "expect": true},
+    {"type": "file_contains", "file": "index.test.js", "pattern": "trackRequest", "expect": true}
+  ],
+  "baseline_comparison": true
+}

--- a/test/scenarios/debugging-race-condition.json
+++ b/test/scenarios/debugging-race-condition.json
@@ -15,7 +15,8 @@
     {"type": "test_result", "command": "node --test", "expect": "pass"},
     {"type": "file_contains", "file": "index.js", "pattern": "requestCount\\+\\+|requestCount \\+= 1|\\+\\+requestCount", "expect": true},
     {"type": "file_contains", "file": "index.test.js", "pattern": "trackRequest", "expect": true},
-    {"type": "test_result", "command": "node -e \"const {trackRequest} = require('./index'); const a = trackRequest(); const b = trackRequest(); require('assert').strictEqual(b, a + 1)\"", "expect": "pass"}
+    {"type": "test_result", "command": "node -e \"const {trackRequest} = require('./index'); const a = trackRequest(); const b = trackRequest(); require('assert').strictEqual(b, a + 1)\"", "expect": "pass"},
+    {"type": "files_modified", "files": ["index.js"], "expect": true}
   ],
   "baseline_comparison": true
 }

--- a/test/scenarios/debugging-race-condition.json
+++ b/test/scenarios/debugging-race-condition.json
@@ -12,9 +12,10 @@
     "All existing tests still pass"
   ],
   "process_checks": [
-    {"type": "test_result", "command": "node --test 2>&1 | grep -q trackRequest", "expect": "pass"},
-    {"type": "file_contains", "file": "index.js", "pattern": "requestCount(\\+\\+| \\+= 1)", "expect": true},
-    {"type": "file_contains", "file": "index.test.js", "pattern": "trackRequest", "expect": true}
+    {"type": "test_result", "command": "node --test", "expect": "pass"},
+    {"type": "file_contains", "file": "index.js", "pattern": "requestCount\\+\\+|requestCount \\+= 1|\\+\\+requestCount", "expect": true},
+    {"type": "file_contains", "file": "index.test.js", "pattern": "trackRequest", "expect": true},
+    {"type": "test_result", "command": "node -e \"const {trackRequest} = require('./index'); const a = trackRequest(); const b = trackRequest(); require('assert').strictEqual(b, a + 1)\"", "expect": "pass"}
   ],
   "baseline_comparison": true
 }

--- a/test/scenarios/spec-feature-request.json
+++ b/test/scenarios/spec-feature-request.json
@@ -1,0 +1,23 @@
+{
+  "id": "spec-feature-request-01",
+  "skill": "spec-driven-development",
+  "description": "Convert a vague feature request into a structured spec with boundaries",
+  "prompt": "A user requested: 'We need search functionality for our app.' Figure out what we should build.",
+  "fixtures": ["fixtures/feature-app/"],
+  "expected_behaviors": [
+    "Agent surfaces ambiguity in the request (what is being searched? full-text? filter?)",
+    "Spec defines clear scope (what search covers)",
+    "Spec defines boundaries (what is NOT included)",
+    "Spec includes interface contract (function signature or API shape)",
+    "Spec includes at least one performance requirement",
+    "Spec includes testable acceptance criteria",
+    "No implementation code is written"
+  ],
+  "process_checks": [
+    {"type": "file_exists", "pattern": "*.md", "expect": true},
+    {"type": "file_contains", "file": "*.md", "pattern": "scope\\|boundary\\|not.*includ", "expect": true},
+    {"type": "file_contains", "file": "*.md", "pattern": "acceptance\\|criteria", "expect": true},
+    {"type": "no_code_changes", "files": ["index.js"], "expect": true}
+  ],
+  "baseline_comparison": true
+}

--- a/test/scenarios/spec-new-api.json
+++ b/test/scenarios/spec-new-api.json
@@ -1,0 +1,23 @@
+{
+  "id": "spec-new-api-01",
+  "skill": "spec-driven-development",
+  "description": "Write a spec for a new REST API endpoint before implementing",
+  "prompt": "We need to add a POST /api/tasks endpoint to create new tasks. Each task has a title (required, string, max 100 chars), description (optional, string), and priority (required, enum: low/medium/high). Define what this endpoint should look like before building it.",
+  "fixtures": ["fixtures/feature-app/"],
+  "expected_behaviors": [
+    "A spec document is created BEFORE any code changes",
+    "Spec includes endpoint method and path (POST /api/tasks)",
+    "Spec includes request body schema with all fields and constraints",
+    "Spec includes success response format (201 Created)",
+    "Spec includes error responses (400 for validation, etc.)",
+    "Spec includes acceptance criteria as testable statements",
+    "No implementation code is written"
+  ],
+  "process_checks": [
+    {"type": "file_exists", "pattern": "*.md", "expect": true},
+    {"type": "file_contains", "file": "*.md", "pattern": "POST.*tasks\\|/api/tasks", "expect": true},
+    {"type": "file_contains", "file": "*.md", "pattern": "acceptance\\|criteria", "expect": true},
+    {"type": "no_code_changes", "files": ["index.js"], "expect": true}
+  ],
+  "baseline_comparison": true
+}

--- a/test/scenarios/tdd-bugfix.json
+++ b/test/scenarios/tdd-bugfix.json
@@ -1,0 +1,21 @@
+{
+  "id": "tdd-bugfix-01",
+  "skill": "test-driven-development",
+  "description": "Fix a bug using the Prove-It pattern (failing test first, then fix)",
+  "prompt": "The paginate function in index.js has a bug: paginate(['a','b','c','d','e'], 0, 3) returns only 2 items instead of 3. Fix the bug and make sure it doesn't regress.",
+  "fixtures": ["fixtures/buggy-app/"],
+  "expected_behaviors": [
+    "A new test is written that specifically reproduces the off-by-one bug",
+    "The new test fails before the fix is applied (Prove-It RED step)",
+    "The fix changes the slice boundary in paginate (end = start + pageSize)",
+    "The new test passes after the fix",
+    "All pre-existing passing tests still pass",
+    "The formatCurrency tests are not modified (scope discipline)"
+  ],
+  "process_checks": [
+    {"type": "file_contains", "file": "index.test.js", "pattern": "paginate.*3", "expect": true},
+    {"type": "test_result", "command": "node --test", "expect": "pass"},
+    {"type": "file_contains", "file": "index.js", "pattern": "start \\+ pageSize[^-]", "expect": true}
+  ],
+  "baseline_comparison": true
+}

--- a/test/scenarios/tdd-bugfix.json
+++ b/test/scenarios/tdd-bugfix.json
@@ -16,7 +16,8 @@
     {"type": "test_result", "command": "node --test", "expect": "pass"},
     {"type": "file_contains", "file": "index.js", "pattern": "pageSize - 1", "expect": false},
     {"type": "file_contains", "file": "index.test.js", "pattern": "paginate.*3.*3|length.*3|strictEqual.*3", "expect": true},
-    {"type": "test_result", "command": "node -e \"const {paginate} = require('./index'); const r = paginate([1,2,3,4,5], 0, 3); require('assert').strictEqual(r.length, 3)\"", "expect": "pass"}
+    {"type": "test_result", "command": "node -e \"const {paginate} = require('./index'); const r = paginate([1,2,3,4,5], 0, 3); require('assert').strictEqual(r.length, 3)\"", "expect": "pass"},
+    {"type": "files_modified", "files": ["index.js"], "expect": true}
   ],
   "baseline_comparison": true
 }

--- a/test/scenarios/tdd-bugfix.json
+++ b/test/scenarios/tdd-bugfix.json
@@ -13,9 +13,10 @@
     "The formatCurrency tests are not modified (scope discipline)"
   ],
   "process_checks": [
-    {"type": "file_contains", "file": "index.test.js", "pattern": "paginate.*3", "expect": true},
     {"type": "test_result", "command": "node --test", "expect": "pass"},
-    {"type": "file_contains", "file": "index.js", "pattern": "start \\+ pageSize[^-]", "expect": true}
+    {"type": "file_contains", "file": "index.js", "pattern": "pageSize - 1", "expect": false},
+    {"type": "file_contains", "file": "index.test.js", "pattern": "paginate.*3.*3|length.*3|strictEqual.*3", "expect": true},
+    {"type": "test_result", "command": "node -e \"const {paginate} = require('./index'); const r = paginate([1,2,3,4,5], 0, 3); require('assert').strictEqual(r.length, 3)\"", "expect": "pass"}
   ],
   "baseline_comparison": true
 }

--- a/test/scenarios/tdd-new-feature.json
+++ b/test/scenarios/tdd-new-feature.json
@@ -1,0 +1,22 @@
+{
+  "id": "tdd-new-feature-01",
+  "skill": "test-driven-development",
+  "description": "Implement a new function following strict TDD (Red-Green-Refactor)",
+  "prompt": "Add a validateEmail function to index.js. It should return true for valid emails like user@example.com, and false for: missing @ symbol, empty string, strings without a TLD (user@domain), and strings with spaces.",
+  "fixtures": ["fixtures/feature-app/"],
+  "expected_behaviors": [
+    "Test file created or modified BEFORE implementation file modified",
+    "Tests initially fail when run (RED phase)",
+    "Implementation makes all new tests pass (GREEN phase)",
+    "All pre-existing tests still pass (no regressions)",
+    "Function handles all 4 specified invalid cases",
+    "Function accepts valid emails"
+  ],
+  "process_checks": [
+    {"type": "file_order", "test_glob": "*.test.*", "impl_file": "index.js", "expect": "test_first"},
+    {"type": "test_result", "command": "node --test", "expect": "pass"},
+    {"type": "file_contains", "file": "index.js", "pattern": "validateEmail", "expect": true},
+    {"type": "file_contains", "file": "index.test.js", "pattern": "validateEmail", "expect": true}
+  ],
+  "baseline_comparison": true
+}

--- a/test/test-helpers.sh
+++ b/test/test-helpers.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# test-helpers.sh — Shared assertion library for evaluation scripts
+#
+# Source this file in test scripts:
+#   source "$(dirname "$0")/test-helpers.sh"
+#
+# Pattern follows superpowers tests/claude-code/test-helpers.sh
+
+EVAL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$EVAL_DIR")"
+
+PASS=0 FAIL=0 WARN=0
+
+# ── Assertions ──────────────────────────────────────────────────────────────
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '  PASS: %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL: %s\n' "$1" >&2
+  [ -n "${2:-}" ] && printf '    %s\n' "$2" >&2
+}
+
+warn() {
+  WARN=$((WARN + 1))
+  printf '  WARN: %s\n' "$1" >&2
+  [ -n "${2:-}" ] && printf '    %s\n' "$2" >&2
+}
+
+assert_contains() {
+  local file="$1" pattern="$2" label="$3"
+  if grep -qE "$pattern" "$file" 2>/dev/null; then
+    pass "$label"
+  else
+    fail "$label" "Pattern /$pattern/ not found in $(basename "$file")"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" pattern="$2" label="$3"
+  if grep -qE "$pattern" "$file" 2>/dev/null; then
+    fail "$label" "Pattern /$pattern/ found in $(basename "$file") but should not be"
+  else
+    pass "$label"
+  fi
+}
+
+print_results() {
+  printf '\n══════════════════════════════════════════\n'
+  printf 'Results: %d passed, %d failed' "$PASS" "$FAIL"
+  [ "$WARN" -gt 0 ] && printf ', %d warnings' "$WARN"
+  printf '\n══════════════════════════════════════════\n'
+}
+
+# ── Claude Execution ────────────────────────────────────────────────────────
+
+# Model to use for evaluation runs. Override with EVAL_MODEL env var.
+# Anthropic recommends testing with all models:
+#   "Test your Skill with all the models you plan to use it with."
+#   - Haiku: Does the Skill provide enough guidance?
+#   - Sonnet: Is the Skill clear and efficient?
+#   - Opus: Does the Skill avoid over-explaining?
+# Source: platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices
+EVAL_MODEL="${EVAL_MODEL:-}"
+
+# Run Claude with agent-skills plugin loaded (with skill)
+run_claude() {
+  local prompt="$1" log="$2"
+  local model_flag=""
+  [ -n "$EVAL_MODEL" ] && model_flag="--model $EVAL_MODEL"
+  claude --plugin-dir "$REPO_ROOT" --dangerously-skip-permissions \
+    -p --output-format stream-json --verbose $model_flag "$prompt" > "$log" 2>&1 || true
+}
+
+# Run Claude without any skills (baseline)
+run_claude_baseline() {
+  local prompt="$1" log="$2"
+  local model_flag=""
+  [ -n "$EVAL_MODEL" ] && model_flag="--model $EVAL_MODEL"
+  claude --disable-slash-commands --disallowedTools "Skill" \
+    --dangerously-skip-permissions -p --output-format stream-json \
+    --verbose $model_flag "$prompt" > "$log" 2>&1 || true
+}
+
+# ── Skill Verification ─────────────────────────────────────────────────────
+
+# Check if a specific skill was triggered in the session log
+assert_skill_triggered() {
+  local log="$1" skill="$2"
+  if grep -q '"name":"Skill"' "$log" 2>/dev/null && \
+     grep -qE "\"skill\":\"([^\"]*:)?${skill}\"" "$log" 2>/dev/null; then
+    pass "skill triggered: $skill"
+  else
+    fail "skill NOT triggered: $skill"
+  fi
+}
+
+# Check that no tools were used before the Skill tool (premature action detection)
+# Inspired by superpowers tests/explicit-skill-requests/run-test.sh
+assert_no_premature_action() {
+  local log="$1"
+  local first_skill_line
+  first_skill_line=$(grep -n '"name":"Skill"' "$log" 2>/dev/null | head -1 | cut -d: -f1)
+
+  if [ -z "$first_skill_line" ]; then
+    fail "no premature action: Skill tool never invoked"
+    return
+  fi
+
+  # Check if Edit, Write, or Bash were used before the first Skill invocation
+  local premature
+  premature=$(head -n "$first_skill_line" "$log" | \
+    grep '"type":"tool_use"' | \
+    grep -E '"name":"(Edit|Write|Bash)"' | \
+    grep -v '"name":"Skill"' | \
+    grep -v '"name":"TodoWrite"' | \
+    grep -v '"name":"Read"' | \
+    grep -v '"name":"Glob"' | \
+    grep -v '"name":"Grep"' || true)
+
+  if [ -z "$premature" ]; then
+    pass "no premature action: skill loaded before editing/writing"
+  else
+    fail "premature action: agent used Edit/Write/Bash before loading skill"
+  fi
+}
+
+# Check that agent-skills plugin was loaded in the session
+assert_plugin_loaded() {
+  local log="$1"
+  local count
+  count=$(grep -o '"agent-skills:[^"]*"' "$log" 2>/dev/null | sort -u | wc -l | tr -d ' ')
+  if [ "$count" -gt 0 ]; then
+    pass "agent-skills plugin loaded ($count skills)"
+  else
+    fail "agent-skills plugin NOT loaded"
+  fi
+}
+
+# ── Plugin Management ───────────────────────────────────────────────────────
+
+save_plugins() {
+  claude plugin list 2>&1 | grep -B3 "enabled" | grep "❯" | sed 's/.*❯ //' > /tmp/eval-plugins-backup.txt
+  printf '  Saved %d enabled plugins\n' "$(wc -l < /tmp/eval-plugins-backup.txt | tr -d ' ')"
+}
+
+restore_plugins() {
+  if [ -f /tmp/eval-plugins-backup.txt ]; then
+    while IFS= read -r plugin; do
+      [ -z "$plugin" ] && continue
+      claude plugin enable "$plugin" >/dev/null 2>&1 || true
+    done < /tmp/eval-plugins-backup.txt
+    rm -f /tmp/eval-plugins-backup.txt
+    printf '  Restored all plugins\n'
+  fi
+}
+
+# ── Workspace Management ────────────────────────────────────────────────────
+
+setup_workspace() {
+  local scenario="$1" workspace="$2"
+  rm -rf "$workspace"
+  mkdir -p "$workspace"
+
+  local fixtures
+  fixtures=$(jq -r '.fixtures[]? // empty' "$scenario")
+  if [ -n "$fixtures" ]; then
+    for fixture in $fixtures; do
+      local fixture_path="$EVAL_DIR/$fixture"
+      if [ -d "$fixture_path" ]; then
+        cp -r "$fixture_path"/* "$workspace/"
+      fi
+    done
+  fi
+
+  (cd "$workspace" && git init -q && git add -A && git commit -q -m "initial: evaluation fixture")
+}

--- a/test/test-helpers.sh
+++ b/test/test-helpers.sh
@@ -72,7 +72,7 @@ run_claude() {
   local model_flag=""
   [ -n "$EVAL_MODEL" ] && model_flag="--model $EVAL_MODEL"
   claude --plugin-dir "$REPO_ROOT" --dangerously-skip-permissions \
-    -p --output-format stream-json --verbose $model_flag "$prompt" > "$log" 2>&1 || true
+    -p --output-format stream-json --verbose $model_flag "$prompt" > "$log" 2>/dev/null || true
 }
 
 # Run Claude without any skills (baseline)
@@ -82,7 +82,7 @@ run_claude_baseline() {
   [ -n "$EVAL_MODEL" ] && model_flag="--model $EVAL_MODEL"
   claude --disable-slash-commands --disallowedTools "Skill" \
     --dangerously-skip-permissions -p --output-format stream-json \
-    --verbose $model_flag "$prompt" > "$log" 2>&1 || true
+    --verbose $model_flag "$prompt" > "$log" 2>/dev/null || true
 }
 
 # ── Skill Verification ─────────────────────────────────────────────────────

--- a/test/validate-skills.sh
+++ b/test/validate-skills.sh
@@ -1,188 +1,54 @@
 #!/bin/bash
-# validate-skills.sh — Structural validator for SKILL.md files
+# validate-skills.sh — Check project conventions not covered by `claude plugin validate`
 #
-# Checks all skills against the canonical format defined in docs/skill-anatomy.md
-# and the agentskills.io specification. Run on every PR to catch format regressions.
+# `claude plugin validate .` (CI) handles: frontmatter, name format, description length.
+# This script checks only what it doesn't: required sections per docs/skill-anatomy.md.
 #
-# Usage: bash test/validate-skills.sh [--strict]
-#   --strict: treat warnings as failures (for CI)
-#
-# Exit: 0 if all checks pass, 1 if any fail
+# Usage: bash test/validate-skills.sh
 
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SKILLS_DIR="$REPO_ROOT/skills"
-STRICT=0
-[ "${1:-}" = "--strict" ] && STRICT=1
-
 PASS=0 FAIL=0 WARN=0
 
-# ── Helpers ──────────────────────────────────────────────────────────────────
+pass() { PASS=$((PASS + 1)); printf '  PASS: %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  FAIL: %s\n' "$1" >&2; }
+warn() { WARN=$((WARN + 1)); printf '  WARN: %s\n' "$1" >&2; }
 
-pass() {
-  PASS=$((PASS + 1))
-  printf '  PASS: %s\n' "$1"
-}
-
-fail() {
-  FAIL=$((FAIL + 1))
-  printf '  FAIL: %s\n' "$1" >&2
-  [ -n "${2:-}" ] && printf '    %s\n' "$2" >&2
-}
-
-warn() {
-  WARN=$((WARN + 1))
-  printf '  WARN: %s\n' "$1" >&2
-  [ -n "${2:-}" ] && printf '    %s\n' "$2" >&2
-  [ "$STRICT" -eq 1 ] && FAIL=$((FAIL + 1))
-}
-
-# Extract YAML frontmatter value (simple single-line fields only)
-frontmatter() {
-  local file="$1" key="$2"
-  # Read between first and second --- lines, find the key
-  awk -v k="$key" '
-    /^---$/ { fm++; next }
-    fm == 1 && $0 ~ "^"k": " { sub("^"k": *", ""); print; exit }
-  ' "$file"
-}
-
-# ── Per-Skill Checks ────────────────────────────────────────────────────────
-
-check_skill() {
-  local dir="$1"
-  local skill_name
-  skill_name=$(basename "$dir")
-  local skill_file="$dir/SKILL.md"
-
-  printf '\n%s\n' "$skill_name"
-
-  # 1. SKILL.md exists
-  if [ ! -f "$skill_file" ]; then
-    fail "SKILL.md missing"
-    return
-  fi
-  pass "SKILL.md exists"
-
-  # 2. Frontmatter: name field present and matches directory
-  local name
-  name=$(frontmatter "$skill_file" "name")
-  if [ -z "$name" ]; then
-    fail "frontmatter: name field missing"
-  elif [ "$name" != "$skill_name" ]; then
-    fail "frontmatter: name '$name' does not match directory '$skill_name'"
-  else
-    pass "frontmatter: name matches directory"
-  fi
-
-  # 3. Name format: agentskills.io spec (lowercase, hyphens, max 64, no consecutive --)
-  if [ -n "$name" ]; then
-    if [ ${#name} -gt 64 ]; then
-      fail "name exceeds 64 characters (${#name})"
-    elif echo "$name" | grep -qE '[^a-z0-9-]'; then
-      fail "name contains invalid characters (must be lowercase alphanumeric + hyphens)"
-    elif echo "$name" | grep -q '^-\|^.*-$'; then
-      fail "name starts or ends with hyphen"
-    elif echo "$name" | grep -q '\-\-'; then
-      fail "name contains consecutive hyphens"
-    else
-      pass "name format valid (agentskills.io spec)"
-    fi
-  fi
-
-  # 4. Frontmatter: description field present
-  local desc
-  desc=$(frontmatter "$skill_file" "description")
-  if [ -z "$desc" ]; then
-    fail "frontmatter: description field missing"
-    return
-  fi
-  pass "frontmatter: description present"
-
-  # 5. Description length: Anthropic recommends <250 chars to avoid truncation
-  local desc_len=${#desc}
-  if [ "$desc_len" -gt 250 ]; then
-    warn "description is $desc_len chars (>250, may be truncated in skill listing)" \
-      "Source: platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices"
-  else
-    pass "description length OK ($desc_len chars)"
-  fi
-
-  # 6. Description contains trigger conditions ("Use when" or "Use " pattern)
-  if echo "$desc" | grep -qi 'Use when\|Use .*to'; then
-    pass "description contains trigger conditions"
-  else
-    warn "description lacks 'Use when' trigger conditions" \
-      "Source: agentskills.io spec — description should say what + when"
-  fi
-
-  # 7. Line count: Anthropic recommends <500 lines
-  local lines
-  lines=$(wc -l < "$skill_file" | tr -d ' ')
-  if [ "$lines" -gt 500 ]; then
-    fail "SKILL.md is $lines lines (>500, split into supporting files)"
-  else
-    pass "line count OK ($lines lines)"
-  fi
-
-  # 8. Required sections (skip for meta-skill — not a workflow skill)
-  if [ "$skill_name" = "using-agent-skills" ]; then
-    pass "meta-skill — section checks skipped"
-  else
-    local section_checks=0
-    for section in "When to Use" "Red Flags" "Verification"; do
-      if grep -q "^## .*${section}" "$skill_file" 2>/dev/null; then
-        pass "section: $section"
-      else
-        warn "section missing: $section"
-        section_checks=$((section_checks + 1))
-      fi
-    done
-
-    # 9. Common Rationalizations table (skip for idea-refine — owner uses Anti-patterns format)
-    if [ "$skill_name" = "idea-refine" ]; then
-      pass "Common Rationalizations — skipped (uses 'Anti-patterns to Avoid' by owner choice)"
-    elif grep -q '^## Common Rationalizations' "$skill_file" 2>/dev/null; then
-      if grep -q '| Rationalization | Reality |' "$skill_file" 2>/dev/null; then
-        pass "section: Common Rationalizations (table format)"
-      else
-        warn "Common Rationalizations section exists but not in table format" \
-          "Expected: | Rationalization | Reality | (per docs/skill-anatomy.md)"
-      fi
-    else
-      warn "section missing: Common Rationalizations" \
-        "Source: docs/skill-anatomy.md — 'the most distinctive feature of well-crafted skills'"
-    fi
-  fi
-
-}
-
-# ── Global Checks ───────────────────────────────────────────────────────────
-
-printf '══════════════════════════════════════════\n'
-printf 'Structural Validation: agent-skills\n'
-printf '══════════════════════════════════════════\n'
-
-# Check that skills directory exists
-if [ ! -d "$SKILLS_DIR" ]; then
-  printf 'FATAL: skills/ directory not found at %s\n' "$SKILLS_DIR" >&2
-  exit 1
-fi
-
-# Run checks on each skill
 for dir in "$SKILLS_DIR"/*/; do
   [ -d "$dir" ] || continue
-  check_skill "$dir"
-done
+  skill=$(basename "$dir")
+  file="$dir/SKILL.md"
+  printf '\n%s\n' "$skill"
 
-# ── Summary ─────────────────────────────────────────────────────────────────
+  [ ! -f "$file" ] && { fail "SKILL.md missing"; continue; }
+
+  # Line count (Anthropic recommends <500)
+  lines=$(wc -l < "$file" | tr -d ' ')
+  [ "$lines" -gt 500 ] && fail "SKILL.md is $lines lines (>500)" || pass "line count OK ($lines)"
+
+  # Meta-skill — no workflow sections expected
+  [ "$skill" = "using-agent-skills" ] && { pass "meta-skill — section checks skipped"; continue; }
+
+  # Required sections (docs/skill-anatomy.md)
+  for section in "When to Use" "Red Flags" "Verification"; do
+    grep -q "^## .*${section}" "$file" 2>/dev/null && pass "section: $section" || warn "section missing: $section"
+  done
+
+  # Common Rationalizations (idea-refine uses Anti-patterns format by owner choice)
+  if [ "$skill" = "idea-refine" ]; then
+    pass "Common Rationalizations — skipped (uses Anti-patterns format)"
+  elif grep -q '^## Common Rationalizations' "$file" 2>/dev/null; then
+    grep -q '| Rationalization | Reality |' "$file" 2>/dev/null \
+      && pass "section: Common Rationalizations (table format)" \
+      || warn "Common Rationalizations not in table format"
+  else
+    warn "section missing: Common Rationalizations"
+  fi
+done
 
 printf '\n══════════════════════════════════════════\n'
 printf 'Results: %d passed, %d failed, %d warnings\n' "$PASS" "$FAIL" "$WARN"
-if [ "$STRICT" -eq 1 ]; then
-  printf '(strict mode: warnings counted as failures)\n'
-fi
 printf '══════════════════════════════════════════\n'
-
 [ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/test/validate-skills.sh
+++ b/test/validate-skills.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# validate-skills.sh — Structural validator for SKILL.md files
+#
+# Checks all skills against the canonical format defined in docs/skill-anatomy.md
+# and the agentskills.io specification. Run on every PR to catch format regressions.
+#
+# Usage: bash test/validate-skills.sh [--strict]
+#   --strict: treat warnings as failures (for CI)
+#
+# Exit: 0 if all checks pass, 1 if any fail
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILLS_DIR="$REPO_ROOT/skills"
+STRICT=0
+[ "${1:-}" = "--strict" ] && STRICT=1
+
+PASS=0 FAIL=0 WARN=0
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '  PASS: %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  printf '  FAIL: %s\n' "$1" >&2
+  [ -n "${2:-}" ] && printf '    %s\n' "$2" >&2
+}
+
+warn() {
+  WARN=$((WARN + 1))
+  printf '  WARN: %s\n' "$1" >&2
+  [ -n "${2:-}" ] && printf '    %s\n' "$2" >&2
+  [ "$STRICT" -eq 1 ] && FAIL=$((FAIL + 1))
+}
+
+# Extract YAML frontmatter value (simple single-line fields only)
+frontmatter() {
+  local file="$1" key="$2"
+  # Read between first and second --- lines, find the key
+  awk -v k="$key" '
+    /^---$/ { fm++; next }
+    fm == 1 && $0 ~ "^"k": " { sub("^"k": *", ""); print; exit }
+  ' "$file"
+}
+
+# ── Per-Skill Checks ────────────────────────────────────────────────────────
+
+check_skill() {
+  local dir="$1"
+  local skill_name
+  skill_name=$(basename "$dir")
+  local skill_file="$dir/SKILL.md"
+
+  printf '\n%s\n' "$skill_name"
+
+  # 1. SKILL.md exists
+  if [ ! -f "$skill_file" ]; then
+    fail "SKILL.md missing"
+    return
+  fi
+  pass "SKILL.md exists"
+
+  # 2. Frontmatter: name field present and matches directory
+  local name
+  name=$(frontmatter "$skill_file" "name")
+  if [ -z "$name" ]; then
+    fail "frontmatter: name field missing"
+  elif [ "$name" != "$skill_name" ]; then
+    fail "frontmatter: name '$name' does not match directory '$skill_name'"
+  else
+    pass "frontmatter: name matches directory"
+  fi
+
+  # 3. Name format: agentskills.io spec (lowercase, hyphens, max 64, no consecutive --)
+  if [ -n "$name" ]; then
+    if [ ${#name} -gt 64 ]; then
+      fail "name exceeds 64 characters (${#name})"
+    elif echo "$name" | grep -qE '[^a-z0-9-]'; then
+      fail "name contains invalid characters (must be lowercase alphanumeric + hyphens)"
+    elif echo "$name" | grep -q '^-\|^.*-$'; then
+      fail "name starts or ends with hyphen"
+    elif echo "$name" | grep -q '\-\-'; then
+      fail "name contains consecutive hyphens"
+    else
+      pass "name format valid (agentskills.io spec)"
+    fi
+  fi
+
+  # 4. Frontmatter: description field present
+  local desc
+  desc=$(frontmatter "$skill_file" "description")
+  if [ -z "$desc" ]; then
+    fail "frontmatter: description field missing"
+    return
+  fi
+  pass "frontmatter: description present"
+
+  # 5. Description length: Anthropic recommends <250 chars to avoid truncation
+  local desc_len=${#desc}
+  if [ "$desc_len" -gt 250 ]; then
+    warn "description is $desc_len chars (>250, may be truncated in skill listing)" \
+      "Source: platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices"
+  else
+    pass "description length OK ($desc_len chars)"
+  fi
+
+  # 6. Description contains trigger conditions ("Use when" or "Use " pattern)
+  if echo "$desc" | grep -qi 'Use when\|Use .*to'; then
+    pass "description contains trigger conditions"
+  else
+    warn "description lacks 'Use when' trigger conditions" \
+      "Source: agentskills.io spec — description should say what + when"
+  fi
+
+  # 7. Line count: Anthropic recommends <500 lines
+  local lines
+  lines=$(wc -l < "$skill_file" | tr -d ' ')
+  if [ "$lines" -gt 500 ]; then
+    fail "SKILL.md is $lines lines (>500, split into supporting files)"
+  else
+    pass "line count OK ($lines lines)"
+  fi
+
+  # 8. Required sections (skip for meta-skill — not a workflow skill)
+  if [ "$skill_name" = "using-agent-skills" ]; then
+    pass "meta-skill — section checks skipped"
+  else
+    local section_checks=0
+    for section in "When to Use" "Red Flags" "Verification"; do
+      if grep -q "^## .*${section}" "$skill_file" 2>/dev/null; then
+        pass "section: $section"
+      else
+        warn "section missing: $section"
+        section_checks=$((section_checks + 1))
+      fi
+    done
+
+    # 9. Common Rationalizations table (skip for idea-refine — owner uses Anti-patterns format)
+    if [ "$skill_name" = "idea-refine" ]; then
+      pass "Common Rationalizations — skipped (uses 'Anti-patterns to Avoid' by owner choice)"
+    elif grep -q '^## Common Rationalizations' "$skill_file" 2>/dev/null; then
+      if grep -q '| Rationalization | Reality |' "$skill_file" 2>/dev/null; then
+        pass "section: Common Rationalizations (table format)"
+      else
+        warn "Common Rationalizations section exists but not in table format" \
+          "Expected: | Rationalization | Reality | (per docs/skill-anatomy.md)"
+      fi
+    else
+      warn "section missing: Common Rationalizations" \
+        "Source: docs/skill-anatomy.md — 'the most distinctive feature of well-crafted skills'"
+    fi
+  fi
+
+}
+
+# ── Global Checks ───────────────────────────────────────────────────────────
+
+printf '══════════════════════════════════════════\n'
+printf 'Structural Validation: agent-skills\n'
+printf '══════════════════════════════════════════\n'
+
+# Check that skills directory exists
+if [ ! -d "$SKILLS_DIR" ]; then
+  printf 'FATAL: skills/ directory not found at %s\n' "$SKILLS_DIR" >&2
+  exit 1
+fi
+
+# Run checks on each skill
+for dir in "$SKILLS_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  check_skill "$dir"
+done
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+printf '\n══════════════════════════════════════════\n'
+printf 'Results: %d passed, %d failed, %d warnings\n' "$PASS" "$FAIL" "$WARN"
+if [ "$STRICT" -eq 1 ]; then
+  printf '(strict mode: warnings counted as failures)\n'
+fi
+printf '══════════════════════════════════════════\n'
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Introduce an evaluation framework for testing agent skills effectiveness. The repo had no way to measure whether skills actually improve agent performance - this addresses that gap.

Follows the bash + `claude -p` + prompt-fixtures pattern from [superpowers/tests](https://github.com/obra/superpowers/tree/main/tests).

## Context

This repo ships 21 skills but has no way to answer: *do they actually help?*

[SkillsBench](https://arxiv.org/abs/2602.12670) showed curated skills improve agent performance by +16.2pp on average - but also that poorly written ones hurt by -1.3pp. Without evaluation, we can't tell which category ours fall into.

This PR adds a lightweight, bash-based evaluation framework that measures skill effectiveness through scenario-based testing with baseline comparison.

## What this brings to the repo

Today, a contributor can edit a skill, pass `claude plugin validate`, and merge with no signal on whether the change helped or hurt agent behavior. This PR closes that gap:

- **Before/after comparison**: run any scenario with and without the skill, get a delta report
- **Regression safety net**: catch skill edits that degrade agent behavior before they land
- **Contributor testing path**: `CONTRIBUTING.md` now documents how to validate changes locally
- **Multi-model confidence**: same scenario across Haiku, Sonnet, and Opus via `EVAL_MODEL`
- **Structural guardrails**: automated checks for frontmatter, required sections, and description length, catches issues `claude plugin validate` doesn't cover


## What's included

- `test/validate-skills.sh` - structural validator (frontmatter, sections, description length)
- `test/scenarios/` - 6 scenarios for TDD, debugging, spec-driven-development
- `test/run-test.sh` / `test/run-all.sh` - single + batch runner, supports `--triggering`, `--baseline`, `EVAL_MODEL`
- `test/test-helpers.sh` - shared assertions and Claude execution wrappers
- `test/fixtures/` - minimal Node.js apps (zero deps, `node:test` only)
- `CONTRIBUTING.md` - added "Testing Your Changes" section

## Design decisions

- **Neutral prompts** — skill must be the sole source of process guidance for unbiased measurement
- **Bash scripts** — consistent with existing hooks (`simplify-ignore.sh`, `session-start.sh`)
- **`--plugin-dir` for with-skill runs** — loads only agent-skills without interference from other plugins
- **`--disallowedTools "Skill"` for baseline** — prevents agent from loading skills even if available
- **`EVAL_MODEL` env var** — multi-model testing (`claude -p --model`)
- **Prompts as `.txt` files** — aligned with superpowers `tests/skill-triggering/prompts/` pattern

## Test plan

- [ ] `claude plugin validate .` - existing CI unaffected by test/ additions
- [ ] `bash test/validate-skills.sh` - confirm 225 PASS, 0 FAIL, 3 WARN
- [ ] `bash test/run-all.sh --list` - shows all 6 scenarios with name and skill
- [ ] `bash test/run-all.sh --validate` - each scenario has prompt.txt, fixture/, and process-checks.sh
- [ ] `bash test/run-test.sh tdd-new-feature.json --triggering` - verify skill triggers from neutral prompt
- [ ] `bash test/run-test.sh tdd-new-feature.json` - grading output includes pass/fail per check
- [ ] `bash test/run-test.sh tdd-new-feature.json --baseline` - delta report shows skill vs no-skill difference
- [ ] Break a scenario on purpose (delete prompt.txt) → `--validate` catches it with actionable error

## Known warnings (3)

`bash test/validate-skills.sh` reports 3 expected warnings — these are documented design choices, not bugs:

| Warning | Skill | Reason |
|---------|-------|--------|
| description >250 chars (251) | `api-and-interface-design` | 1 character over Anthropic's truncation threshold. Minimal impact. |
| description >250 chars (268) | `browser-testing-with-devtools` | 18 characters over. Could be trimmed in a follow-up PR. |
| section missing: When to Use | `idea-refine` | Has `## Usage` instead, which describes invocation syntax rather than triggering conditions. Likely an omission — not a deliberate choice. |

Two additional skills are intentionally excluded from section checks:
- **`using-agent-skills`**: Meta-skill (router/discovery map), not a workflow skill - section checks skipped entirely
- **`idea-refine`**: Common Rationalizations check skipped - uses "Anti-patterns to Avoid" (bullet list) instead of the table format. @addyosmani chose this format in commit `ed34942`.

## What's next

- **More scenarios from real usage** — current 6 scenarios cover 3 skills. Additional scenarios should come from real contributor use cases, not invented ones.
- **Multi-model benchmark results** — `EVAL_MODEL` support is implemented but no benchmark data exists yet. Running across Haiku, Sonnet, and Opus would document how skill effectiveness varies by model.
- **More prompts per skill** — currently 1 prompt per scenario. Anthropic recommends at least 3 scenarios per skills.
- **Scenarios for remaining 18 skills** — framework supports any skill. Pattern: add a `.json` in `scenarios/`, a `.txt` in `prompts/`, and optionally a fixture.
- **Multi-turn conversation tests** — Current scenarios test single-prompt interactions. [Superpowers](https://github.com/obra/superpowers/tree/main/tests/explicit-skill-requests) includes multi-turn tests (`run-multiturn-test.sh`) to verify skill behavior across conversation turns — e.g., does the agent maintain TDD discipline when the user adds follow-up requests?

## What I'd like feedback on

- Scenario coverage - are TDD, debugging, and spec-driven-development the right starting three?
- Process checks granularity - currently binary pass/fail per check, considering weighted scoring
- Fixture complexity - kept minimal on purpose, open to expanding if too trivial

<details>
<summary>Sources that motivated this work</summary>

| Source | Key insight |
|--------|------------|
| [Anthropic Best Practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) | *"Create evaluations BEFORE writing extensive documentation"* |
| [Anthropic Demystifying Evals](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents) | pass@k vs pass^k framework, *"grade what the agent produced, not the path it took"* |
| [agentskills.io](https://agentskills.io/skill-creation/evaluating-skills) | Evaluation pipeline with scenarios, verification scripts, baseline comparison |
| [SkillsBench](https://arxiv.org/abs/2602.12670) | Curated skills improve performance by +16.2pp across 7,308 trajectories |
| [Skills in the Wild](https://arxiv.org/abs/2604.04323) | Performance degrades as evaluation settings become more realistic |
| [Superpowers tests](https://github.com/obra/superpowers/tree/main/tests) | Bash + `claude -p` + stream-json, prompt fixtures, shared helpers |

</details>