### PR TITLE
 docs: Add Copilot CLI setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ Use agent definitions from `agents/` as Copilot personas and skill content in `.
 </details>
 
 <details>
+<summary><b>GitHub Copilot CLI</b></summary>
+
+Install agent-skills globally in Copilot CLI using the marketplace commands:
+
+1. Add the marketplace:
+```bash
+/plugin marketplace add addyosmani/agent-skills
+```
+
+2. Install the plugin:
+```bash
+/plugin install agent-skills@addy-agent-skills
+```
+
+Once installed, you can use any of the 20+ skills included in this repository with Copilot CLI as well as GitHub Copilot within Visual Studio and Visual Studio Code. The skills will be automatically available for use in your sessions. See [docs/copilot-cli-setup.md](docs/copilot-cli-setup.md) for more details.
+
+</details>
+
+<details>
   <summary><b>Kiro IDE & CLI </b></summary>
   Skills for Kiro reside under ".kiro/skills/" and can be stored under Project or Global level. Kiro also supports Agents.md. See Kiro docs at https://kiro.dev/docs/skills/
 </details>

--- a/docs/copilot-cli-setup.md
+++ b/docs/copilot-cli-setup.md
@@ -1,0 +1,30 @@
+# Using agent-skills with GitHub Copilot CLI
+
+## Setup
+
+### Installation
+
+Copilot CLI supports installing agent skills using the same marketplace installation commands as Claude Code.
+
+To install agent-skills globally in Copilot CLI, run the commands one at a time:
+
+1. Add the marketplace:
+```bash
+/plugin marketplace add addyosmani/agent-skills
+```
+
+2. Install the plugin:
+```bash
+/plugin install agent-skills@addy-agent-skills
+```
+
+> **Note**: The marketplace clones repositories via SSH. If you don't have SSH keys set up on GitHub, either [add your SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) or switch to HTTPS for fetches only:
+> ```bash
+> git config --global url."https://github.com/".insteadOf "git@github.com:"
+> ```
+
+### Usage
+
+Once installed, you can use any of the 20+ skills included in this repository with Copilot CLI. The skills will be automatically available for use in your sessions.
+
+For more information on using Copilot CLI with agent skills, see the [official Copilot CLI documentation](https://docs.github.com/en/copilot/using-copilot/using-the-cli).


### PR DESCRIPTION
- Create docs/copilot-cli-setup.md with installation instructions for GitHub Copilot CLI
 - Update README.md with Copilot CLI Quick Start section
 - Document the two-step installation process: marketplace add followed by install
 - Follow existing documentation patterns and formatting