### PR TITLE
docs: align skill contribution guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for your interest in contributing! This project is a collection of produc
 1. Create a directory under `skills/` with a kebab-case name
 2. Add a `SKILL.md` following the format in [docs/skill-anatomy.md](docs/skill-anatomy.md)
 3. Include YAML frontmatter with `name` and `description` fields
-4. Ensure the `description` briefly says what the skill does in third person, then includes clear "Use when" trigger conditions
+4. Ensure the `description` briefly says what the skill does (third person), then includes `Use when` trigger conditions
 
 ### Skill Quality Bar
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for your interest in contributing! This project is a collection of produc
 1. Create a directory under `skills/` with a kebab-case name
 2. Add a `SKILL.md` following the format in [docs/skill-anatomy.md](docs/skill-anatomy.md)
 3. Include YAML frontmatter with `name` and `description` fields
-4. Ensure the `description` briefly says what the skill does, then includes clear "Use when" trigger conditions
+4. Ensure the `description` briefly says what the skill does in third person, then includes clear "Use when" trigger conditions
 
 ### Skill Quality Bar
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for your interest in contributing! This project is a collection of produc
 1. Create a directory under `skills/` with a kebab-case name
 2. Add a `SKILL.md` following the format in [docs/skill-anatomy.md](docs/skill-anatomy.md)
 3. Include YAML frontmatter with `name` and `description` fields
-4. Ensure the `description` starts with "Use when" and describes triggering conditions
+4. Ensure the `description` briefly says what the skill does, then includes clear "Use when" trigger conditions
 
 ### Skill Quality Bar
 
@@ -20,7 +20,12 @@ Skills should be:
 
 ### Structure
 
-Every skill should include these sections:
+Every new skill must have:
+
+- `SKILL.md` in the skill directory
+- YAML frontmatter with valid `name` and `description`
+
+New skills should generally follow the standard anatomy:
 
 - **Overview** — What this skill does and why it matters
 - **When to Use** — Triggering conditions

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Every skill follows a consistent anatomy:
 │  │ name: lowercase-hyphen-name               │  │
 │  │ description: Guides agents through [task].│  │
 │  │              Use when…                    │  │
-│  └───────────────────────────────────────────┘  │                                                                                                
+│  └───────────────────────────────────────────┘  │
 │  Overview         → What this skill does        │
 │  When to Use      → Triggering conditions       │
 │  Process          → Step-by-step workflow       │

--- a/README.md
+++ b/README.md
@@ -207,24 +207,24 @@ Quick-reference material that skills pull in when needed:
 
 ## How Skills Work
 
-Most skills follow a consistent anatomy:
+Every skill follows a consistent anatomy:
 
 ```
-┌─────────────────────────────────────────────┐
-│  SKILL.md                                   │
-│                                             │
-│  ┌─ Frontmatter ─────────────────────────┐  │
-│  │ name: lowercase-hyphen-name           │  │
-│  │ description: What it does. Use when…  │  │
-│  └───────────────────────────────────────┘  │
-│                                             │
-│  Overview         → What this skill does    │
-│  When to Use      → Triggering conditions   │
-│  Process          → Step-by-step workflow   │
-│  Rationalizations → Excuses + rebuttals     │
-│  Red Flags        → Signs something's wrong │
-│  Verification     → Evidence requirements   │
-└─────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────┐
+│  SKILL.md                                       │
+│                                                 │
+│  ┌─ Frontmatter ─────────────────────────────┐  │
+│  │ name: lowercase-hyphen-name               │  │
+│  │ description: Guides agents through [task].│  │
+│  │              Use when…                    │  │
+│  └───────────────────────────────────────────┘  │                                                                                                
+│  Overview         → What this skill does        │
+│  When to Use      → Triggering conditions       │
+│  Process          → Step-by-step workflow       │
+│  Rationalizations → Excuses + rebuttals         │
+│  Red Flags        → Signs something's wrong     │
+│  Verification     → Evidence requirements       │
+└─────────────────────────────────────────────────┘
 ```
 
 **Key design choices:**

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Every skill follows a consistent anatomy:
 │  │ name: lowercase-hyphen-name               │  │
 │  │ description: Guides agents through [task].│  │
 │  │              Use when…                    │  │
-│  └───────────────────────────────────────────┘  │
+│  └───────────────────────────────────────────┘  │                                                                                                
 │  Overview         → What this skill does        │
 │  When to Use      → Triggering conditions       │
 │  Process          → Step-by-step workflow       │

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Quick-reference material that skills pull in when needed:
 
 ## How Skills Work
 
-Every skill follows a consistent anatomy:
+Most skills follow a consistent anatomy:
 
 ```
 ┌─────────────────────────────────────────────┐
@@ -215,7 +215,7 @@ Every skill follows a consistent anatomy:
 │                                             │
 │  ┌─ Frontmatter ─────────────────────────┐  │
 │  │ name: lowercase-hyphen-name           │  │
-│  │ description: Use when [trigger]       │  │
+│  │ description: What it does. Use when…  │  │
 │  └───────────────────────────────────────┘  │
 │                                             │
 │  Overview         → What this skill does    │

--- a/docs/skill-anatomy.md
+++ b/docs/skill-anatomy.md
@@ -20,13 +20,13 @@ skills/
 ```yaml
 ---
 name: skill-name-with-hyphens
-description: Brief statement of what the skill does. Use when [specific trigger conditions].
+description: Guides agents through [task/workflow]. Use when [specific trigger conditions].
 ---
 ```
 
 **Rules:**
 - `name`: Lowercase, hyphen-separated. Must match the directory name.
-- `description`: Start with what the skill does, then include one or more clear "Use when" trigger conditions. Include both *what* and *when*. Maximum 1024 characters.
+- `description`: Start with what the skill does in third person, then include one or more clear "Use when" trigger conditions. Include both *what* and *when*. Maximum 1024 characters.
 
 **Why this matters:** Agents discover skills by reading descriptions. The description is injected into the system prompt, so it must tell the agent both what the skill provides and when to activate it. Do not summarize the workflow — if the description contains process steps, the agent may follow the summary instead of reading the full skill.
 
@@ -90,28 +90,6 @@ Observable signs that the skill is being violated. Useful during code review and
 
 ### Verification
 The exit criteria. A checklist the agent uses to confirm the skill's process is complete. Every checkbox should be verifiable with evidence (test output, build result, screenshot, etc.).
-
-## Required vs Recommended
-
-Required:
-
-- A skill directory under `skills/`
-- A `SKILL.md` file
-- Valid frontmatter with `name` and `description`
-
-Recommended for new contributions:
-
-- Follow the standard section anatomy above unless there is a clear reason not to
-- `# Skill Title`
-- `## Overview`
-- `## When to Use`
-- A clearly named workflow section such as `## Process`, `## The Workflow`, or `## Steps`
-- `## Common Rationalizations`
-- `## Red Flags`
-- `## Verification`
-- Add supporting files only when they keep `SKILL.md` focused
-
-This is the common project pattern, but not every existing skill uses the exact same section names or layout.
 
 ## Supporting Files
 

--- a/docs/skill-anatomy.md
+++ b/docs/skill-anatomy.md
@@ -9,7 +9,7 @@ Every skill lives in its own directory under `skills/`:
 ```
 skills/
   skill-name/
-    SKILL.md          # Required: The skill definition
+    SKILL.md           # Required: The skill definition
     supporting-file.md # Optional: Reference material loaded on demand
 ```
 
@@ -26,11 +26,11 @@ description: Brief statement of what the skill does. Use when [specific trigger 
 
 **Rules:**
 - `name`: Lowercase, hyphen-separated. Must match the directory name.
-- `description`: Starts with what the skill does (third person), followed by trigger conditions. Include both *what* and *when*. Maximum 1024 characters.
+- `description`: Start with what the skill does, then include one or more clear "Use when" trigger conditions. Include both *what* and *when*. Maximum 1024 characters.
 
 **Why this matters:** Agents discover skills by reading descriptions. The description is injected into the system prompt, so it must tell the agent both what the skill provides and when to activate it. Do not summarize the workflow — if the description contains process steps, the agent may follow the summary instead of reading the full skill.
 
-### Standard Sections
+### Standard Sections (Recommended Pattern)
 
 ```markdown
 # Skill Title
@@ -90,6 +90,28 @@ Observable signs that the skill is being violated. Useful during code review and
 
 ### Verification
 The exit criteria. A checklist the agent uses to confirm the skill's process is complete. Every checkbox should be verifiable with evidence (test output, build result, screenshot, etc.).
+
+## Required vs Recommended
+
+Required:
+
+- A skill directory under `skills/`
+- A `SKILL.md` file
+- Valid frontmatter with `name` and `description`
+
+Recommended for new contributions:
+
+- Follow the standard section anatomy above unless there is a clear reason not to
+- `# Skill Title`
+- `## Overview`
+- `## When to Use`
+- A clearly named workflow section such as `## Process`, `## The Workflow`, or `## Steps`
+- `## Common Rationalizations`
+- `## Red Flags`
+- `## Verification`
+- Add supporting files only when they keep `SKILL.md` focused
+
+This is the common project pattern, but not every existing skill uses the exact same section names or layout.
 
 ## Supporting Files
 


### PR DESCRIPTION
This PR makes the skill contribution guidance more consistent for first-time contributors.

Changes:
- aligns the guidance for the `description` field between `CONTRIBUTING.md` and `docs/skill-anatomy.md`
- clarifies what is required vs recommended in the skill anatomy
- fixes related misleading documentation wording where needed

Why:
There was some ambiguity between the contribution guide and the skill anatomy guide, which made new skill submissions harder to format consistently.

This PR is intentionally small and documentation-only.