### PR TITLE
docs(frontend-ui): prevent page scroll in custom button example

### DIFF
--- a/skills/frontend-ui-engineering/SKILL.md
+++ b/skills/frontend-ui-engineering/SKILL.md
@@ -174,8 +174,11 @@ Every component must meet these standards:
 <div onClick={handleClick}>Click me</div>               // ✗ Not focusable
 <div role="button" tabIndex={0} onClick={handleClick}    // ✓ But prefer <button>
      onKeyDown={e => {
+       if (e.key === 'Enter') handleClick();
        if (e.key === ' ') e.preventDefault();
-       if (e.key === 'Enter' || e.key === ' ') handleClick();
+     }}
+     onKeyUp={e => {
+       if (e.key === ' ') handleClick();
      }}>
   Click me
 </div>

--- a/skills/frontend-ui-engineering/SKILL.md
+++ b/skills/frontend-ui-engineering/SKILL.md
@@ -173,7 +173,10 @@ Every component must meet these standards:
 <button onClick={handleClick}>Click me</button>        // ✓ Focusable by default
 <div onClick={handleClick}>Click me</div>               // ✗ Not focusable
 <div role="button" tabIndex={0} onClick={handleClick}    // ✓ But prefer <button>
-     onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && handleClick()}>
+     onKeyDown={e => {
+       if (e.key === ' ') e.preventDefault();
+       if (e.key === 'Enter' || e.key === ' ') handleClick();
+     }}>
   Click me
 </div>
 ```


### PR DESCRIPTION
## Summary

Prevent page scroll in the custom button keyboard example by calling `e.preventDefault()` for `Space` before triggering `handleClick()`.

## Problem

PR #58 correctly added `Space` activation to the non-native button example, but the current snippet still allows the browser's default `Space` action on a custom `role="button"` element.

That means the example can both:
- activate the handler, and
- scroll the page

In a local browser reproduction of the current pattern:
- one `Space` press triggered the click handler once
- `window.scrollY` changed from `0` to `660`

With the updated snippet in this PR:
- one `Space` press still triggered the click handler once
- `window.scrollY` stayed at `0`

## Fix

Keep the change docs-only and limited to the existing example in `skills/frontend-ui-engineering/SKILL.md`.

The updated snippet:
- prevents the default `Space` action on the custom button
- preserves `Enter` and `Space` activation behavior
- stays aligned with the accessibility intent of the skill

## Verification

- Local WKWebView/browser reproduction of the current snippet
- Local WKWebView/browser reproduction of the patched snippet
- `git diff --check`

Closes #78
