### PR TITLE
Update accessibility checklist for skip-to-content link

### DIFF
--- a/references/accessibility-checklist.md
+++ b/references/accessibility-checklist.md
@@ -18,7 +18,7 @@ Quick reference for WCAG 2.1 AA compliance. Use alongside the `frontend-ui-engin
 - [ ] Focus is visible (outline/ring on focused elements)
 - [ ] Custom widgets have keyboard support (Enter to activate, Escape to close)
 - [ ] No keyboard traps (user can always Tab away from a component)
-- [ ] Skip-to-content link at top of page
+- [ ] Skip-to-content link at top of page - visible (at least) on keyboard focus
 - [ ] Modals trap focus while open, return focus on close
 
 ### Screen Readers


### PR DESCRIPTION
Clarified the requirement for the skip-to-content link to be visible on keyboard focus - as it is mostly beneficial to users that can see the screen (but also others)