### PR TITLE
Fix button accessibility guidance in frontend-ui-engineering skill

### DIFF
--- a/skills/frontend-ui-engineering/SKILL.md
+++ b/skills/frontend-ui-engineering/SKILL.md
@@ -173,7 +173,7 @@ Every component must meet these standards:
 <button onClick={handleClick}>Click me</button>        // ✓ Focusable by default
 <div onClick={handleClick}>Click me</div>               // ✗ Not focusable
 <div role="button" tabIndex={0} onClick={handleClick}    // ✓ But prefer <button>
-     onKeyDown={e => e.key === 'Enter' && handleClick()}>
+     onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && handleClick()}>
   Click me
 </div>
 ```


### PR DESCRIPTION
Native buttons support both "enter" and "space", and any JavaScript simulations of buttons should account for that when handling keyboard events.

This PR fixes the fact that "space" was missing in the frontend accessibility guidance for keyboard event handlers.

I hope this PR helps! 😄 