### PR TITLE
Add observability skill, cross-references, and persona integration

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -11,7 +11,8 @@ Run through the complete pre-launch checklist:
 3. **Performance** — Core Web Vitals good, no N+1 queries, images optimized, bundle sized
 4. **Accessibility** — Keyboard nav works, screen reader compatible, contrast adequate
 5. **Infrastructure** — Env vars set, migrations ready, monitoring configured
-6. **Documentation** — README current, ADRs written, changelog updated
+6. **Observability** — Invoke the agent-skills:observability-and-monitoring skill to verify structured logging, metrics (four golden signals), SLOs, and alerting are in place before going live
+7. **Documentation** — README current, ADRs written, changelog updated
 
 Report any failing checks and help resolve them before deployment.
 Define the rollback plan before proceeding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,32 @@ The agent should automatically map user intent to skills:
 - Feature / new functionality → `spec-driven-development`, then `incremental-implementation`, `test-driven-development`
 - Planning / breakdown → `planning-and-task-breakdown`
 - Bug / failure / unexpected behavior → `debugging-and-error-recovery`
-- Code review → `code-review-and-quality`
+- Code review → `code-review-and-quality` + load `agents/code-reviewer.md` persona for the review subagent
+- Security review / hardening → `security-and-hardening` + load `agents/security-auditor.md` persona
+- Test strategy / writing tests → `test-driven-development` + load `agents/test-engineer.md` persona for bug reproduction subagents
 - Refactoring / simplification → `code-simplification`
 - API or interface design → `api-and-interface-design`
 - UI work → `frontend-ui-engineering`
+- Production visibility / logging / alerting → `observability-and-monitoring`
+
+### Agent Personas
+
+Three reusable agent personas live in `agents/`. Load them when a skill calls for a specialized review or testing subagent — they provide structured output formats, severity classifications, and rules the base agent lacks.
+
+| Persona | File | Load when |
+|---------|------|-----------|
+| Senior Code Reviewer | `agents/code-reviewer.md` | Running code review via `code-review-and-quality` |
+| Security Auditor | `agents/security-auditor.md` | Running security review via `security-and-hardening` |
+| Test Engineer | `agents/test-engineer.md` | Writing tests or reproducing bugs via `test-driven-development` |
+
+**How to invoke a persona:**
+
+```
+You are the [persona name] (read agents/[persona-file].md for your full role and rules).
+[Task description]
+```
+
+Personas are not skills — they define *who the agent is* for a task, not *what process to follow*. Skills and personas are used together.
 
 ### Lifecycle Mapping (Implicit Commands)
 
@@ -39,8 +61,8 @@ Instead, the agent must internally follow this lifecycle:
 - PLAN → `planning-and-task-breakdown`
 - BUILD → `incremental-implementation` + `test-driven-development`
 - VERIFY → `debugging-and-error-recovery`
-- REVIEW → `code-review-and-quality`
-- SHIP → `shipping-and-launch`
+- REVIEW → `code-review-and-quality` (+ `code-reviewer` persona)
+- SHIP → `observability-and-monitoring`, then `shipping-and-launch`
 
 ### Execution Model
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,10 @@ This is the agent-skills project — a collection of production-grade engineerin
 
 ```
 skills/       → Core skills (SKILL.md per directory)
-agents/       → Reusable agent personas (code-reviewer, test-engineer, security-auditor)
+agents/       → Reusable agent personas — load these when a skill calls for a specialized subagent
+                  code-reviewer.md     (invoked from code-review-and-quality)
+                  security-auditor.md  (invoked from security-and-hardening)
+                  test-engineer.md     (invoked from test-driven-development)
 hooks/        → Session lifecycle hooks
 .claude/commands/ → Slash commands (/spec, /plan, /build, /test, /review, /code-simplify, /ship)
 references/   → Supplementary checklists (testing, performance, security, accessibility)
@@ -20,7 +23,7 @@ docs/         → Setup guides for different tools
 **Build:** incremental-implementation, test-driven-development, context-engineering, source-driven-development, frontend-ui-engineering, api-and-interface-design
 **Verify:** browser-testing-with-devtools, debugging-and-error-recovery
 **Review:** code-review-and-quality, code-simplification, security-and-hardening, performance-optimization
-**Ship:** git-workflow-and-versioning, ci-cd-and-automation, deprecation-and-migration, documentation-and-adrs, shipping-and-launch
+**Ship:** git-workflow-and-versioning, ci-cd-and-automation, deprecation-and-migration, documentation-and-adrs, observability-and-monitoring, shipping-and-launch
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ Skills are plain Markdown - they work with any agent that accepts system prompts
 
 ---
 
-## All 20 Skills
+## All 21 Skills
 
-The commands above are the entry points. Under the hood, they activate these 20 skills — each one a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
+The commands above are the entry points. Under the hood, they activate these 21 skills — each one a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
 
 ### Define - Clarify what to build
 
@@ -176,6 +176,7 @@ The commands above are the entry points. Under the hood, they activate these 20 
 | [ci-cd-and-automation](skills/ci-cd-and-automation/SKILL.md) | Shift Left, Faster is Safer, feature flags, quality gate pipelines, failure feedback loops | Setting up or modifying build and deploy pipelines |
 | [deprecation-and-migration](skills/deprecation-and-migration/SKILL.md) | Code-as-liability mindset, compulsory vs advisory deprecation, migration patterns, zombie code removal | Removing old systems, migrating users, or sunsetting features |
 | [documentation-and-adrs](skills/documentation-and-adrs/SKILL.md) | Architecture Decision Records, API docs, inline documentation standards - document the *why* | Making architectural decisions, changing APIs, or shipping features |
+| [observability-and-monitoring](skills/observability-and-monitoring/SKILL.md) | Structured logging, four golden signals metrics, OpenTelemetry tracing, SLO-based alerting, dashboard design | Before shipping a service or when debugging production without sufficient data |
 | [shipping-and-launch](skills/shipping-and-launch/SKILL.md) | Pre-launch checklists, feature flag lifecycle, staged rollouts, rollback procedures, monitoring setup | Preparing to deploy to production |
 
 ---
@@ -260,6 +261,7 @@ agent-skills/
 │   ├── ci-cd-and-automation/          #   Ship
 │   ├── deprecation-and-migration/     #   Ship
 │   ├── documentation-and-adrs/        #   Ship
+│   ├── observability-and-monitoring/   #   Ship
 │   ├── shipping-and-launch/           #   Ship
 │   └── using-agent-skills/            #   Meta: how to use this pack
 ├── agents/                            # 3 specialist personas

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -197,11 +197,13 @@ Human makes the final call
 
 This catches issues that a single model might miss — different models have different blind spots.
 
+**Use the `code-reviewer` agent persona** for the review model. It applies the five-axis framework (correctness, readability, architecture, security, performance) with structured output — Critical / Important / Suggestion — and rules for when to approve vs. request changes. Load it from `agents/code-reviewer.md`.
+
 **Example prompt for a review agent:**
 ```
-Review this code change for correctness, security, and adherence to
+You are the code-reviewer agent (agents/code-reviewer.md).
+Review this change for correctness, security, and adherence to
 our project conventions. The spec says [X]. The change should [Y].
-Flag any issues as Critical, Important, or Suggestion.
 ```
 
 ## Dead Code Hygiene
@@ -312,6 +314,7 @@ Part of code review is dependency review:
 ```
 ## See Also
 
+- For the full review agent persona (five-axis framework, output template, rules), see `agents/code-reviewer.md`
 - For detailed security review guidance, see `references/security-checklist.md`
 - For performance review checks, see `references/performance-checklist.md`
 

--- a/skills/deprecation-and-migration/SKILL.md
+++ b/skills/deprecation-and-migration/SKILL.md
@@ -93,12 +93,12 @@ Don't deprecate without a working alternative. The replacement must:
 
 ### Step 3: Migrate Incrementally
 
-Migrate consumers one at a time, not all at once. For each consumer:
+Migrate consumers one at a time, not all at once. Follow the `incremental-implementation` skill — each migration step should leave the system in a working, testable state before moving to the next. For each consumer:
 
 ```
 1. Identify all touchpoints with the deprecated system
 2. Update to use the replacement
-3. Verify behavior matches (tests, integration checks)
+3. Verify behavior matches — use `test-driven-development` to write tests against the replacement before removing the old system
 4. Remove references to the old system
 5. Confirm no regressions
 ```
@@ -107,7 +107,7 @@ Migrate consumers one at a time, not all at once. For each consumer:
 
 ### Step 4: Remove the Old System
 
-Only after all consumers have migrated:
+Only after all consumers have migrated. Use `git-workflow-and-versioning` for atomic commits — one commit per removal step makes rollback clean if something was missed.
 
 ```
 1. Verify zero active usage (metrics, logs, dependency analysis)

--- a/skills/idea-refine/SKILL.md
+++ b/skills/idea-refine/SKILL.md
@@ -139,6 +139,8 @@ Produce a concrete artifact — a markdown one-pager that moves work forward:
 
 Ask the user if they'd like to save this to `docs/ideas/[idea-name].md` (or a location of their choosing). Only save if they confirm.
 
+**Next step:** If the user wants to build the refined idea, continue with `spec-driven-development` to define requirements and acceptance criteria before any implementation work begins.
+
 ### Anti-patterns to Avoid
 
 - **Don't generate 20+ ideas.** Quality over quantity. 5-8 well-considered variations beat 20 shallow ones.

--- a/skills/observability-and-monitoring/SKILL.md
+++ b/skills/observability-and-monitoring/SKILL.md
@@ -78,8 +78,8 @@ Saturation → How full is the system (CPU, memory, queue depth, connection pool
 
 ```
 Every HTTP endpoint:
-  - request_count (counter, by status code, method, path)
-  - request_duration_seconds (histogram, by status code, method, path)
+  - request_count (counter, by status code, method, route_template)
+  - request_duration_seconds (histogram, by status code, method, route_template)
 
 Every queue/worker:
   - queue_depth (gauge)
@@ -93,6 +93,8 @@ Every external dependency:
 
 **Use histograms for latency, not averages.** An average of 200ms can hide a p99 of 10s. A p99 of 10s means 1 in 100 users is waiting 10 seconds.
 
+**Cardinality rule:** Metric labels must be low-cardinality. Use route templates (`/users/:id`), not raw paths (`/users/123`). Never include user IDs, tenant IDs, request bodies, or query strings in labels — each unique value creates a new time series, which can make dashboards unusable and drive up telemetry cost.
+
 ## Step 3: Distributed Tracing
 
 Tracing shows the full path of a request across services. Add it when:
@@ -101,16 +103,23 @@ Tracing shows the full path of a request across services. Add it when:
 
 **Minimum viable tracing:**
 
+Use OpenTelemetry — it is the industry standard and interoperates across services via the W3C `traceparent`/`tracestate` headers. Do not hand-roll custom `X-Trace-Id` or `X-Span-Id` headers; they will not be understood by downstream services or telemetry backends.
+
 ```python
-# Propagate trace context on every outbound call
-headers = {
-    "X-Trace-Id": current_trace_id(),
-    "X-Span-Id": new_span_id(),
-}
-response = http_client.post(url, headers=headers)
+# OpenTelemetry handles context propagation automatically
+from opentelemetry import trace
+from opentelemetry.propagate import inject
+
+tracer = trace.get_tracer(__name__)
+
+with tracer.start_as_current_span("checkout.process_payment") as span:
+    span.set_attribute("order.id", order_id)
+    headers = {}
+    inject(headers)  # Injects W3C traceparent/tracestate — not custom headers
+    response = http_client.post(payment_url, headers=headers)
 ```
 
-Use an existing tracing library (OpenTelemetry is the standard) rather than rolling your own.
+Services that extract context via the configured OpenTelemetry propagator will automatically continue the trace across the boundary.
 
 ## Step 4: SLOs and Alerting
 

--- a/skills/observability-and-monitoring/SKILL.md
+++ b/skills/observability-and-monitoring/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: observability-and-monitoring
+description: Instruments systems for production visibility. Use when a service is about to ship, when debugging production issues without sufficient data, or when setting up alerting and dashboards for an existing system.
+---
+
+# Observability and Monitoring
+
+## Overview
+
+Shipping code without observability is guessing in the dark. This skill covers the three pillars of production visibility — logs, metrics, and traces — and the alerting strategy that turns raw signals into actionable pages. Build observability before you need it, not after your first outage.
+
+## When to Use
+
+- Before a service ships to production
+- When a production issue can't be debugged because the data isn't there
+- When alerts fire constantly (or never) and nobody trusts them
+- When onboarding a new service or taking ownership of an existing one
+- When defining or auditing SLOs
+
+**When NOT to use:** Pre-production development where log output in the terminal is sufficient. Don't instrument for production before the feature is stable enough to ship.
+
+## The Three Pillars
+
+```
+Logs ──────→ What happened (discrete events, full context)
+Metrics ───→ How the system behaves over time (aggregates, trends)
+Traces ────→ Why it happened (request path across services)
+```
+
+Each pillar answers different questions. Logs alone don't scale; metrics alone lose context; traces alone miss the big picture. Use all three.
+
+## Step 1: Structured Logging
+
+Logs are only useful if they're searchable and correlatable. Raw string logs are text you can grep at 3am — structured logs are data you can query.
+
+**What structured logging looks like:**
+
+```json
+{
+  "timestamp": "2025-03-01T14:23:01Z",
+  "level": "error",
+  "message": "Payment processing failed",
+  "trace_id": "abc123",
+  "user_id": "u_456",
+  "order_id": "ord_789",
+  "error_code": "card_declined",
+  "duration_ms": 342
+}
+```
+
+**Log level discipline:**
+
+| Level | When to use |
+|-------|-------------|
+| `error` | Something failed that requires human attention |
+| `warn` | Degraded state, non-fatal, worth investigating |
+| `info` | Key business events (order placed, user signed in) |
+| `debug` | Detailed internal state — disabled in production by default |
+
+**Rules:**
+- Include a `trace_id` on every log line so you can reconstruct a request's path
+- Log at decision points, not every function call
+- Never log PII (passwords, tokens, credit card numbers, SSNs)
+- Log the inputs and outputs of external service calls (redacted where necessary)
+
+## Step 2: Metrics
+
+Metrics answer "how is the system performing?" They're aggregates — not individual events. The four golden signals cover most production systems:
+
+```
+Latency   → How long requests take (p50, p95, p99 — never just average)
+Traffic   → How many requests per second
+Errors    → Error rate (not count — rate normalizes for traffic)
+Saturation → How full is the system (CPU, memory, queue depth, connection pool)
+```
+
+**Instrument these first:**
+
+```
+Every HTTP endpoint:
+  - request_count (counter, by status code, method, path)
+  - request_duration_seconds (histogram, by status code, method, path)
+
+Every queue/worker:
+  - queue_depth (gauge)
+  - processing_duration_seconds (histogram)
+  - job_failures_total (counter)
+
+Every external dependency:
+  - dependency_request_duration_seconds (histogram, by service, endpoint)
+  - dependency_errors_total (counter, by service, error type)
+```
+
+**Use histograms for latency, not averages.** An average of 200ms can hide a p99 of 10s. A p99 of 10s means 1 in 100 users is waiting 10 seconds.
+
+## Step 3: Distributed Tracing
+
+Tracing shows the full path of a request across services. Add it when:
+- You have more than one service involved in a request
+- You're debugging latency and can't tell which service is slow
+
+**Minimum viable tracing:**
+
+```python
+# Propagate trace context on every outbound call
+headers = {
+    "X-Trace-Id": current_trace_id(),
+    "X-Span-Id": new_span_id(),
+}
+response = http_client.post(url, headers=headers)
+```
+
+Use an existing tracing library (OpenTelemetry is the standard) rather than rolling your own.
+
+## Step 4: SLOs and Alerting
+
+SLOs define what "working correctly" means. Without SLOs, you don't know when to page, and every anomaly becomes a question mark.
+
+**Define SLOs before writing alerts:**
+
+```
+Service: Checkout API
+SLO: 99.9% of requests succeed (non-5xx) over a 30-day window
+SLO: 95% of requests complete in under 500ms over a 30-day window
+Error budget: 0.1% = ~43 minutes of downtime per 30 days
+```
+
+**Alert on SLO burn rate, not thresholds:**
+
+```
+BAD:  Alert when error rate > 1%
+      → Fires on transient spikes, causes alert fatigue
+
+GOOD: Alert when error budget burns > 5% in the last 1 hour
+      → Fires only when the SLO is at real risk
+```
+
+**Alert routing:**
+- Page immediately: SLO breach imminent (burn rate high), complete outage
+- Ticket (next business day): Elevated error rate but error budget not at risk
+- Dashboard only: Normal variation, trends to watch
+
+**Eliminate noisy alerts.** An alert that fires and gets ignored trains engineers to ignore alerts. Every alert must be actionable — if you can't describe what action to take, don't page for it.
+
+## Step 5: Dashboards
+
+Dashboards are for humans. Design them for the question they answer, not to show every metric.
+
+**Three dashboards to build:**
+
+```
+1. Service health (operational)
+   → Error rate, latency p99, traffic, saturation
+   → Audience: on-call engineer at 3am
+   → Design: big numbers, clear red/green status
+
+2. Business metrics (product)
+   → User-facing outcomes: signups, conversions, active sessions
+   → Audience: PMs, leadership
+   → Design: trends over time, week-over-week comparisons
+
+3. Dependency health (diagnostic)
+   → Per-dependency error rates and latency
+   → Audience: engineer debugging an incident
+   → Design: side-by-side, correlatable time ranges
+```
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "We'll add monitoring after launch" | After launch you'll have a production incident and no data. You'll add monitoring reactively, under pressure, badly. |
+| "The logs are enough" | Unstructured logs are full-text search. At 3am with a P0. No correlation IDs, no trace context, no queryable fields. |
+| "We alert on CPU > 80%" | CPU is a symptom, not a user experience. You'll page at night for nothing. Alert on what users feel: error rates and latency. |
+| "Our error rate is low, we're fine" | Error rate without a latency SLO misses slow requests. A 0% error rate with p99 of 30s is not "fine". |
+| "We don't have SLOs yet" | Without SLOs you can't define "working correctly," you can't set meaningful alerts, and you can't have a rational on-call rotation. |
+| "OpenTelemetry is too complex" | It's the industry standard. Rolling your own tracing is a much worse investment. |
+
+## Red Flags
+
+- Logs with no trace_id or correlation identifier
+- Logging PII (passwords, tokens, card numbers)
+- Alerts on raw resource metrics (CPU, memory) with no user-impact alerts
+- Alert fatigue — engineers auto-acknowledging pages without looking
+- `error_count > 10` style alerts instead of rate-based alerts
+- No SLOs defined, so nobody agrees on what "working" means
+- Dashboards nobody looks at (stale, wrong time range defaults, broken queries)
+- Metrics averaged instead of percentiled (p95/p99) for latency
+- No tracing across service boundaries — each service is a black box
+- Observability added reactively after the first production incident
+
+## Verification
+
+After instrumenting a service:
+
+- [ ] Every HTTP endpoint emits request count and latency histograms
+- [ ] Logs are structured (JSON), include trace_id, and contain no PII
+- [ ] Log levels are correct — debug disabled in production, errors are actionable
+- [ ] SLOs are defined for availability and latency
+- [ ] Alerts fire on SLO burn rate, not raw thresholds
+- [ ] Every alert has a documented runbook or action to take
+- [ ] Service health dashboard exists with error rate, latency p99, and traffic
+- [ ] Trace context propagated across all outbound calls
+- [ ] Error budget is tracked and visible to the team
+- [ ] On-call rotation tested — alert fires, right person gets paged, runbook resolves it
+
+Use `shipping-and-launch` for the pre-launch checklist that confirms observability is in place before going live.

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -314,7 +314,8 @@ git diff --cached | grep -i "password\|secret\|api_key\|token"
 ```
 ## See Also
 
-For detailed security checklists and pre-commit verification steps, see `references/security-checklist.md`.
+- For a dedicated security review agent (threat modeling, severity classification, OWASP Top 10, exploitation scenarios), use the `security-auditor` persona from `agents/security-auditor.md`. Invoke it when a change touches auth, input handling, data storage, or third-party integrations.
+- For detailed security checklists and pre-commit verification steps, see `references/security-checklist.md`.
 
 ## Common Rationalizations
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -342,6 +342,14 @@ then verifies the test passes.
 
 This separation ensures the test is written without knowledge of the fix, making it more robust.
 
+**Use the `test-engineer` agent persona** for the subagent. It covers test strategy, the Prove-It pattern for bugs, the right level of test (unit/integration/E2E), scenario coverage (happy path, boundaries, error paths), and output format for coverage analysis. Load it from `agents/test-engineer.md`.
+
+```
+Main agent: "You are the test-engineer agent (agents/test-engineer.md).
+Write a test that demonstrates this bug: [bug description].
+The test must FAIL with the current code. Do not look at the fix."
+```
+
 ## See Also
 
 For detailed testing patterns, examples, and anti-patterns across frameworks, see `references/testing-patterns.md`.

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -33,7 +33,8 @@ Task arrives
     ├── Committing/branching? ─────────→ git-workflow-and-versioning
     ├── CI/CD pipeline work? ──────────→ ci-cd-and-automation
     ├── Writing docs/ADRs? ───────────→ documentation-and-adrs
-    └── Deploying/launching? ─────────→ shipping-and-launch
+    ├── Deploying/launching? ─────────→ shipping-and-launch
+    └── System live, need visibility? ─→ observability-and-monitoring
 ```
 
 ## Core Operating Behaviors
@@ -146,6 +147,7 @@ For a complete feature, the typical skill sequence is:
 9. git-workflow-and-versioning → Clean commit history
 10. documentation-and-adrs     → Document decisions
 11. shipping-and-launch        → Deploy safely
+12. observability-and-monitoring → Instrument for production visibility
 ```
 
 Not every task needs every skill. A bug fix might only need: `debugging-and-error-recovery` → `test-driven-development` → `code-review-and-quality`.
@@ -172,3 +174,4 @@ Not every task needs every skill. A bug fix might only need: `debugging-and-erro
 | Ship | ci-cd-and-automation | Automated quality gates on every change |
 | Ship | documentation-and-adrs | Document the why, not just the what |
 | Ship | shipping-and-launch | Pre-launch checklist, monitoring, rollback plan |
+| Ship | observability-and-monitoring | Logs, metrics, traces, and SLO-based alerting |

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -33,8 +33,8 @@ Task arrives
     ├── Committing/branching? ─────────→ git-workflow-and-versioning
     ├── CI/CD pipeline work? ──────────→ ci-cd-and-automation
     ├── Writing docs/ADRs? ───────────→ documentation-and-adrs
-    ├── Deploying/launching? ─────────→ shipping-and-launch
-    └── System live, need visibility? ─→ observability-and-monitoring
+    ├── Need production visibility? ──→ observability-and-monitoring
+    └── Deploying/launching? ─────────→ shipping-and-launch
 ```
 
 ## Core Operating Behaviors
@@ -145,9 +145,9 @@ For a complete feature, the typical skill sequence is:
 7. test-driven-development     → Prove each slice works
 8. code-review-and-quality     → Review before merge
 9. git-workflow-and-versioning → Clean commit history
-10. documentation-and-adrs     → Document decisions
-11. shipping-and-launch        → Deploy safely
-12. observability-and-monitoring → Instrument for production visibility
+10. documentation-and-adrs       → Document decisions
+11. observability-and-monitoring → Instrument for production visibility
+12. shipping-and-launch          → Deploy safely
 ```
 
 Not every task needs every skill. A bug fix might only need: `debugging-and-error-recovery` → `test-driven-development` → `code-review-and-quality`.
@@ -173,5 +173,5 @@ Not every task needs every skill. A bug fix might only need: `debugging-and-erro
 | Ship | git-workflow-and-versioning | Atomic commits, clean history |
 | Ship | ci-cd-and-automation | Automated quality gates on every change |
 | Ship | documentation-and-adrs | Document the why, not just the what |
-| Ship | shipping-and-launch | Pre-launch checklist, monitoring, rollback plan |
 | Ship | observability-and-monitoring | Logs, metrics, traces, and SLO-based alerting |
+| Ship | shipping-and-launch | Pre-launch checklist, monitoring, rollback plan |

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -131,6 +131,11 @@ These are the subtle errors that look like productivity but create problems:
 
 4. **When in doubt, start with a spec.** If the task is non-trivial and there's no spec, begin with `spec-driven-development`.
 
+5. **Agent personas are available for specialized roles.** When a skill calls for a review or testing subagent, load the matching persona from `agents/`:
+   - `agents/code-reviewer.md` — five-axis code review, invoked from `code-review-and-quality`
+   - `agents/security-auditor.md` — vulnerability detection, invoked from `security-and-hardening`
+   - `agents/test-engineer.md` — test strategy and bug reproduction, invoked from `test-driven-development`
+
 ## Lifecycle Sequence
 
 For a complete feature, the typical skill sequence is:


### PR DESCRIPTION
## Summary

- **New skill: `observability-and-monitoring`** — fills the only confirmed lifecycle gap in the collection. Covers structured logging (with cardinality rules), four golden signals metrics, OpenTelemetry-standard distributed tracing (W3C `traceparent`/`tracestate`), SLO-based alerting (burn rate, not raw thresholds), and dashboard design. Follows `skill-anatomy.md` format exactly: Overview, When to Use, stepwise process, Common Rationalizations, Red Flags, Verification checklist.
- **Cross-references added to isolated skills** — `idea-refine` now points forward to `spec-driven-development`; `deprecation-and-migration` now references `incremental-implementation`, `test-driven-development`, and `git-workflow-and-versioning` at the natural touch points in the migration process.
- **`/ship` command updated** — `observability-and-monitoring` is wired into the launch checklist so the skill is reachable via the `/ship` entrypoint, not just via the meta-skill decision tree.
- **`using-agent-skills` updated** — new skill added to decision tree, lifecycle sequence (before `shipping-and-launch`, not after), and quick reference table.
- **README updated** — skill count 20 → 21, new entry in Ship section and directory tree.

## How findings were addressed

This PR went through both `/codex:adversarial-review` and `/codex:review` before submission:

| Finding | Fix |
|---|---|
| Metric `path` label causes cardinality explosion | Changed to `route_template`; added explicit cardinality rule banning user IDs, tenant IDs, query strings from labels |
| Tracing example used custom `X-Trace-Id` headers (non-interoperable) | Replaced with OpenTelemetry `inject()` + W3C `traceparent`/`tracestate` |
| New skill not reachable via `/ship` entrypoint | Added as step 6 in ship command |
| Skill count stale in README | Updated to 21, added to table and directory tree |
| Lifecycle placed observability after deploy | Moved before `shipping-and-launch` in decision tree, lifecycle, and quick reference |

## Test plan

- [ ] Verify `skills/observability-and-monitoring/SKILL.md` exists and passes frontmatter lint
- [ ] Verify skill count in README matches `ls skills/ | wc -l`
- [ ] Confirm `/ship` command references `observability-and-monitoring`
- [ ] Confirm lifecycle in `using-agent-skills` has observability before shipping