### PR TITLE
feat: add delegation-provenance skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ docs/         → Setup guides for different tools
 
 **Define:** spec-driven-development
 **Plan:** planning-and-task-breakdown
-**Build:** incremental-implementation, test-driven-development, context-engineering, source-driven-development, frontend-ui-engineering, api-and-interface-design
+**Build:** incremental-implementation, test-driven-development, context-engineering, source-driven-development, delegation-provenance, frontend-ui-engineering, api-and-interface-design
 **Verify:** browser-testing-with-devtools, debugging-and-error-recovery
 **Review:** code-review-and-quality, code-simplification, security-and-hardening, performance-optimization
 **Ship:** git-workflow-and-versioning, ci-cd-and-automation, deprecation-and-migration, documentation-and-adrs, shipping-and-launch

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The commands above are the entry points. Under the hood, they activate these 21 
 | [test-driven-development](skills/test-driven-development/SKILL.md) | Red-Green-Refactor, test pyramid (80/15/5), test sizes, DAMP over DRY, Beyonce Rule, browser testing | Implementing logic, fixing bugs, or changing behavior |
 | [context-engineering](skills/context-engineering/SKILL.md) | Feed agents the right information at the right time - rules files, context packing, MCP integrations | Starting a session, switching tasks, or when output quality drops |
 | [source-driven-development](skills/source-driven-development/SKILL.md) | Ground every framework decision in official documentation - verify, cite sources, flag what's unverified | You want authoritative, source-cited code for any framework or library |
-| [delegation-provenance](skills/delegation-provenance/SKILL.md) | Enforce scoped authorization, auditable handoffs, and reauthorization across agent and tool boundaries | Building agents that delegate, call tools, or act across trust boundaries |
+| [delegation-provenance](skills/delegation-provenance/SKILL.md) | Preserve scoped authorization, auditable handoffs, and reauthorization across delegated execution | Building multi-agent or delegated tool workflows where authorization must survive multiple hops |
 | [frontend-ui-engineering](skills/frontend-ui-engineering/SKILL.md) | Component architecture, design systems, state management, responsive design, WCAG 2.1 AA accessibility | Building or modifying user-facing interfaces |
 | [api-and-interface-design](skills/api-and-interface-design/SKILL.md) | Contract-first design, Hyrum's Law, One-Version Rule, error semantics, boundary validation | Designing APIs, module boundaries, or public interfaces |
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ Skills are plain Markdown - they work with any agent that accepts system prompts
 
 ---
 
-## All 20 Skills
+## All 21 Skills
 
-The commands above are the entry points. Under the hood, they activate these 20 skills — each one a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
+The commands above are the entry points. Under the hood, they activate these 21 skills — each one a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
 
 ### Define - Clarify what to build
 
@@ -142,6 +142,7 @@ The commands above are the entry points. Under the hood, they activate these 20 
 | [test-driven-development](skills/test-driven-development/SKILL.md) | Red-Green-Refactor, test pyramid (80/15/5), test sizes, DAMP over DRY, Beyonce Rule, browser testing | Implementing logic, fixing bugs, or changing behavior |
 | [context-engineering](skills/context-engineering/SKILL.md) | Feed agents the right information at the right time - rules files, context packing, MCP integrations | Starting a session, switching tasks, or when output quality drops |
 | [source-driven-development](skills/source-driven-development/SKILL.md) | Ground every framework decision in official documentation - verify, cite sources, flag what's unverified | You want authoritative, source-cited code for any framework or library |
+| [delegation-provenance](skills/delegation-provenance/SKILL.md) | Enforce scoped authorization, auditable handoffs, and reauthorization across agent and tool boundaries | Building agents that delegate, call tools, or act across trust boundaries |
 | [frontend-ui-engineering](skills/frontend-ui-engineering/SKILL.md) | Component architecture, design systems, state management, responsive design, WCAG 2.1 AA accessibility | Building or modifying user-facing interfaces |
 | [api-and-interface-design](skills/api-and-interface-design/SKILL.md) | Contract-first design, Hyrum's Law, One-Version Rule, error semantics, boundary validation | Designing APIs, module boundaries, or public interfaces |
 
@@ -233,13 +234,14 @@ Every skill follows a consistent anatomy:
 
 ```
 agent-skills/
-├── skills/                            # 20 core skills (SKILL.md per directory)
+├── skills/                            # 21 core skills (SKILL.md per directory)
 │   ├── idea-refine/                   #   Define
 │   ├── spec-driven-development/       #   Define
 │   ├── planning-and-task-breakdown/   #   Plan
 │   ├── incremental-implementation/    #   Build
 │   ├── context-engineering/           #   Build
 │   ├── source-driven-development/     #   Build
+│   ├── delegation-provenance/         #   Build
 │   ├── frontend-ui-engineering/       #   Build
 │   ├── test-driven-development/       #   Build
 │   ├── api-and-interface-design/      #   Build

--- a/skills/delegation-provenance/SKILL.md
+++ b/skills/delegation-provenance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: delegation-provenance
-description: Enforces auditable authorization and scoped delegation across agent handoffs, tool calls, and trust-boundary crossings. Use when building agents that delegate to other agents, call external tools, access sensitive data, or perform actions that require human approval to survive multiple hops.
+description: Use when building agents that delegate to other agents, call external tools, access sensitive data, or perform actions that require human approval to survive multiple hops. Enforces auditable authorization and scoped delegation across agent handoffs, tool calls, and trust-boundary crossings.
 ---
 
 # Delegation Provenance

--- a/skills/delegation-provenance/SKILL.md
+++ b/skills/delegation-provenance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: delegation-provenance
-description: Use when building agents that delegate to other agents, call external tools, access sensitive data, or perform actions that require human approval to survive multiple hops. Enforces auditable authorization and scoped delegation across agent handoffs, tool calls, and trust-boundary crossings.
+description: Preserves scoped authorization across delegated execution. Use only when building software that delegates actions across agent, tool, or service hops where authorization must survive trust-boundary crossings and remain auditable.
 ---
 
 # Delegation Provenance
@@ -9,21 +9,22 @@ description: Use when building agents that delegate to other agents, call extern
 
 Treat human approval as something that travels with the work, not a sentence that got said once and then disappeared into chat history. When an agent delegates, calls a tool, or crosses a trust boundary, it must carry proof of who authorized the action, what scope was granted, and whether the current step still fits. This skill prevents invisible scope expansion, unaudited handoffs, and "the model decided" from quietly becoming a substitute for authorization.
 
+This skill is intentionally narrow: it is not part of ordinary app development unless the software itself delegates authority across agent or tool hops.
+
 ## When to Use
 
-- Building multi-agent workflows with explicit handoffs
-- Calling external tools, MCP servers, A2A agents, OpenAPI actions, or hosted services
-- Accessing sensitive data, internal systems, or user-scoped resources
-- Modifying persistent state (tickets, databases, cloud resources, emails, payments)
-- Performing financially consequential or real-world actions
-- Designing human-in-the-loop approvals that must remain valid across multiple hops
-- Reviewing an agent workflow for authorization gaps, silent scope expansion, or missing auditability
+- Building multi-agent workflows with explicit handoffs and scoped delegation
+- Building delegated tool-execution systems where authorization must survive multiple hops
+- Designing provenance and reauthorization flows for agentic systems that cross trust boundaries
+- Reviewing multi-agent or multi-tool workflows for authorization continuity gaps, silent scope expansion, or missing auditability
 
 **When NOT to use:**
 
-- Authority never changes across the workflow: no delegation, no external identity, no sensitive data, and no side effects
-- Pure local transformations where the agent is not reading from or writing to any external boundary
-- The user is asking for a thought experiment or architecture discussion, not an executable workflow
+- Building ordinary React/UI features or other app code with no delegated execution model
+- Building standard REST or CRUD endpoints where one service handles the action directly
+- Calling a third-party API directly from one agent or service without downstream delegation or authorization propagation
+- Using tools in a single-agent workflow where approval does not need to survive multiple hops
+- The user is asking for a thought experiment or architecture discussion, not an executable delegated workflow
 
 ## The Process
 
@@ -98,6 +99,8 @@ function authorize(artifact, action, delegatee, serviceId, trustAnchors, depth) 
   if (depth > claims.maxDelegationDepth) throw new Error('DELEGATION_LIMIT_EXCEEDED');
 }
 ```
+
+`verifyAuthorizationArtifact(...)` is intentionally out of scope for this skill. Use a vetted library or protocol implementation for your artifact format, such as `jose` for JWT/JWS verification, and treat rolling your own verifier as a red flag.
 
 If your system cannot answer "who signed or issued this, and why do I trust them?" then it is not ready to rely on delegation artifacts for enforcement.
 

--- a/skills/delegation-provenance/SKILL.md
+++ b/skills/delegation-provenance/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: delegation-provenance
+description: Enforces auditable authorization and scoped delegation across agent handoffs, tool calls, and trust-boundary crossings. Use when building agents that delegate to other agents, call external tools, access sensitive data, or perform actions that require human approval to survive multiple hops.
+---
+
+# Delegation Provenance
+
+## Overview
+
+Treat human approval as something that travels with the work, not a sentence that got said once and then disappeared into chat history. When an agent delegates, calls a tool, or crosses a trust boundary, it must carry proof of who authorized the action, what scope was granted, and whether the current step still fits. This skill prevents invisible scope expansion, unaudited handoffs, and "the model decided" from quietly becoming a substitute for authorization.
+
+## When to Use
+
+- Building multi-agent workflows with explicit handoffs
+- Calling external tools, MCP servers, A2A agents, OpenAPI actions, or hosted services
+- Accessing sensitive data, internal systems, or user-scoped resources
+- Modifying persistent state (tickets, databases, cloud resources, emails, payments)
+- Performing financially consequential or real-world actions
+- Designing human-in-the-loop approvals that must remain valid across multiple hops
+- Reviewing an agent workflow for authorization gaps, silent scope expansion, or missing auditability
+
+**When NOT to use:**
+
+- Authority never changes across the workflow: no delegation, no external identity, no sensitive data, and no side effects
+- Pure local transformations where the agent is not reading from or writing to any external boundary
+- The user is asking for a thought experiment or architecture discussion, not an executable workflow
+
+## The Process
+
+```
+CLASSIFY ──→ VERIFY ──→ PROPAGATE ──→ REAUTHORIZE
+   │            │            │              │
+   ▼            ▼            ▼              ▼
+ What trust   Is this       Carry the      Get fresh
+ boundary?    action in     receipt and    approval when
+              scope?        append a hop   scope expands
+```
+
+### Step 1: Classify the Trust Boundary
+
+Before any agent handoff or tool call, classify what kind of boundary is being crossed and what could go wrong if the action is out of scope.
+
+| Boundary | Example | What must be checked |
+|---|---|---|
+| Agent handoff | planner -> researcher | Allowed delegatees, delegation depth, action summary |
+| External tool | agent -> CRM, Stripe, GitHub, email API | Credential identity, allowed operation, target resource |
+| Sensitive data | reading PII, finance, health, source repos | Data scope, purpose, retention, redaction |
+| Persistent state | DB write, ticket update, file mutation | Write permission, idempotency, rollback path |
+| Real-world / financial | refund, purchase, robot action | Explicit approval, hard limits, ceilings, geofencing |
+
+State the boundary explicitly:
+
+```
+TRUST BOUNDARY DETECTED:
+- Boundary: External billing tool
+- Requested action: issue_refund
+- Resource: order_1234
+- Side effect: customer receives money
+→ Verifying authorization before proceeding.
+```
+
+If you cannot say what boundary is being crossed, you are not ready to run the step yet.
+
+### Step 2: Verify Authorization and Scope
+
+Every boundary-crossing action must have a durable authorization artifact that survives delegation. Prompt text alone is not enough.
+
+Minimum checks:
+
+- **Who authorized this?** Principal or controlling user
+- **What is allowed?** Actions, tools, resources, data domains
+- **What is forbidden?** Explicit exclusions matter as much as inclusions
+- **How long is it valid?** Expiry or session bound
+- **How far can it delegate?** Delegation depth, allowed sub-agents, tool allowlist
+- **Which identity executes it?** User auth, agent auth, service account, API key
+
+Example receipt shape:
+
+```json
+{
+  "authorization_id": "auth_7f3c",
+  "principal": "user_123",
+  "session_id": "sess_abc",
+  "allowed_actions": ["read:orders", "draft:refund", "refund:issue<=50"],
+  "disallowed_actions": ["send:email", "refund:issue>50"],
+  "allowed_delegatees": ["triage-agent", "policy-agent", "refund-tool"],
+  "max_delegation_depth": 2,
+  "expires_at": "2026-04-10T18:00:00Z"
+}
+```
+
+Fail closed when the receipt is missing, expired, or ambiguous:
+
+```typescript
+function authorize(receipt, action, delegatee, depth) {
+  if (!receipt) throw new Error('AUTHORIZATION_REQUIRED');
+  if (Date.now() > Date.parse(receipt.expires_at)) throw new Error('AUTHORIZATION_EXPIRED');
+  if (!receipt.allowed_actions.includes(action)) throw new Error('OUT_OF_SCOPE');
+  if (!receipt.allowed_delegatees.includes(delegatee)) throw new Error('DELEGATEE_NOT_ALLOWED');
+  if (depth > receipt.max_delegation_depth) throw new Error('DELEGATION_LIMIT_EXCEEDED');
+}
+```
+
+If the receiving agent or tool cannot inspect the receipt before acting, do not delegate directly. Add a policy wrapper or stop the workflow there.
+
+When declared authorization and runtime permissions disagree, trust neither blindly. A broad credential does not expand scope, and a narrow credential does not prove the receipt is correct. Surface the mismatch, fail closed, and have the workflow owner resolve it before anything proceeds.
+
+### Step 3: Propagate Provenance on Every Hop
+
+Every handoff must carry both the task and the authorization context. Do not overwrite the original approval context; extend it with an append-only hop record.
+
+For each hop, record:
+
+- Acting agent or tool
+- Receiving agent or tool
+- Action summary
+- Timestamp
+- Authorization ID used
+- Parent hop or previous hop reference
+
+Example:
+
+```
+DELEGATION CHAIN:
+1. human-support-manager -> triage-agent
+   "Classify refund request for delayed order"
+2. triage-agent -> policy-agent
+   "Check whether order_1234 qualifies under refund policy"
+3. policy-agent -> refund-tool
+   "Issue refund up to $50 for delayed shipment"
+```
+
+The downstream participant must be able to answer:
+
+- Who originally authorized this workflow?
+- Which hop delegated this specific action?
+- Which scope was in force at this point in the chain?
+- Is this action still within that scope?
+
+If those answers require reconstructing chat history by hand, the provenance model is too weak for the job.
+
+### Step 4: Reauthorize on Scope Change
+
+Fresh human approval is required whenever the workflow expands beyond the current receipt.
+
+Common reauthorization triggers:
+
+- Read-only becomes write
+- Draft-only becomes send/execute
+- Internal data access becomes external disclosure
+- A higher-privilege credential is required
+- A new tool, agent, or dataset appears
+- Delegation depth increases
+- A financial, legal, or physical action appears
+- Time horizon extends beyond the original approval window
+
+Surface scope expansion explicitly:
+
+```
+SCOPE CHANGE DETECTED:
+Current authorization covers:
+- Read order history
+- Draft a refund recommendation
+- Issue refunds up to $50 via refund-tool
+
+Requested next action:
+- Send a customer-facing confirmation email
+- Use notification-service credentials
+- Add a new delegatee: comms-agent
+
+→ Requires fresh human approval before proceeding.
+```
+
+The new receipt should supersede the previous one, link back to it, and restart execution from the newly approved scope.
+
+## Implementation Patterns
+
+- Prefer self-contained, inspectable receipts over hidden mutable server state
+- Prefer least-privileged credentials per tool over one broad shared credential
+- Separate approval to **analyze**, **draft**, **send**, and **mutate** — those are different powers
+- Include explicit ceilings for risky actions (`<= $50`, `read-only`, `zone_A`, `repo:issues only`)
+- Combine this skill with `security-and-hardening` for credential handling and `source-driven-development` when integrating with specific agent frameworks or callback APIs
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "The user asked for it in the prompt" | Prompts are intent, not durable authorization. They do not survive delegation cleanly and they do not constrain downstream tools by themselves. |
+| "This is a trusted agent, it doesn't need a receipt" | Trusted agents still drift, retry, recurse, and delegate. Provenance is what lets you verify what happened after the workflow spreads across more agents and tools. |
+| "We'll log it after the fact" | Logging without pre-execution checks does not prevent unauthorized actions. Auditability is not a substitute for enforcement. |
+| "It's only a read" | Reads can expose sensitive data, trigger retention issues, or create downstream write opportunities. Treat data access as a scoped action. |
+| "The next step is basically the same action" | "Basically the same" is how silent scope expansion happens. New tool, new credential, new side effect, new approval. |
+| "We can reuse the same approval for the whole session" | Long-lived blanket approvals accumulate risk. Authorization should narrow to the task and expire. |
+
+## Red Flags
+
+- Tool calls carry task text but no explicit authorization artifact
+- A read-only approval is later used for a write or send action
+- Agent handoffs drop the principal, expiry, or scope metadata
+- Delegation depth is unlimited or untracked
+- The most privileged credential is used for every tool call
+- Human approval exists only as chat history or UI text
+- New tools or delegatees appear without any reauthorization step
+- Downstream systems cannot verify whether the action was in scope
+- Audit records cannot reconstruct who approved what through which hops
+
+## Verification
+
+After implementing delegation provenance:
+
+- [ ] Every trust-boundary action is classified before execution
+- [ ] Boundary-crossing actions fail closed when authorization is missing, expired, or out of scope
+- [ ] Authorization artifacts include principal, scope, expiry, and delegation limits
+- [ ] Each agent handoff or tool call carries the authorization context forward
+- [ ] The workflow records an append-only delegation chain or equivalent audit trail
+- [ ] Scope expansion triggers fresh human approval instead of silent escalation
+- [ ] Downstream agents and tools can inspect authorization before acting
+- [ ] Least-privileged credentials are used for external actions
+- [ ] No approval depends solely on prompt text or manual chat reconstruction

--- a/skills/delegation-provenance/SKILL.md
+++ b/skills/delegation-provenance/SKILL.md
@@ -68,38 +68,38 @@ Every boundary-crossing action must have a durable authorization artifact that s
 Minimum checks:
 
 - **Who authorized this?** Principal or controlling user
+- **Who issued the artifact, and can you verify it?** Trusted issuer, signature or MAC, and trust anchor or key resolution
 - **What is allowed?** Actions, tools, resources, data domains
 - **What is forbidden?** Explicit exclusions matter as much as inclusions
 - **How long is it valid?** Expiry or session bound
 - **How far can it delegate?** Delegation depth, allowed sub-agents, tool allowlist
 - **Which identity executes it?** User auth, agent auth, service account, API key
 
-Example receipt shape:
+Do not invent an unsigned JSON receipt just because it is convenient to sketch. A plain object that says `allowed_actions: ["*"]` is not an authorization artifact; it is just data.
 
-```json
-{
-  "authorization_id": "auth_7f3c",
-  "principal": "user_123",
-  "session_id": "sess_abc",
-  "allowed_actions": ["read:orders", "draft:refund", "refund:issue<=50"],
-  "disallowed_actions": ["send:email", "refund:issue>50"],
-  "allowed_delegatees": ["triage-agent", "policy-agent", "refund-tool"],
-  "max_delegation_depth": 2,
-  "expires_at": "2026-04-10T18:00:00Z"
-}
-```
+Prefer an existing verifiable format or protocol layer:
 
-Fail closed when the receipt is missing, expired, or ambiguous:
+- **OAuth 2.0 Token Exchange** ([RFC 8693](https://datatracker.ietf.org/doc/rfc8693/)) when delegation needs to flow through an authorization server
+- **Signed JWTs** ([RFC 7519](https://datatracker.ietf.org/doc/rfc7519/), [RFC 8725](https://datatracker.ietf.org/doc/rfc8725/)) when claims, issuer identity, audience, and expiry must be verifiable
+- **UCAN**, **Macaroons**, or a protocol like **HDP** when your system already uses capability-style or provenance-aware delegation
+
+The critical property is not the syntax. It is that the consumer can verify issuer, integrity, audience, expiry, and delegation-related claims before trusting the artifact.
+
+Structural example:
 
 ```typescript
-function authorize(receipt, action, delegatee, depth) {
-  if (!receipt) throw new Error('AUTHORIZATION_REQUIRED');
-  if (Date.now() > Date.parse(receipt.expires_at)) throw new Error('AUTHORIZATION_EXPIRED');
-  if (!receipt.allowed_actions.includes(action)) throw new Error('OUT_OF_SCOPE');
-  if (!receipt.allowed_delegatees.includes(delegatee)) throw new Error('DELEGATEE_NOT_ALLOWED');
-  if (depth > receipt.max_delegation_depth) throw new Error('DELEGATION_LIMIT_EXCEEDED');
+function authorize(artifact, action, delegatee, serviceId, trustAnchors, depth) {
+  const claims = verifyAuthorizationArtifact(artifact, trustAnchors);
+  if (!claims) throw new Error('AUTHORIZATION_INVALID');
+  if (Date.now() > claims.expiresAt) throw new Error('AUTHORIZATION_EXPIRED');
+  if (!claims.audience.includes(serviceId)) throw new Error('WRONG_AUDIENCE');
+  if (!claims.allowedActions.includes(action)) throw new Error('OUT_OF_SCOPE');
+  if (!claims.allowedDelegatees.includes(delegatee)) throw new Error('DELEGATEE_NOT_ALLOWED');
+  if (depth > claims.maxDelegationDepth) throw new Error('DELEGATION_LIMIT_EXCEEDED');
 }
 ```
+
+If your system cannot answer "who signed or issued this, and why do I trust them?" then it is not ready to rely on delegation artifacts for enforcement.
 
 If the receiving agent or tool cannot inspect the receipt before acting, do not delegate directly. Add a policy wrapper or stop the workflow there.
 

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -23,7 +23,8 @@ Task arrives
     │   ├── UI work? ─────────────────→ frontend-ui-engineering
     │   ├── API work? ────────────────→ api-and-interface-design
     │   ├── Need better context? ─────→ context-engineering
-    │   └── Need doc-verified code? ───→ source-driven-development
+    │   ├── Need doc-verified code? ───→ source-driven-development
+    │   └── Agent handoffs / tool boundaries? → delegation-provenance
     ├── Writing/running tests? ────────→ test-driven-development
     │   └── Browser-based? ───────────→ browser-testing-with-devtools
     ├── Something broke? ──────────────→ debugging-and-error-recovery
@@ -140,12 +141,13 @@ For a complete feature, the typical skill sequence is:
 3. planning-and-task-breakdown → Break into verifiable chunks
 4. context-engineering         → Load the right context
 5. source-driven-development   → Verify against official docs
-6. incremental-implementation  → Build slice by slice
-7. test-driven-development     → Prove each slice works
-8. code-review-and-quality     → Review before merge
-9. git-workflow-and-versioning → Clean commit history
-10. documentation-and-adrs     → Document decisions
-11. shipping-and-launch        → Deploy safely
+6. delegation-provenance       → Guard agent/tool trust boundaries
+7. incremental-implementation  → Build slice by slice
+8. test-driven-development     → Prove each slice works
+9. code-review-and-quality     → Review before merge
+10. git-workflow-and-versioning → Clean commit history
+11. documentation-and-adrs     → Document decisions
+12. shipping-and-launch        → Deploy safely
 ```
 
 Not every task needs every skill. A bug fix might only need: `debugging-and-error-recovery` → `test-driven-development` → `code-review-and-quality`.
@@ -159,6 +161,7 @@ Not every task needs every skill. A bug fix might only need: `debugging-and-erro
 | Plan | planning-and-task-breakdown | Decompose into small, verifiable tasks |
 | Build | incremental-implementation | Thin vertical slices, test each before expanding |
 | Build | source-driven-development | Verify against official docs before implementing |
+| Build | delegation-provenance | Carry scoped authorization and reauthorization across agent hops |
 | Build | context-engineering | Right context at the right time |
 | Build | frontend-ui-engineering | Production-quality UI with accessibility |
 | Build | api-and-interface-design | Stable interfaces with clear contracts |

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -24,7 +24,7 @@ Task arrives
     │   ├── API work? ────────────────→ api-and-interface-design
     │   ├── Need better context? ─────→ context-engineering
     │   ├── Need doc-verified code? ───→ source-driven-development
-    │   └── Agent handoffs / tool boundaries? → delegation-provenance
+    │   └── Software delegates across agent/tool hops with scoped authorization? → delegation-provenance
     ├── Writing/running tests? ────────→ test-driven-development
     │   └── Browser-based? ───────────→ browser-testing-with-devtools
     ├── Something broke? ──────────────→ debugging-and-error-recovery
@@ -141,7 +141,7 @@ For a complete feature, the typical skill sequence is:
 3. planning-and-task-breakdown → Break into verifiable chunks
 4. context-engineering         → Load the right context
 5. source-driven-development   → Verify against official docs
-6. delegation-provenance       → Guard agent/tool trust boundaries
+6. delegation-provenance       → Guard delegated agent/tool trust boundaries
 7. incremental-implementation  → Build slice by slice
 8. test-driven-development     → Prove each slice works
 9. code-review-and-quality     → Review before merge
@@ -161,7 +161,7 @@ Not every task needs every skill. A bug fix might only need: `debugging-and-erro
 | Plan | planning-and-task-breakdown | Decompose into small, verifiable tasks |
 | Build | incremental-implementation | Thin vertical slices, test each before expanding |
 | Build | source-driven-development | Verify against official docs before implementing |
-| Build | delegation-provenance | Carry scoped authorization and reauthorization across agent hops |
+| Build | delegation-provenance | Carry scoped authorization and reauthorization across delegated agent/tool hops |
 | Build | context-engineering | Right context at the right time |
 | Build | frontend-ui-engineering | Production-quality UI with accessibility |
 | Build | api-and-interface-design | Stable interfaces with clear contracts |


### PR DESCRIPTION
## What this adds

This adds a new **delegation-provenance** skill for agent workflows that cross trust boundaries.

The simple idea is: once work starts bouncing between agents and tools, human approval gets fuzzy fast. It ends up living in chat history, UI state, or in one orchestrator that "knows" what was allowed. This skill pushes back on that. It teaches agents to treat approval as something they need to verify, carry forward, and refresh when the scope changes.

## The problem it solves

Agent systems are getting very good at delegation, but the accountability story still gets messy once work fans out.

After a few handoffs, it becomes surprisingly hard to answer basic questions:

- who actually authorized the final action
- what scope was granted
- whether the current step is still inside that scope
- whether the workflow quietly picked up new powers halfway through
- whether the downstream tool or agent had any way to check this before acting

That gap matters most when the workflow touches sensitive data, persistent state, money, or anything with real-world consequences.

## How it works

Four-step process: **CLASSIFY → VERIFY → PROPAGATE → REAUTHORIZE**

1. Classify the trust boundary before each agent handoff or tool call
2. Verify a durable authorization artifact with principal, scope, expiry, and delegation limits
3. Propagate provenance on every hop with an append-only delegation record
4. Require fresh human approval whenever scope expands

The skill also makes two things explicit:

- fail closed when authorization is missing, expired, ambiguous, or out of scope
- surface mismatches between declared authorization and runtime permissions instead of hand-waving them away

## What makes it different from generic security guidance

This is not just "be careful with auth."

It focuses on **multi-hop authorization continuity**:
- approval should survive delegation
- downstream actors should be able to inspect scope before acting
- scope expansion should be visible, not something that just sort of happens

It also stays implementation-agnostic, so teams can apply it across MCP tools, A2A-style agent handoffs, hosted services, or internal multi-agent systems.

## Integration

- Added to the `using-agent-skills` discovery flow and lifecycle sequence
- Added to `CLAUDE.md` Build phase
- Added to `README.md` Build table and project structure (`21` skills total)

## Background

This skill is informed by the Human Delegation Provenance (HDP) work:

- Paper: https://arxiv.org/abs/2604.04522
- IETF Internet-Draft: https://datatracker.ietf.org/doc/draft-helixar-hdp-agentic-delegation/

HDP frames human authorization as a verifiable chain-of-custody for multi-agent systems. This skill borrows that design insight, but keeps the workflow broad enough to be useful even if a team is not using HDP directly.

## Demo

Example workflow with the skill active:

- `human-support-manager -> triage-agent`
- `triage-agent -> policy-agent`
- `policy-agent -> refund-tool`

The agent:
- classifies the refund path as a financial trust boundary
- verifies allowed actions, delegatees, expiry, and delegation depth
- carries the authorization context forward on each hop
- asks for fresh approval before adding a new delegatee (`comms-agent`) to send a customer-facing email

Without the skill, that email step is easy to smuggle in as "basically the same task." With the skill, it gets surfaced for what it is: a scope change.

## Future work

A natural follow-up would be implementation-specific examples for ADK callbacks, MCP middleware, or A2A boundaries.

I kept this PR focused on the workflow itself so the skill stays generally useful and easier to review.
