### PR TITLE
Add CI skill validator

### DIFF
--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -6,8 +6,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  validate-skills:
+    name: Validate skill content
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate all skills
+        run: node scripts/validate-skills.js
+
   validate:
     name: Validate plugin structure
+    needs: validate-skills
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/scripts/validate-skills.js
+++ b/scripts/validate-skills.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * validate-skills.js
+ *
+ * Validates every skill in skills/ against the rules in docs/skill-anatomy.md.
+ *
+ * Checks (errors block CI):
+ *   - SKILL.md exists in every skill directory
+ *   - YAML frontmatter present with 'name' and 'description' fields
+ *   - frontmatter 'name' matches the directory name
+ *   - description does not exceed 1024 characters
+ *   - required sections are present
+ *
+ * Checks (warnings, do not block CI):
+ *   - cross-skill references point to known skills
+ *
+ * Exit codes: 0 = all clear, 1 = one or more errors
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+const SKILLS_DIR = path.resolve(__dirname, '..', 'skills');
+
+const MAX_DESCRIPTION_LENGTH = 1024;
+
+// Sections every standard SKILL.md must contain.
+// Each entry is an array of acceptable heading strings — the first
+// match wins, so you can list canonical + legacy aliases.
+const REQUIRED_SECTIONS = [
+  ['## Overview'],
+  ['## When to Use'],
+  ['## Common Rationalizations'],
+  ['## Red Flags'],
+  ['## Verification'],
+];
+
+// Skills that are intentionally exempt from section checks.
+// Exemptions live HERE, not in skill frontmatter, so contributors
+// cannot bypass the validator by editing their own skill file.
+// Every entry must have a documented reason.
+const SECTION_EXEMPT_SKILLS = {
+  'using-agent-skills': 'Meta-skill — orchestrates other skills; When-to-Use and Verification are not applicable to a routing document.',
+  'idea-refine':        'Legacy structure predating skill-anatomy.md — uses How-It-Works/Usage/Anti-patterns instead of standard headings. Tracked for conformance in https://github.com/addyosmani/agent-skills/issues',
+};
+
+// Regex patterns that indicate an explicit cross-skill reference.
+// Only these patterns trigger the dead-reference warning — generic
+// backtick strings in code blocks are intentionally excluded.
+const SKILL_REF_PATTERNS = [
+  /\buse the `([a-z][a-z0-9-]+[a-z0-9])` skill/g,
+  /\bfollow the `([a-z][a-z0-9-]+[a-z0-9])` skill/g,
+  /\binvoke the `([a-z][a-z0-9-]+[a-z0-9])` skill/g,
+  /\bcontinue with `([a-z][a-z0-9-]+[a-z0-9])`/g,
+  /\buse `([a-z][a-z0-9-]+[a-z0-9])` skill/g,
+  /`([a-z][a-z0-9-]+[a-z0-9])` skill\b/g,
+  /`([a-z][a-z0-9-]+[a-z0-9])` persona\b/g,
+  /\bsee `([a-z][a-z0-9-]+[a-z0-9])`/g,
+  /──→ ([a-z][a-z0-9-]+[a-z0-9])\b/g,          // ASCII diagram arrows
+  /→ `([a-z][a-z0-9-]+[a-z0-9])`/g,
+];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Parse YAML-style frontmatter from the top of a markdown file.
+ * Returns a key→value object, or null if no frontmatter block found.
+ * Values are stripped of surrounding quotes.
+ */
+function parseFrontmatter(content) {
+  const match = content.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n/);
+  if (!match) return null;
+
+  const result = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key   = line.slice(0, colonIdx).trim();
+    const value = line.slice(colonIdx + 1).trim().replace(/^['"]|['"]$/g, '');
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
+/**
+ * Collect all explicit skill cross-references from content.
+ * Only matches against the SKILL_REF_PATTERNS list to avoid
+ * false-positives from inline code snippets.
+ */
+function extractSkillReferences(content) {
+  const refs = new Set();
+  for (const pattern of SKILL_REF_PATTERNS) {
+    // Reset lastIndex for global regexes
+    pattern.lastIndex = 0;
+    let m;
+    while ((m = pattern.exec(content)) !== null) {
+      refs.add(m[1]);
+    }
+  }
+  return refs;
+}
+
+// ─── Validator ───────────────────────────────────────────────────────────────
+
+function validateSkill(dirName, knownSkills) {
+  const errors   = [];
+  const warnings = [];
+  let   exempt   = false;
+  const skillPath = path.join(SKILLS_DIR, dirName, 'SKILL.md');
+
+  if (!fs.existsSync(skillPath)) {
+    errors.push('Missing SKILL.md');
+    return { errors, warnings, exempt };
+  }
+
+  const content = fs.readFileSync(skillPath, 'utf8');
+
+  // ── Frontmatter ──────────────────────────────────────────────────────────
+  const fm = parseFrontmatter(content);
+  if (!fm) {
+    errors.push('Missing or malformed YAML frontmatter (expected --- block at top of file)');
+    return { errors, warnings, exempt };
+  }
+
+  if (!fm.name) {
+    errors.push("Frontmatter missing required field: 'name'");
+  } else if (fm.name !== dirName) {
+    errors.push(`Frontmatter name '${fm.name}' does not match directory name '${dirName}'`);
+  }
+
+  if (!fm.description) {
+    errors.push("Frontmatter missing required field: 'description'");
+  } else if (fm.description.length > MAX_DESCRIPTION_LENGTH) {
+    errors.push(
+      `Description is ${fm.description.length} chars — exceeds the ${MAX_DESCRIPTION_LENGTH}-char limit` +
+      ` (agents inject this into the system prompt)`
+    );
+  }
+
+  // ── Exemption guard ──────────────────────────────────────────────────────
+  // Exemptions are validator-owned (SECTION_EXEMPT_SKILLS above).
+  // If a skill's frontmatter tries to declare its own exemption, fail loud —
+  // that's a sign someone is trying to bypass the validator.
+  if (fm.type === 'meta' || fm.exempt === 'sections') {
+    if (!SECTION_EXEMPT_SKILLS[dirName]) {
+      errors.push(
+        `Frontmatter declares 'type: meta' or 'exempt: sections' but '${dirName}' is not in ` +
+        `the validator's SECTION_EXEMPT_SKILLS allowlist. ` +
+        `Add an entry to scripts/validate-skills.js with a documented reason.`
+      );
+    }
+  }
+
+  // ── Required sections ────────────────────────────────────────────────────
+  exempt = dirName in SECTION_EXEMPT_SKILLS;
+
+  if (!exempt) {
+    for (const aliases of REQUIRED_SECTIONS) {
+      const found = aliases.some(heading => content.includes(heading));
+      if (!found) {
+        errors.push(`Missing required section: ${aliases[0]}`);
+      }
+    }
+  }
+
+  // ── Cross-skill references ───────────────────────────────────────────────
+  const refs = extractSkillReferences(content);
+  for (const ref of refs) {
+    if (!knownSkills.has(ref)) {
+      warnings.push(`Dead cross-reference: \`${ref}\` is not a known skill`);
+    }
+  }
+
+  return { errors, warnings, exempt };
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+function main() {
+  if (!fs.existsSync(SKILLS_DIR)) {
+    console.error(`ERROR: skills directory not found at ${SKILLS_DIR}`);
+    process.exit(1);
+  }
+
+  const skillDirs = fs.readdirSync(SKILLS_DIR)
+    .filter(d => fs.statSync(path.join(SKILLS_DIR, d)).isDirectory())
+    .sort();
+
+  const knownSkills = new Set(skillDirs);
+
+  let totalErrors   = 0;
+  let totalWarnings = 0;
+
+  for (const dirName of skillDirs) {
+    const { errors, warnings, exempt } = validateSkill(dirName, knownSkills);
+    totalErrors   += errors.length;
+    totalWarnings += warnings.length;
+
+    if (errors.length === 0 && warnings.length === 0) {
+      const tag = exempt ? ' (section checks exempt)' : '';
+      console.log(`  ✓  ${dirName}${tag}`);
+    } else {
+      const icon = errors.length > 0 ? '  ✗ ' : '  ⚠ ';
+      console.log(`${icon} ${dirName}`);
+      for (const msg of errors)   console.log(`       ERROR: ${msg}`);
+      for (const msg of warnings) console.log(`       WARN:  ${msg}`);
+    }
+  }
+
+  const status = totalErrors > 0 ? 'FAILED' : totalWarnings > 0 ? 'PASSED WITH WARNINGS' : 'PASSED';
+  console.log(`\n${skillDirs.length} skills checked — ${totalErrors} error(s), ${totalWarnings} warning(s) — ${status}`);
+
+  if (totalErrors > 0) process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

- **`scripts/validate-skills.js`** — zero-dependency Node.js script that validates every skill on every PR. Checks: SKILL.md exists, frontmatter has `name` + `description`, `name` matches directory, description ≤ 1024 chars, all five required sections present (Overview, When to Use, Common Rationalizations, Red Flags, Verification), and cross-skill references point to real skills.
- **CI job `validate-skills`** — runs before the existing manifest-validation job and blocks merge on any error. Uses Node 20, no `npm install` required.
- **Validator-owned allowlist** — `using-agent-skills` and `idea-refine` are exempt from section checks via an explicit `SECTION_EXEMPT_SKILLS` map in the script (with documented reasons). Skills cannot self-declare exemptions via frontmatter — if they try, CI fails loud.

## Adversarial review finding addressed

Initial implementation used `type: meta` / `exempt: sections` frontmatter fields to opt skills out of section checks. Adversarial review correctly flagged this as a bypass vector — any contributor could add `exempt: sections` to their own skill and pass CI. Fixed by moving the allowlist entirely into the validator script. Non-allowlisted skills that declare these fields now fail with an explicit error.

## Test plan

- [ ] `node scripts/validate-skills.js` exits 0 on current main
- [ ] Introducing a skill with missing frontmatter exits 1
- [ ] Introducing a skill with missing `## Verification` section exits 1  
- [ ] Introducing a skill with `exempt: sections` that is not in the allowlist exits 1
- [ ] CI `validate-skills` job passes on this branch