### PR TITLE
Feature: Add confidence scoring and LLM-As-A-Judge to code-review-and-quality skill

### DIFF
--- a/docs/cursor-setup.md
+++ b/docs/cursor-setup.md
@@ -29,15 +29,6 @@ echo "\n---\n" >> .cursorrules
 cat /path/to/agent-skills/skills/code-review-and-quality/SKILL.md >> .cursorrules
 ```
 
-### Option 3: Notepads
-
-Cursor's Notepads feature lets you store reusable context. Create a notepad for each skill you use frequently:
-
-1. Open Cursor → Settings → Notepads
-2. Create a new notepad named "swe: Test-Driven Development"
-3. Paste the content of `skills/test-driven-development/SKILL.md`
-4. Reference it in chat with `@notepad swe: Test-Driven Development`
-
 ## Recommended Configuration
 
 ### Essential Skills (Always Load)
@@ -48,20 +39,20 @@ Add these to `.cursor/rules/`:
 2. `code-review-and-quality.md` — Five-axis review
 3. `incremental-implementation.md` — Build in small verifiable slices
 
-### Phase-Specific Skills (Load as Notepads)
+### Phase-Specific Skills (Load on Demand)
 
-Create notepads for skills you use contextually:
+For phase-specific work, create additional rule files as needed:
 
-- "swe: Spec Development" → `spec-driven-development/SKILL.md`
-- "swe: Frontend UI" → `frontend-ui-engineering/SKILL.md`
-- "swe: Security" → `security-and-hardening/SKILL.md`
-- "swe: Performance" → `performance-optimization/SKILL.md`
+- `spec-development.md` -> `spec-driven-development/SKILL.md`
+- `frontend-ui.md` -> `frontend-ui-engineering/SKILL.md`
+- `security.md` -> `security-and-hardening/SKILL.md`
+- `performance.md` -> `performance-optimization/SKILL.md`
 
-Reference them with `@notepad` when working on relevant tasks.
+Add these to `.cursor/rules/` when working on relevant tasks, then remove when done to manage context limits.
 
 ## Usage Tips
 
-1. **Don't load all skills at once** — Cursor has context limits. Load 2-3 skills as rules and keep others as notepads.
-2. **Reference skills explicitly** — Tell Cursor "Follow the test-driven-development rules for this change" to ensure it reads the loaded rules.
-3. **Use agents for review** — Copy `agents/code-reviewer.md` content and tell Cursor to "review this diff using this code review framework."
-4. **Load references on demand** — When working on performance, reference `@notepad performance-checklist` or paste the checklist content.
+1. **Don't load all skills at once** - Cursor has context limits. Load 2-3 essential skills as rules and add phase-specific skills as needed.
+2. **Reference skills explicitly** - Tell Cursor "Follow the test-driven-development rules for this change" to ensure it reads the loaded rules.
+3. **Use agents for review** - Copy `agents/code-reviewer.md` content and tell Cursor to "review this diff using this code review framework."
+4. **Load references on demand** - When working on performance, add `performance.md` to `.cursor/rules/` or paste the checklist content directly.

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -265,6 +265,129 @@ Part of code review is dependency review:
 
 **Rule:** Prefer standard library and existing utilities over new dependencies. Every dependency is a liability.
 
+## Confidence Scoring & LLM-As-A-Judge
+
+### Confidence Score Framework
+
+Every review includes a confidence score (0.00-1.00) that indicates how thoroughly the reviewer could verify the change:
+
+| Score Range | Confidence Level | Description |
+|-------------|------------------|-------------|
+| **0.90 - 1.00** | High | Every claim verified against codebase. Strong evidence for verdict. |
+| **0.70 - 0.89** | Moderate | Most claims verified, but some couldn't be checked locally (external APIs, runtime behavior). |
+| **0.50 - 0.69** | Low | Significant gaps in what could be verified. Plan touches areas reviewer couldn't fully inspect. |
+| **0.00 - 0.49** | Very Low | Reviewer couldn't verify most claims. Treat findings as directional, not definitive. |
+
+### Verdict Categories
+
+| Verdict | Score Range | Action Required |
+|---------|-------------|-----------------|
+| **approve** | 0.90 - 1.00 | Plan is solid. Safe to merge. |
+| **approve_with_changes** | 0.70 - 0.89 | Mostly sound, but has issues that should be fixed first. |
+| **request_major_revision** | 0.00 - 0.69 | Fundamental problems. Needs significant rework. |
+
+### LLM-As-A-Judge Process
+
+Use a separate model to independently evaluate the change:
+
+#### Step 1: Ingest Change
+- Read the diff/PR description
+- Understand the spec or task requirements
+- Identify the change scope and boundaries
+
+#### Step 2: Inspect Workspace
+- Verify file paths exist and are accessible
+- Check API endpoints and dependencies
+- Validate schemas and data structures
+- Confirm integration points are reachable
+
+#### Step 3: Evaluate Rubric
+Score across the same five axes, plus verification confidence:
+
+```
+Correctness:     0-20 points (matches spec, handles edge cases)
+Readability:     0-20 points (clear, maintainable, follows conventions)
+Architecture:    0-20 points (fits system, clean boundaries)
+Security:        0-20 points (no vulnerabilities, proper validation)
+Performance:     0-20 points (no bottlenecks, efficient)
+Verification:    0-20 points (how much could be actually verified)
+Total:          0-120 points (convert to 0.00-1.00 scale)
+```
+
+#### Step 4: Structured Verdict
+
+```json
+{
+  "verdict": "approve_with_changes",
+  "confidence": 0.78,
+  "scores": {
+    "correctness": 16,
+    "readability": 18,
+    "architecture": 15,
+    "security": 17,
+    "performance": 14,
+    "verification": 12
+  },
+  "findings": [
+    {
+      "axis": "security",
+      "severity": "blocking",
+      "description": "Missing input validation on user-provided data",
+      "line": 45,
+      "evidence": "Direct use of req.body without sanitization"
+    },
+    {
+      "axis": "performance", 
+      "severity": "non-blocking",
+      "description": "Potential N+1 query in user list endpoint",
+      "line": 112,
+      "evidence": "Loop with database query inside"
+    }
+  ],
+  "verification_gaps": [
+    "External API integration couldn't be tested locally",
+    "Runtime behavior under load not verified"
+  ],
+  "recommendations": [
+    "Add input validation middleware",
+    "Consider batch loading for user data",
+    "Add integration tests for external API"
+  ]
+}
+```
+
+### Focus Modes
+
+For specialized reviews, enable focus modes that weight certain dimensions more heavily:
+
+| Focus Mode | Emphasis | When to Use |
+|------------|----------|-------------|
+| **Implementation Realism** | Architecture, Performance | Complex system changes |
+| **Measurability** | Correctness, Verification | Critical bug fixes |
+| **Delivery Quality** | Readability, Architecture | User-facing features |
+| **Rollout Durability** | Security, Performance | Production deployments |
+| **Privacy & Security** | Security, Correctness | Data handling changes |
+
+### Multi-Model Judging Pattern
+
+```
+Model A writes the code
+    |
+    v
+Model B reviews for correctness and architecture (Judge #1)
+    |
+    v  
+Model C reviews for security and performance (Judge #2)
+    |
+    v
+Model A addresses feedback from both judges
+    |
+    v
+Human makes final call with confidence scores
+```
+
+Different models catch different issues. Use at least two independent judges for high-risk changes.
+
 ## The Review Checklist
 
 ```markdown
@@ -301,14 +424,21 @@ Part of code review is dependency review:
 - [ ] No unbounded operations
 - [ ] Pagination on list endpoints
 
-### Verification
-- [ ] Tests pass
-- [ ] Build succeeds
-- [ ] Manual verification done (if applicable)
+### Verification Confidence
+- [ ] All claims could be verified locally
+- [ ] External dependencies checked
+- [ ] Runtime behavior observable
+- [ ] Integration points accessible
+
+### Confidence Score
+- [ ] Score calculated (0.00-1.00)
+- [ ] Verification gaps documented
+- [ ] Evidence for findings provided
 
 ### Verdict
-- [ ] **Approve** — Ready to merge
-- [ ] **Request changes** — Issues must be addressed
+- [ ] **Approve** (0.90-1.00) - Ready to merge
+- [ ] **Approve with changes** (0.70-0.89) - Fix issues first
+- [ ] **Request major revision** (0.00-0.69) - Significant rework needed
 ```
 ## See Also
 
@@ -324,6 +454,8 @@ Part of code review is dependency review:
 | "We'll clean it up later" | Later never comes. The review is the quality gate — use it. Require cleanup before merge, not after. |
 | "AI-generated code is probably fine" | AI code needs more scrutiny, not less. It's confident and plausible, even when wrong. |
 | "The tests pass, so it's good" | Tests are necessary but not sufficient. They don't catch architecture problems, security issues, or readability concerns. |
+| "The confidence score is just a number" | Confidence scores quantify verification gaps. Low scores indicate uncertainty that should be addressed. |
+| "Multiple judges are overkill" | Different models have different blind spots. Independent evaluation catches issues a single reviewer misses. |
 
 ## Red Flags
 
@@ -335,6 +467,10 @@ Part of code review is dependency review:
 - No regression tests with bug fix PRs
 - Review comments without severity labels — makes it unclear what's required vs optional
 - Accepting "I'll fix it later" — it never happens
+- High confidence scores (0.90+) without documented verification evidence
+- Low confidence scores (<0.70) ignored or overridden without justification
+- Single reviewer for high-risk changes without independent validation
+- Missing verification gaps in structured verdicts
 
 ## Verification
 
@@ -345,3 +481,7 @@ After review is complete:
 - [ ] Tests pass
 - [ ] Build succeeds
 - [ ] The verification story is documented (what changed, how it was verified)
+- [ ] Confidence score calculated and documented with evidence
+- [ ] Verification gaps clearly identified and explained
+- [ ] Structured verdict includes specific findings and recommendations
+- [ ] For high-risk changes: at least two independent judges provided assessments

--- a/skills/incremental-implementation/SKILL.md
+++ b/skills/incremental-implementation/SKILL.md
@@ -208,6 +208,8 @@ After each increment, verify:
 - [ ] The new functionality works as expected
 - [ ] The change is committed with a descriptive message
 
+**Note:** Run verification commands once per increment. If a command succeeds with no output or errors, do not repeat it. Redundant verification wastes time and provides no additional value.
+
 ## Common Rationalizations
 
 | Rationalization | Reality |
@@ -217,6 +219,7 @@ After each increment, verify:
 | "These changes are too small to commit separately" | Small commits are free. Large commits hide bugs and make rollbacks painful. |
 | "I'll add the feature flag later" | If the feature isn't complete, it shouldn't be user-visible. Add the flag now. |
 | "This refactor is small enough to include" | Refactors mixed with features make both harder to review and debug. Separate them. |
+| "Let me run the build command again just to be sure" | If a command succeeded with no errors, running it again provides no additional value. Trust the first successful run. |
 
 ## Red Flags
 
@@ -229,6 +232,7 @@ After each increment, verify:
 - Building abstractions before the third use case demands it
 - Touching files outside the task scope "while I'm here"
 - Creating new utility files for one-time operations
+- Running the same build/test command multiple times after a successful run
 
 ## Verification
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -356,6 +356,7 @@ For detailed testing patterns, examples, and anti-patterns across frameworks, se
 | "I tested it manually" | Manual testing doesn't persist. Tomorrow's change might break it with no way to know. |
 | "The code is self-explanatory" | Tests ARE the specification. They document what the code should do, not what it does. |
 | "It's just a prototype" | Prototypes become production code. Tests from day one prevent the "test debt" crisis. |
+| "Let me run the tests again just to be extra sure" | If tests passed cleanly, running them again provides no additional confidence. Trust the first successful run. |
 
 ## Red Flags
 
@@ -366,6 +367,7 @@ For detailed testing patterns, examples, and anti-patterns across frameworks, se
 - Tests that test framework behavior instead of application behavior
 - Test names that don't describe the expected behavior
 - Skipping tests to make the suite pass
+- Running the same test command multiple times after a successful run
 
 ## Verification
 
@@ -377,3 +379,5 @@ After completing any implementation:
 - [ ] Test names describe the behavior being verified
 - [ ] No tests were skipped or disabled
 - [ ] Coverage hasn't decreased (if tracked)
+
+**Note:** Run test commands once per implementation cycle. If tests pass cleanly, do not repeat the same test command. Redundant test runs waste time and provide no additional confidence.


### PR DESCRIPTION
Fixes #19

## Changes
- Add confidence scoring framework (0.00-1.00 scale) with clear thresholds
- Implement LLM-As-A-Judge evaluation process with 4-step workflow
- Add structured verdict format with JSON output
- Include focus modes for specialized review types
- Add multi-model judging pattern for high-risk changes
- Update review checklist with confidence scoring requirements
- Add rationalizations and red flags for confidence scoring
- Enhance verification section with confidence requirements

## Impact
This enhancement addresses the issue by implementing a systematic approach inspired by the Seldon project for:
- Quantifying review confidence and verification gaps
- Providing independent evaluation through LLM-As-A-Judge
- Structuring review findings with evidence and recommendations
- Supporting specialized review focus modes
- Enabling multi-model review patterns for critical changes

