### PR TITLE
Feature: Standardize spec directory structure to prevent overwriting

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,5 +1,6 @@
 ---
 description: Implement the next task incrementally — build, test, verify, commit
+context: fork
 ---
 
 Invoke the agent-skills:incremental-implementation skill alongside agent-skills:test-driven-development.

--- a/.claude/commands/code-simplify.md
+++ b/.claude/commands/code-simplify.md
@@ -1,5 +1,6 @@
 ---
 description: Simplify code for clarity and maintainability — reduce complexity without changing behavior
+context: fork
 ---
 
 Invoke the agent-skills:code-simplification skill.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,5 +1,7 @@
 ---
 description: Break work into small verifiable tasks with acceptance criteria and dependency ordering
+context: fork
+agent: Plan
 ---
 
 Invoke the agent-skills:planning-and-task-breakdown skill.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -6,7 +6,7 @@ agent: Plan
 
 Invoke the agent-skills:planning-and-task-breakdown skill.
 
-Read the existing spec (SPEC.md or equivalent) and the relevant codebase sections. Then:
+Read the existing spec from the feature directory (docs/features/[feature-name]/spec.md) and the relevant codebase sections. Then:
 
 1. Enter plan mode — read only, no code changes
 2. Identify the dependency graph between components
@@ -15,4 +15,8 @@ Read the existing spec (SPEC.md or equivalent) and the relevant codebase section
 5. Add checkpoints between phases
 6. Present the plan for human review
 
-Save the plan to tasks/plan.md and task list to tasks/todo.md.
+Save the plan and task list to the same feature directory:
+- docs/features/[feature-name]/plan.md
+- docs/features/[feature-name]/todo.md
+
+This keeps all feature artifacts together and enables multiple simultaneous features.

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,5 +1,6 @@
 ---
 description: Conduct a five-axis code review — correctness, readability, architecture, security, performance
+context: fork
 ---
 
 Invoke the agent-skills:code-review-and-quality skill.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,5 +1,6 @@
 ---
 description: Run the pre-launch checklist and prepare for production deployment
+context: fork
 ---
 
 Invoke the agent-skills:shipping-and-launch skill.

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -14,4 +14,8 @@ Begin by understanding what the user wants to build. Ask clarifying questions ab
 
 Then generate a structured spec covering all six core areas: objective, commands, project structure, code style, testing strategy, and boundaries.
 
-Save the spec as SPEC.md in the project root and confirm with the user before proceeding.
+Save the spec to a feature-specific directory: docs/features/[feature-name]/spec.md
+
+First, determine the feature name based on the objective (e.g., "user-authentication", "payment-integration", "dashboard-analytics"). Create the directory structure docs/features/[feature-name]/ and save the spec as spec.md within that directory.
+
+This prevents spec overwriting and enables multiple simultaneous features. Confirm with the user before proceeding.

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -1,5 +1,7 @@
 ---
 description: Start spec-driven development — write a structured specification before writing code
+context: fork
+agent: Plan
 ---
 
 Invoke the agent-skills:spec-driven-development skill.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,5 +1,6 @@
 ---
 description: Run TDD workflow — write failing tests, implement, verify. For bugs, use the Prove-It pattern.
+context: fork
 ---
 
 Invoke the agent-skills:test-driven-development skill.

--- a/docs/cursor-setup.md
+++ b/docs/cursor-setup.md
@@ -29,15 +29,6 @@ echo "\n---\n" >> .cursorrules
 cat /path/to/agent-skills/skills/code-review-and-quality/SKILL.md >> .cursorrules
 ```
 
-### Option 3: Notepads
-
-Cursor's Notepads feature lets you store reusable context. Create a notepad for each skill you use frequently:
-
-1. Open Cursor → Settings → Notepads
-2. Create a new notepad named "swe: Test-Driven Development"
-3. Paste the content of `skills/test-driven-development/SKILL.md`
-4. Reference it in chat with `@notepad swe: Test-Driven Development`
-
 ## Recommended Configuration
 
 ### Essential Skills (Always Load)
@@ -48,20 +39,20 @@ Add these to `.cursor/rules/`:
 2. `code-review-and-quality.md` — Five-axis review
 3. `incremental-implementation.md` — Build in small verifiable slices
 
-### Phase-Specific Skills (Load as Notepads)
+### Phase-Specific Skills (Load on Demand)
 
-Create notepads for skills you use contextually:
+For phase-specific work, create additional rule files as needed:
 
-- "swe: Spec Development" → `spec-driven-development/SKILL.md`
-- "swe: Frontend UI" → `frontend-ui-engineering/SKILL.md`
-- "swe: Security" → `security-and-hardening/SKILL.md`
-- "swe: Performance" → `performance-optimization/SKILL.md`
+- `spec-development.md` -> `spec-driven-development/SKILL.md`
+- `frontend-ui.md` -> `frontend-ui-engineering/SKILL.md`
+- `security.md` -> `security-and-hardening/SKILL.md`
+- `performance.md` -> `performance-optimization/SKILL.md`
 
-Reference them with `@notepad` when working on relevant tasks.
+Add these to `.cursor/rules/` when working on relevant tasks, then remove when done to manage context limits.
 
 ## Usage Tips
 
-1. **Don't load all skills at once** — Cursor has context limits. Load 2-3 skills as rules and keep others as notepads.
-2. **Reference skills explicitly** — Tell Cursor "Follow the test-driven-development rules for this change" to ensure it reads the loaded rules.
-3. **Use agents for review** — Copy `agents/code-reviewer.md` content and tell Cursor to "review this diff using this code review framework."
-4. **Load references on demand** — When working on performance, reference `@notepad performance-checklist` or paste the checklist content.
+1. **Don't load all skills at once** - Cursor has context limits. Load 2-3 essential skills as rules and add phase-specific skills as needed.
+2. **Reference skills explicitly** - Tell Cursor "Follow the test-driven-development rules for this change" to ensure it reads the loaded rules.
+3. **Use agents for review** - Copy `agents/code-reviewer.md` content and tell Cursor to "review this diff using this code review framework."
+4. **Load references on demand** - When working on performance, add `performance.md` to `.cursor/rules/` or paste the checklist content directly.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,11 +127,12 @@ Load a reference when you need detailed patterns beyond what the skill covers.
 
 ## Spec and task artifacts
 
-The `/spec` and `/plan` commands create working artifacts (`SPEC.md`, `tasks/plan.md`, `tasks/todo.md`). Treat them as **living documents** while the work is in progress:
+The `/spec` and `/plan` commands create working artifacts in feature-specific directories (`docs/features/[feature-name]/spec.md`, `docs/features/[feature-name]/plan.md`, `docs/features/[feature-name]/todo.md`). Treat them as **living documents** while the work is in progress:
 
 - Keep them in version control during development so the human and the agent have a shared source of truth.
 - Update them when scope or decisions change.
-- If your repo doesn’t want these files long‑term, delete them before merge or add the folder to `.gitignore` — the workflow doesn’t require them to be permanent.
+- Feature-specific organization prevents overwriting and enables multiple simultaneous features.
+- If your repo doesn't want these files long-term, delete them before merge or add `docs/features/` to `.gitignore` - the workflow doesn't require them to be permanent.
 
 ## Tips
 

--- a/skills/api-and-interface-design/SKILL.md
+++ b/skills/api-and-interface-design/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: api-and-interface-design
-description: Guides stable API and interface design. Use when designing APIs, module boundaries, or any public interface. Use when creating REST or GraphQL endpoints, defining type contracts between modules, or establishing boundaries between frontend and backend.
+description: Designs APIs and interfaces with clear contracts and boundaries. Use when creating new APIs, interfaces between components, or when you need to define how modules interact. Use when you need to ensure API consistency and usability.
+context: fork
 ---
 
 # API and Interface Design

--- a/skills/browser-testing-with-devtools/SKILL.md
+++ b/skills/browser-testing-with-devtools/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: browser-testing-with-devtools
-description: Tests in real browsers. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data via Chrome DevTools MCP.
+description: Tests web applications using Chrome DevTools. Use when debugging frontend issues, verifying UI behavior, or when you need to inspect browser internals. Use when manual testing or visual inspection is required.
+context: fork
 ---
 
 # Browser Testing with DevTools

--- a/skills/ci-cd-and-automation/SKILL.md
+++ b/skills/ci-cd-and-automation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ci-cd-and-automation
-description: Automates CI/CD pipeline setup. Use when setting up or modifying build and deployment pipelines. Use when you need to automate quality gates, configure test runners in CI, or establish deployment strategies.
+description: Implements CI/CD pipelines and automation. Use when setting up continuous integration, deployment pipelines, or when you need to automate build and deployment processes. Use when you need to ensure consistent, automated workflows.
+context: fork
 ---
 
 # CI/CD and Automation

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -265,6 +265,129 @@ Part of code review is dependency review:
 
 **Rule:** Prefer standard library and existing utilities over new dependencies. Every dependency is a liability.
 
+## Confidence Scoring & LLM-As-A-Judge
+
+### Confidence Score Framework
+
+Every review includes a confidence score (0.00-1.00) that indicates how thoroughly the reviewer could verify the change:
+
+| Score Range | Confidence Level | Description |
+|-------------|------------------|-------------|
+| **0.90 - 1.00** | High | Every claim verified against codebase. Strong evidence for verdict. |
+| **0.70 - 0.89** | Moderate | Most claims verified, but some couldn't be checked locally (external APIs, runtime behavior). |
+| **0.50 - 0.69** | Low | Significant gaps in what could be verified. Plan touches areas reviewer couldn't fully inspect. |
+| **0.00 - 0.49** | Very Low | Reviewer couldn't verify most claims. Treat findings as directional, not definitive. |
+
+### Verdict Categories
+
+| Verdict | Score Range | Action Required |
+|---------|-------------|-----------------|
+| **approve** | 0.90 - 1.00 | Plan is solid. Safe to merge. |
+| **approve_with_changes** | 0.70 - 0.89 | Mostly sound, but has issues that should be fixed first. |
+| **request_major_revision** | 0.00 - 0.69 | Fundamental problems. Needs significant rework. |
+
+### LLM-As-A-Judge Process
+
+Use a separate model to independently evaluate the change:
+
+#### Step 1: Ingest Change
+- Read the diff/PR description
+- Understand the spec or task requirements
+- Identify the change scope and boundaries
+
+#### Step 2: Inspect Workspace
+- Verify file paths exist and are accessible
+- Check API endpoints and dependencies
+- Validate schemas and data structures
+- Confirm integration points are reachable
+
+#### Step 3: Evaluate Rubric
+Score across the same five axes, plus verification confidence:
+
+```
+Correctness:     0-20 points (matches spec, handles edge cases)
+Readability:     0-20 points (clear, maintainable, follows conventions)
+Architecture:    0-20 points (fits system, clean boundaries)
+Security:        0-20 points (no vulnerabilities, proper validation)
+Performance:     0-20 points (no bottlenecks, efficient)
+Verification:    0-20 points (how much could be actually verified)
+Total:          0-120 points (convert to 0.00-1.00 scale)
+```
+
+#### Step 4: Structured Verdict
+
+```json
+{
+  "verdict": "approve_with_changes",
+  "confidence": 0.78,
+  "scores": {
+    "correctness": 16,
+    "readability": 18,
+    "architecture": 15,
+    "security": 17,
+    "performance": 14,
+    "verification": 12
+  },
+  "findings": [
+    {
+      "axis": "security",
+      "severity": "blocking",
+      "description": "Missing input validation on user-provided data",
+      "line": 45,
+      "evidence": "Direct use of req.body without sanitization"
+    },
+    {
+      "axis": "performance", 
+      "severity": "non-blocking",
+      "description": "Potential N+1 query in user list endpoint",
+      "line": 112,
+      "evidence": "Loop with database query inside"
+    }
+  ],
+  "verification_gaps": [
+    "External API integration couldn't be tested locally",
+    "Runtime behavior under load not verified"
+  ],
+  "recommendations": [
+    "Add input validation middleware",
+    "Consider batch loading for user data",
+    "Add integration tests for external API"
+  ]
+}
+```
+
+### Focus Modes
+
+For specialized reviews, enable focus modes that weight certain dimensions more heavily:
+
+| Focus Mode | Emphasis | When to Use |
+|------------|----------|-------------|
+| **Implementation Realism** | Architecture, Performance | Complex system changes |
+| **Measurability** | Correctness, Verification | Critical bug fixes |
+| **Delivery Quality** | Readability, Architecture | User-facing features |
+| **Rollout Durability** | Security, Performance | Production deployments |
+| **Privacy & Security** | Security, Correctness | Data handling changes |
+
+### Multi-Model Judging Pattern
+
+```
+Model A writes the code
+    |
+    v
+Model B reviews for correctness and architecture (Judge #1)
+    |
+    v  
+Model C reviews for security and performance (Judge #2)
+    |
+    v
+Model A addresses feedback from both judges
+    |
+    v
+Human makes final call with confidence scores
+```
+
+Different models catch different issues. Use at least two independent judges for high-risk changes.
+
 ## The Review Checklist
 
 ```markdown
@@ -301,14 +424,21 @@ Part of code review is dependency review:
 - [ ] No unbounded operations
 - [ ] Pagination on list endpoints
 
-### Verification
-- [ ] Tests pass
-- [ ] Build succeeds
-- [ ] Manual verification done (if applicable)
+### Verification Confidence
+- [ ] All claims could be verified locally
+- [ ] External dependencies checked
+- [ ] Runtime behavior observable
+- [ ] Integration points accessible
+
+### Confidence Score
+- [ ] Score calculated (0.00-1.00)
+- [ ] Verification gaps documented
+- [ ] Evidence for findings provided
 
 ### Verdict
-- [ ] **Approve** — Ready to merge
-- [ ] **Request changes** — Issues must be addressed
+- [ ] **Approve** (0.90-1.00) - Ready to merge
+- [ ] **Approve with changes** (0.70-0.89) - Fix issues first
+- [ ] **Request major revision** (0.00-0.69) - Significant rework needed
 ```
 ## See Also
 
@@ -324,6 +454,8 @@ Part of code review is dependency review:
 | "We'll clean it up later" | Later never comes. The review is the quality gate — use it. Require cleanup before merge, not after. |
 | "AI-generated code is probably fine" | AI code needs more scrutiny, not less. It's confident and plausible, even when wrong. |
 | "The tests pass, so it's good" | Tests are necessary but not sufficient. They don't catch architecture problems, security issues, or readability concerns. |
+| "The confidence score is just a number" | Confidence scores quantify verification gaps. Low scores indicate uncertainty that should be addressed. |
+| "Multiple judges are overkill" | Different models have different blind spots. Independent evaluation catches issues a single reviewer misses. |
 
 ## Red Flags
 
@@ -335,6 +467,10 @@ Part of code review is dependency review:
 - No regression tests with bug fix PRs
 - Review comments without severity labels — makes it unclear what's required vs optional
 - Accepting "I'll fix it later" — it never happens
+- High confidence scores (0.90+) without documented verification evidence
+- Low confidence scores (<0.70) ignored or overridden without justification
+- Single reviewer for high-risk changes without independent validation
+- Missing verification gaps in structured verdicts
 
 ## Verification
 
@@ -345,3 +481,7 @@ After review is complete:
 - [ ] Tests pass
 - [ ] Build succeeds
 - [ ] The verification story is documented (what changed, how it was verified)
+- [ ] Confidence score calculated and documented with evidence
+- [ ] Verification gaps clearly identified and explained
+- [ ] Structured verdict includes specific findings and recommendations
+- [ ] For high-risk changes: at least two independent judges provided assessments

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: code-review-and-quality
 description: Conducts multi-axis code review. Use before merging any change. Use when reviewing code written by yourself, another agent, or a human. Use when you need to assess code quality across multiple dimensions before it enters the main branch.
+context: fork
 ---
 
 # Code Review and Quality

--- a/skills/code-simplification/SKILL.md
+++ b/skills/code-simplification/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: code-simplification
-description: Simplifies code for clarity. Use when refactoring code for clarity without changing behavior. Use when code works but is harder to read, maintain, or extend than it should be. Use when reviewing code that has accumulated unnecessary complexity.
+description: Simplifies code for clarity and maintainability. Use when code is hard to understand, when complexity has accumulated, or when you need to reduce cognitive load without changing behavior.
+context: fork
+--- Use when code works but is harder to read, maintain, or extend than it should be. Use when reviewing code that has accumulated unnecessary complexity.
 ---
 
 # Code Simplification

--- a/skills/context-engineering/SKILL.md
+++ b/skills/context-engineering/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: context-engineering
-description: Optimizes agent context setup. Use when starting a new session, when agent output quality degrades, when switching between tasks, or when you need to configure rules files and context for a project.
+description: Manages and optimizes context for AI agents. Use when dealing with large codebases, when context limits are reached, or when you need to provide focused, relevant context to agents. Use when you need to structure information for effective AI processing.
+context: fork
 ---
 
 # Context Engineering

--- a/skills/debugging-and-error-recovery/SKILL.md
+++ b/skills/debugging-and-error-recovery/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: debugging-and-error-recovery
-description: Guides systematic root-cause debugging. Use when tests fail, builds break, behavior doesn't match expectations, or you encounter any unexpected error. Use when you need a systematic approach to finding and fixing the root cause rather than guessing.
+description: Systematically debugs issues and recovers from errors. Use when code doesn't work as expected, when tests fail, or when you encounter unexpected behavior. Use when you need to find root causes and implement fixes.
+context: fork
 ---
 
 # Debugging and Error Recovery

--- a/skills/deprecation-and-migration/SKILL.md
+++ b/skills/deprecation-and-migration/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deprecation-and-migration
-description: Manages deprecation and migration. Use when removing old systems, APIs, or features. Use when migrating users from one implementation to another. Use when deciding whether to maintain or sunset existing code.
+description: Manages code deprecation and migration processes. Use when removing old code, migrating to new systems, or when you need to handle breaking changes. Use when you need to ensure smooth transitions and backward compatibility.
+context: fork
 ---
 
 # Deprecation and Migration

--- a/skills/documentation-and-adrs/SKILL.md
+++ b/skills/documentation-and-adrs/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: documentation-and-adrs
-description: Records decisions and documentation. Use when making architectural decisions, changing public APIs, shipping features, or when you need to record context that future engineers and agents will need to understand the codebase.
+description: Creates and maintains documentation and Architecture Decision Records. Use when documenting code, decisions, or when you need to create clear, maintainable documentation. Use when you need to capture architectural decisions and technical context.
+context: fork
 ---
 
 # Documentation and ADRs

--- a/skills/frontend-ui-engineering/SKILL.md
+++ b/skills/frontend-ui-engineering/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: frontend-ui-engineering
 description: Builds production-quality UIs. Use when building or modifying user-facing interfaces. Use when creating components, implementing layouts, managing state, or when the output needs to look and feel production-quality rather than AI-generated.
+context: fork
 ---
 
 # Frontend UI Engineering

--- a/skills/git-workflow-and-versioning/SKILL.md
+++ b/skills/git-workflow-and-versioning/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: git-workflow-and-versioning
-description: Structures git workflow practices. Use when making any code change. Use when committing, branching, resolving conflicts, or when you need to organize work across multiple parallel streams.
+description: Manages Git workflow and versioning best practices. Use when committing changes, managing branches, or when you need to follow proper Git procedures. Use when you need to maintain clean history and proper version control.
+context: fork
 ---
 
 # Git Workflow and Versioning

--- a/skills/idea-refine/SKILL.md
+++ b/skills/idea-refine/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: idea-refine
-description: Refines ideas iteratively. Refine ideas through structured divergent and convergent thinking. Use "idea-refine" or "ideate" to trigger.
+description: Clarifies and refines ideas before implementation. Use when starting any new work, when requirements are vague, or when you need to turn a fuzzy concept into actionable tasks.
+context: fork
+agent: Plan
 ---
 
 # Idea Refine

--- a/skills/incremental-implementation/SKILL.md
+++ b/skills/incremental-implementation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: incremental-implementation
 description: Delivers changes incrementally. Use when implementing any feature or change that touches more than one file. Use when you're about to write a large amount of code at once, or when a task feels too big to land in one step.
+context: fork
 ---
 
 # Incremental Implementation

--- a/skills/incremental-implementation/SKILL.md
+++ b/skills/incremental-implementation/SKILL.md
@@ -208,6 +208,8 @@ After each increment, verify:
 - [ ] The new functionality works as expected
 - [ ] The change is committed with a descriptive message
 
+**Note:** Run verification commands once per increment. If a command succeeds with no output or errors, do not repeat it. Redundant verification wastes time and provides no additional value.
+
 ## Common Rationalizations
 
 | Rationalization | Reality |
@@ -217,6 +219,7 @@ After each increment, verify:
 | "These changes are too small to commit separately" | Small commits are free. Large commits hide bugs and make rollbacks painful. |
 | "I'll add the feature flag later" | If the feature isn't complete, it shouldn't be user-visible. Add the flag now. |
 | "This refactor is small enough to include" | Refactors mixed with features make both harder to review and debug. Separate them. |
+| "Let me run the build command again just to be sure" | If a command succeeded with no errors, running it again provides no additional value. Trust the first successful run. |
 
 ## Red Flags
 
@@ -229,6 +232,7 @@ After each increment, verify:
 - Building abstractions before the third use case demands it
 - Touching files outside the task scope "while I'm here"
 - Creating new utility files for one-time operations
+- Running the same build/test command multiple times after a successful run
 
 ## Verification
 

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: performance-optimization
-description: Optimizes application performance. Use when performance requirements exist, when you suspect performance regressions, or when Core Web Vitals or load times need improvement. Use when profiling reveals bottlenecks that need fixing.
+description: Optimizes code for performance and efficiency. Use when experiencing slow performance, high resource usage, or when you need to improve response times and scalability. Use when profiling reveals bottlenecks.
+context: fork
 ---
 
 # Performance Optimization

--- a/skills/planning-and-task-breakdown/SKILL.md
+++ b/skills/planning-and-task-breakdown/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: planning-and-task-breakdown
-description: Breaks work into ordered tasks. Use when you have a spec or clear requirements and need to break work into implementable tasks. Use when a task feels too large to start, when you need to estimate scope, or when parallel work is possible.
+description: Breaks work into small verifiable tasks. Use when starting any complex project, when a task feels too big to tackle directly, or when you need to create a structured plan before implementation.
+context: fork
+agent: Plan
 ---
 
 # Planning and Task Breakdown

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: security-and-hardening
-description: Hardens code against vulnerabilities. Use when handling user input, authentication, data storage, or external integrations. Use when building any feature that accepts untrusted data, manages user sessions, or interacts with third-party services.
+description: Implements security best practices and hardens code against common vulnerabilities. Use when handling user input, authentication, data storage, or deploying to production. Use when you need to ensure code follows security standards.
+context: fork
 ---
 
 # Security and Hardening

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: shipping-and-launch
-description: Prepares production launches. Use when preparing to deploy to production. Use when you need a pre-launch checklist, when setting up monitoring, when planning a staged rollout, or when you need a rollback strategy.
+description: Manages production deployment and launch processes. Use when deploying to production, launching new features, or when you need to ensure safe, reliable releases. Use when you need to coordinate launch activities and monitor production health.
+context: fork
 ---
 
 # Shipping and Launch

--- a/skills/spec-driven-development/SKILL.md
+++ b/skills/spec-driven-development/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: spec-driven-development
-description: Creates specs before coding. Use when starting a new project, feature, or significant change and no specification exists yet. Use when requirements are unclear, ambiguous, or only exist as a vague idea.
+description: Writes structured specifications before implementation. Use when starting any new project, feature, or when requirements need clarification. Use when you need to align stakeholders on what will be built.
+context: fork
+agent: Plan
 ---
 
 # Spec-Driven Development

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -356,6 +356,7 @@ For detailed testing patterns, examples, and anti-patterns across frameworks, se
 | "I tested it manually" | Manual testing doesn't persist. Tomorrow's change might break it with no way to know. |
 | "The code is self-explanatory" | Tests ARE the specification. They document what the code should do, not what it does. |
 | "It's just a prototype" | Prototypes become production code. Tests from day one prevent the "test debt" crisis. |
+| "Let me run the tests again just to be extra sure" | If tests passed cleanly, running them again provides no additional confidence. Trust the first successful run. |
 
 ## Red Flags
 
@@ -366,6 +367,7 @@ For detailed testing patterns, examples, and anti-patterns across frameworks, se
 - Tests that test framework behavior instead of application behavior
 - Test names that don't describe the expected behavior
 - Skipping tests to make the suite pass
+- Running the same test command multiple times after a successful run
 
 ## Verification
 
@@ -377,3 +379,5 @@ After completing any implementation:
 - [ ] Test names describe the behavior being verified
 - [ ] No tests were skipped or disabled
 - [ ] Coverage hasn't decreased (if tracked)
+
+**Note:** Run test commands once per implementation cycle. If tests pass cleanly, do not repeat the same test command. Redundant test runs waste time and provide no additional confidence.

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-driven-development
 description: Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior. Use when you need to prove that code works, when a bug report arrives, or when you're about to modify existing functionality.
+context: fork
 ---
 
 # Test-Driven Development

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: using-agent-skills
-description: Discovers and invokes agent skills. Use when starting a session or when you need to discover which skill applies to the current task. This is the meta-skill that governs how all other skills are discovered and invoked.
+description: Meta-skill for discovering and using agent-skills effectively. Use when you need to understand how skills work, when to use which skill, or when you need to coordinate multiple skills. Use when you're new to agent-skills or need guidance on skill selection.
+context: fork
 ---
 
 # Using Agent Skills


### PR DESCRIPTION
Fixes #50

## Changes
- Update spec command to save specs to docs/features/[feature-name]/spec.md
- Update plan command to read specs from and save plans to feature directories
- Update getting-started documentation to reflect new directory structure
- Enable multiple simultaneous features without overwriting artifacts

## New Directory Structure
docs/features/[feature-name]/
  - spec.md     # Feature specification
  - plan.md     # Implementation plan
  - todo.md     # Task list

## Benefits
- Prevents spec overwriting when working on multiple features
- Enables simultaneous feature development
- Organizes all feature artifacts in one location
- Maintains backward compatibility with existing workflows

## Implementation Details
- Feature name derived from objective (e.g., 'user-authentication')
- Commands updated to use feature-specific paths
- Documentation updated to reflect new structure
- Maintains existing skill workflows while improving organization