### PR TITLE
Add citation cache to source-driven-development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .env.*
 *.log
 .claude/.simplify-ignore-cache/
+.claude/sdd-citations.md

--- a/skills/source-driven-development/SKILL.md
+++ b/skills/source-driven-development/SKILL.md
@@ -27,12 +27,13 @@ Every framework-specific code decision must be backed by official documentation.
 ## The Process
 
 ```
-DETECT ──→ FETCH ──→ IMPLEMENT ──→ CITE
-  │          │           │            │
-  ▼          ▼           ▼            ▼
- What       Get the    Follow the   Show your
- stack?     relevant   documented   sources
-            docs       patterns
+DETECT ──→ RECALL ──→ FETCH ──→ IMPLEMENT ──→ CITE + CACHE
+  │          │          │           │              │
+  ▼          ▼          ▼           ▼              ▼
+ What       Cache      Get the     Follow the    Show your
+ stack?     hit?       relevant    documented    sources and
+            Skip       docs        patterns      append the
+            fetch                                citation
 ```
 
 ### Step 1: Detect Stack and Versions
@@ -60,9 +61,11 @@ STACK DETECTED:
 
 If versions are missing or ambiguous, **ask the user**. Don't guess — the version determines which patterns are correct.
 
-### Step 2: Fetch Official Documentation
+### Step 2: Check the Citation Cache, Then Fetch
 
-Fetch the specific documentation page for the feature you're implementing. Not the homepage, not the full docs — the relevant page.
+**Check the cache first.** Read `.claude/sdd-citations.md` if it exists. If it contains a row matching `framework + version + pattern` for the exact version detected in Step 1, reuse that citation and skip the fetch. Match is **strict**: `react@19.1` does not satisfy `react@19.0`. See the Citation Cache Protocol section below for the format and lookup rules.
+
+If no cache hit, fetch the specific documentation page for the feature you're implementing. Not the homepage, not the full docs — the relevant page.
 
 **Source hierarchy (in order of authority):**
 
@@ -159,6 +162,46 @@ Verify before using in production.
 
 Honesty about what you couldn't verify is more valuable than false confidence.
 
+**Append to the cache.** After citing a fresh fetch, append a row to `.claude/sdd-citations.md` (create the file if missing). One row per `(framework, version, pattern)` triple. See the Citation Cache Protocol below.
+
+## Citation Cache Protocol
+
+A single markdown file at `.claude/sdd-citations.md` acts as the verified-citation cache. It is gitignored by default — opt in to commit only if your team wants a shared cache. The agent reads and writes it directly with Read and Edit; no scripts, no tooling.
+
+### Format
+
+Append-only markdown table, one row per verified citation:
+
+```markdown
+# SDD Citation Cache
+
+| framework | version | pattern | url | verified_at | notes |
+|---|---|---|---|---|---|
+| react | 19.1 | useActionState | https://react.dev/reference/react/useActionState#usage | 2026-04-14 | replaces manual isPending |
+| django | 6.0 | auth-middleware | https://docs.djangoproject.com/en/6.0/topics/auth/ | 2026-04-10 | |
+```
+
+**Field rules:**
+
+- `framework`: lowercase canonical name (`react`, not `React` or `reactjs`)
+- `version`: `major.minor` from the dependency file (`19.1`, not `^19.1.0`)
+- `pattern`: short slug for the feature (`useActionState`, `auth-middleware`, `form-actions`)
+- `url`: full URL with anchor where possible
+- `verified_at`: ISO date `YYYY-MM-DD` from the day of the fetch
+- `notes`: one-line free text — deprecations, version-specific caveats, or empty
+
+### Lookup rules
+
+- Match is **strict** on `framework + version + pattern`. Approximate matches are not hits.
+- If the dependency file shows a newer version than any cached row, the cache is invalidated for that pattern — re-fetch and append a new row.
+- If the user reports a cached citation is wrong, **delete the row**. Do not patch cached citations in place — re-verify and re-add.
+
+### What NOT to put in the cache
+
+- Citations from non-authoritative sources (the source hierarchy in Step 2 still applies)
+- Patterns flagged as `UNVERIFIED` in Step 4
+- Project-specific code snippets — the cache is for *citations*, not implementations
+
 ## Common Rationalizations
 
 | Rationalization | Reality |
@@ -168,6 +211,7 @@ Honesty about what you couldn't verify is more valuable than false confidence.
 | "The docs won't have what I need" | If the docs don't cover it, that's valuable information — the pattern may not be officially recommended. |
 | "I'll just mention it might be outdated" | A disclaimer doesn't help. Either verify and cite, or clearly flag it as unverified. Hedging is the worst option. |
 | "This is a simple task, no need to check" | Simple tasks with wrong patterns become templates. The user copies your deprecated form handler into ten components before discovering the modern approach exists. |
+| "I'll re-fetch even though it's cached, just to be safe" | If `framework + version + pattern` matches a cached row, the doc has not changed for that pattern. Re-fetching wastes tokens and time. The cache exists so you verify *once* per version, not every session. If you don't trust the cache, delete the row — don't bypass it. |
 
 ## Red Flags
 
@@ -179,6 +223,10 @@ Honesty about what you couldn't verify is more valuable than false confidence.
 - Not reading `package.json` / dependency files before implementing
 - Delivering code without source citations for framework-specific decisions
 - Fetching an entire docs site when only one page is relevant
+- Fetching docs without first checking `.claude/sdd-citations.md` for the same `framework + version + pattern`
+- Caching a citation from a non-authoritative source
+- Treating `react@19.0` and `react@19.1` as equivalent cache hits (version match must be strict)
+- Patching a cached row in place after the user flags it as wrong (delete and re-verify instead)
 
 ## Verification
 
@@ -192,3 +240,6 @@ After implementing with source-driven development:
 - [ ] No deprecated APIs are used (checked against migration guides)
 - [ ] Conflicts between docs and existing code were surfaced to the user
 - [ ] Anything that could not be verified is explicitly flagged as unverified
+- [ ] `.claude/sdd-citations.md` was checked before any documentation fetch
+- [ ] Every fresh fetch resulted in an appended cache row with full `framework + version + pattern + url + verified_at` fields
+- [ ] No cached citation was reused when the dependency version no longer matches


### PR DESCRIPTION
## Why

source-driven-development is about grounding every framework decision in official docs, not memory. But that means every session re-fetches the same React 19 form handler docs, the same Django auth patterns. It works, but it's repetitive.

This PR adds a simple idea: write down what you've verified, so the next session can look it up instead of re-verifying.

## How it works

When the agent implements a feature, it now:
1. Checks `.claude/sdd-citations.md` — have we already verified React 19 useActionState?
2. If yes (and the version matches), reuse the citation and skip the fetch
3. If no, fetch as usual, then add a row to the cache

The cache is a simple markdown table with columns: framework, version, pattern, url, verified_at, notes.

**Who sees it?** By default, gitignored and private per developer. But teams can opt in to commit it for a shared audit trail of what's been verified.

## Example

Your project uses React 19.1. First implementation of a form pattern:
- Fetch react.dev/reference/react/useActionState — 5 tokens, cache the result

Next session, same project:
- Check `.claude/sdd-citations.md` — find the row — reuse the citation, skip fetch
- Result: 0 tokens wasted on repeat verification

## Changes

- **Step 2 (Fetch)** now has a cache-check substep before any documentation fetch
- **Step 4 (Cite)** now records the citation to the cache
- **New section** "Citation Cache Protocol" with format, strict lookup rules, and what not to cache
- **Rationalization** for "re-fetching just to be safe" (don't bypass a cache you don't trust — delete the row and re-verify instead)
- **Red flags** for cache misuse (approximate version matching, caching non-authoritative sources, patching rows in place)
- **.gitignore** updated to ignore the cache by default

## Testing

Any implementation using source-driven-development will now:
1. Read `.claude/sdd-citations.md` before any fetch (creates it if missing)
2. Add a row after each successful fetch
3. Verify strict version matching (react@19.0 and react@19.1 are separate entries)