### PR TITLE
feat(hooks): opt-in citation cache for source-driven-development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .env.*
 *.log
 .claude/.simplify-ignore-cache/
+.claude/sdd-cache/

--- a/hooks/SDD-CACHE.md
+++ b/hooks/SDD-CACHE.md
@@ -50,21 +50,26 @@ This hook caches fetched content on disk, but **revalidates with the origin serv
 
 3. Use `/source-driven-development` (or the skill) as usual. No changes to the skill or the agent's workflow — the cache is transparent.
 
+## Mental model
+
+HTTP resource cache keyed by URL. Freshness is delegated to the origin via `ETag` / `Last-Modified`; no TTL, no prompt in the key.
+
+The stored body is not raw HTML — `WebFetch` post-processes each response through a model using the caller's prompt, so what we cache is one agent's reading of the page. The key stays URL-only so reads reuse across sessions; the original prompt is kept as metadata and surfaced in the hit message so the next agent can tell whether the earlier reading fits.
+
 ## How it works
 
-One cache entry per `(url, prompt)` pair, stored as JSON in `.claude/sdd-cache/<sha>.json`:
+One cache entry per URL, stored as JSON in `.claude/sdd-cache/<sha>.json`:
 
 | Event | Action |
 |---|---|
-| `PreToolUse WebFetch` | If an entry exists, sends a `HEAD` request with `If-None-Match` / `If-Modified-Since`. On `304`, blocks the fetch and returns the cached content to the agent via stderr. Otherwise allows the fetch. |
+| `PreToolUse WebFetch` | If an entry exists, sends a `HEAD` request with `If-None-Match` / `If-Modified-Since`. On `304`, blocks the fetch and returns the cached content to the agent via stderr, with the original prompt surfaced as metadata. Otherwise allows the fetch. |
 | `PostToolUse WebFetch` | Captures the response, issues a `HEAD` request to record the current `ETag` / `Last-Modified`, and stores `{url, prompt, etag, last_modified, content, fetched_at}`. |
 
 **Freshness rules:**
 
 - Entry is served only if the origin confirms `304 Not Modified`.
 - Entries without an `ETag` or `Last-Modified` header are never cached — without a validator, the hook cannot verify freshness later, and caching would mean trusting memory.
-- A hard 24-hour TTL bypasses the cache regardless, as a safety net against misbehaving servers.
-- Cache key is `sha256(url + normalized_prompt)`: the same URL asked with a different question is a separate entry. Prompts are normalized (lowercased, whitespace collapsed) before hashing, so stylistic variants like `"Extract the signature"` and `"extract   the\nsignature"` hit the same entry. Semantically different prompts still miss.
+- Cache key is `sha256(url)`. The same URL asked with a different prompt hits the same entry; the cached body reflects the prompt used on the first fetch, and that prompt is shown alongside the hit so the agent can decide whether to re-use or re-fetch manually.
 
 **What the agent sees:**
 
@@ -144,13 +149,14 @@ mkdir -p .claude/sdd-cache && touch .claude/sdd-cache/.debug
 # …disable with: rm .claude/sdd-cache/.debug
 ```
 
-The log captures URL, prompt excerpt, detected `tool_response` shape, HEAD status, and why each invocation hit / missed / bypassed the cache. Useful when a cache miss looks unexpected (typically: the origin stopped emitting validators, or the `(url, prompt)` pair differs by a whitespace).
+The log captures URL, detected `tool_response` shape, HEAD status, and why each invocation hit or missed. Useful when a cache miss looks unexpected (typically: the origin stopped emitting validators).
 
 ## Known limitations
 
-- **WebFetch output is prompt-dependent.** The same URL queried with a different prompt produces different output; the cache keys on `(url, prompt)` to handle this. Cache hit rate depends on the agent reusing the same prompt wording across sessions.
+- **Body is prompt-shaped.** A hit returns the earlier agent's reading of the page, with the original prompt surfaced so the current agent can decide whether it applies. If it doesn't, delete the file under `.claude/sdd-cache/` to force a re-fetch.
+- **Every cache write costs an extra HEAD.** Claude Code doesn't expose the response headers that `WebFetch` already received, so the post hook re-queries the origin to capture `ETag` / `Last-Modified`. One extra roundtrip per miss — the price of keeping this a pure hook with no core changes.
 - **Servers without `ETag` or `Last-Modified` are never cached.** Most official doc sites (react.dev, docs.djangoproject.com, developer.mozilla.org) emit validators. Sites that don't are always re-fetched.
-- **A misbehaving server can serve a wrong `304`.** The 24-hour TTL limits the damage. If a doc changes and the server incorrectly reports it unchanged, the stale entry expires within a day.
+- **A misbehaving server can serve a wrong `304`.** That's a server bug to diagnose, not a cache invariant to defend against; we don't paper over it with a TTL. Delete the entry if you spot a stale one.
 - **Cache is local and per-project.** There is no team-wide shared cache. Adding one would require a signed-content-addressable storage layer, which is out of scope.
 
 ## Requirements

--- a/hooks/SDD-CACHE.md
+++ b/hooks/SDD-CACHE.md
@@ -1,0 +1,161 @@
+# sdd-cache hook
+
+Cross-session citation cache for [`source-driven-development`](../skills/source-driven-development/SKILL.md). Skips redundant `WebFetch` calls without weakening the skill's "verify against current docs" guarantee.
+
+## Why
+
+`source-driven-development` fetches official docs for every framework-specific decision. Working on the same project across sessions means fetching the same pages over and over. Caching the content as local memory would contradict the skill — docs change, and a stale cache hides that.
+
+This hook caches fetched content on disk, but **revalidates with the origin server on every reuse** via HTTP `If-None-Match` / `If-Modified-Since`. Content is only served from cache when the server responds `304 Not Modified`, which is a fresh verification — not a memory read.
+
+## Setup
+
+1. Add hooks to `.claude/settings.json` (or `.claude/settings.local.json` for personal use):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/hooks/sdd-cache-pre.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PROJECT_DIR}/hooks/sdd-cache-post.sh",
+            "async": true,
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+   `${CLAUDE_PROJECT_DIR}` resolves to the directory you launched Claude Code from. The snippet above works when the hooks live inside the same project. If you installed `agent-skills` elsewhere (e.g. as a shared plugin under `~/agent-skills`), replace `${CLAUDE_PROJECT_DIR}/hooks/...` with the absolute path to each script.
+
+2. Make sure `.claude/sdd-cache/` is in your `.gitignore` (already included in this repo).
+
+3. Use `/source-driven-development` (or the skill) as usual. No changes to the skill or the agent's workflow — the cache is transparent.
+
+## How it works
+
+One cache entry per `(url, prompt)` pair, stored as JSON in `.claude/sdd-cache/<sha>.json`:
+
+| Event | Action |
+|---|---|
+| `PreToolUse WebFetch` | If an entry exists, sends a `HEAD` request with `If-None-Match` / `If-Modified-Since`. On `304`, blocks the fetch and returns the cached content to the agent via stderr. Otherwise allows the fetch. |
+| `PostToolUse WebFetch` | Captures the response, issues a `HEAD` request to record the current `ETag` / `Last-Modified`, and stores `{url, prompt, etag, last_modified, content, fetched_at}`. |
+
+**Freshness rules:**
+
+- Entry is served only if the origin confirms `304 Not Modified`.
+- Entries without an `ETag` or `Last-Modified` header are never cached — without a validator, the hook cannot verify freshness later, and caching would mean trusting memory.
+- A hard 24-hour TTL bypasses the cache regardless, as a safety net against misbehaving servers.
+- Cache key is `sha256(url + normalized_prompt)`: the same URL asked with a different question is a separate entry. Prompts are normalized (lowercased, whitespace collapsed) before hashing, so stylistic variants like `"Extract the signature"` and `"extract   the\nsignature"` hit the same entry. Semantically different prompts still miss.
+
+**What the agent sees:**
+
+- Cache hit: `WebFetch` is blocked via exit code 2. Claude Code delivers the hook's stderr payload back to the agent as a tool error — this is the intended signal for a cache hit, not a failure. The payload is prefixed with `[sdd-cache] Cache hit for <url>` and wraps the cached body between `----- BEGIN CACHED CONTENT -----` / `----- END CACHED CONTENT -----` markers so the agent can use it as if `WebFetch` had just returned it.
+- Cache miss or stale: `WebFetch` runs normally; the result is stored for next time.
+
+The skill itself is unchanged. It continues to follow `DETECT → FETCH → IMPLEMENT → CITE`. The hook only changes what happens under the hood when `FETCH` runs.
+
+## Local testing
+
+### 1. Smoke test the scripts directly
+
+```bash
+# Simulate a PostToolUse payload: cache a page
+echo '{
+  "tool_input": {
+    "url": "https://react.dev/reference/react/useActionState",
+    "prompt": "extract the signature"
+  },
+  "tool_response": "useActionState(action, initialState) returns [state, formAction, isPending]"
+}' | bash hooks/sdd-cache-post.sh
+
+# Inspect the stored entry
+ls .claude/sdd-cache/
+cat .claude/sdd-cache/*.json | jq .
+
+# Simulate the next PreToolUse on the same URL + prompt
+echo '{
+  "tool_input": {
+    "url": "https://react.dev/reference/react/useActionState",
+    "prompt": "extract the signature"
+  }
+}' | bash hooks/sdd-cache-pre.sh
+echo "exit=$?"
+```
+
+Expected:
+
+- First command creates one file under `.claude/sdd-cache/` (only if the server returned an `ETag` or `Last-Modified`).
+- Second command exits `2` with the cached content on stderr when the origin replies `304`, or exits `0` silently otherwise.
+
+### 2. End-to-end in a real session
+
+1. Register the hooks in `.claude/settings.local.json` as shown above.
+2. Start a Claude Code session in this repo.
+3. Ask the agent to fetch a documentation page (e.g. "fetch `https://react.dev/reference/react/useActionState` and summarize").
+4. Verify a file appears under `.claude/sdd-cache/`.
+5. Ask the agent to fetch the same page with the same prompt again.
+6. Verify the second `WebFetch` is blocked and the cached content is returned (visible in the session transcript as a tool error with `[sdd-cache]` prefix).
+
+### 3. Freshness verification
+
+To confirm the cache invalidates when docs change, force an `ETag` mismatch. Pick one specific entry — `*.json` is unsafe once the cache holds more than one file:
+
+```bash
+# Pick the entry you want to corrupt (swap in the actual filename)
+ENTRY=.claude/sdd-cache/e49c9f378670cfbb1d7d871b6dee16d9.json
+
+# Patch its ETag to something the origin will not recognize
+jq '.etag = "W/\"stale-etag-forced\""' "$ENTRY" > "$ENTRY.tmp" && mv "$ENTRY.tmp" "$ENTRY"
+
+# Next PreToolUse should miss (server returns 200, not 304)
+echo '{"tool_input":{"url":"...", "prompt":"..."}}' | bash hooks/sdd-cache-pre.sh
+echo "exit=$?"   # expect 0 (fetch allowed through)
+```
+
+### 4. Debugging
+
+Both hooks write timestamped events to `.claude/sdd-cache/.debug.log` when debug mode is on. Enable it with either:
+
+```bash
+# Option A: env var (per-session)
+SDD_CACHE_DEBUG=1 claude
+
+# Option B: sentinel file (persistent)
+mkdir -p .claude/sdd-cache && touch .claude/sdd-cache/.debug
+# …disable with: rm .claude/sdd-cache/.debug
+```
+
+The log captures URL, prompt excerpt, detected `tool_response` shape, HEAD status, and why each invocation hit / missed / bypassed the cache. Useful when a cache miss looks unexpected (typically: the origin stopped emitting validators, or the `(url, prompt)` pair differs by a whitespace).
+
+## Known limitations
+
+- **WebFetch output is prompt-dependent.** The same URL queried with a different prompt produces different output; the cache keys on `(url, prompt)` to handle this. Cache hit rate depends on the agent reusing the same prompt wording across sessions.
+- **Servers without `ETag` or `Last-Modified` are never cached.** Most official doc sites (react.dev, docs.djangoproject.com, developer.mozilla.org) emit validators. Sites that don't are always re-fetched.
+- **A misbehaving server can serve a wrong `304`.** The 24-hour TTL limits the damage. If a doc changes and the server incorrectly reports it unchanged, the stale entry expires within a day.
+- **Cache is local and per-project.** There is no team-wide shared cache. Adding one would require a signed-content-addressable storage layer, which is out of scope.
+
+## Requirements
+
+- `jq`
+- `curl`
+- `shasum` or `sha256sum` (auto-detected)
+- Bash 3.2+

--- a/hooks/sdd-cache-post.sh
+++ b/hooks/sdd-cache-post.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
-# sdd-cache-post.sh — PostToolUse hook for WebFetch
+# sdd-cache-post.sh — PostToolUse hook for WebFetch.
 #
-# After a successful WebFetch, stores the fetched content in
-# .claude/sdd-cache/<sha>.json together with the server's ETag and/or
-# Last-Modified headers captured via a HEAD request. The Pre hook uses
-# those validators to revalidate on the next fetch.
+# After WebFetch, stores the response body in .claude/sdd-cache/<sha>.json
+# with the current ETag / Last-Modified captured via a HEAD request so the
+# pre hook can revalidate on the next fetch.
 #
-# The cache only stores entries for URLs whose servers emit ETag or
-# Last-Modified. Without a validator, the Pre hook cannot verify freshness,
-# so caching the entry would amount to trusting memory — exactly what the
-# skill forbids.
+# Keyed by URL. The caller's prompt is stored as metadata (not part of the
+# key) so a future cache hit can show what question produced the cached
+# reading. Entries without ETag or Last-Modified are not cached.
 #
-# Dependencies: jq, curl, shasum (or sha256sum)
+# Dependencies: jq, curl, shasum (or sha256sum).
 
 set -euo pipefail
 
@@ -65,36 +63,26 @@ if [ -z "$CONTENT" ]; then
 fi
 dbg "extracted content bytes=${#CONTENT}"
 
-# Cache key is (url + normalized prompt) — must match the Pre hook. See
-# sdd-cache-pre.sh for the rationale behind normalization.
-normalize_prompt() {
-  printf '%s' "$1" \
-    | tr '[:upper:]' '[:lower:]' \
-    | tr -s '[:space:]' ' ' \
-    | sed -e 's/^ //' -e 's/ $//'
-}
-
+# Must match the pre hook: sha256(URL), first 32 hex chars.
 hash_key() {
-  local norm
-  norm=$(normalize_prompt "$2")
-  local key="$1"$'\x1f'"$norm"
   if command -v shasum >/dev/null 2>&1; then
-    printf '%s' "$key" | shasum -a 256 | cut -c1-32
+    printf '%s' "$1" | shasum -a 256 | cut -c1-32
   else
-    printf '%s' "$key" | sha256sum | cut -c1-32
+    printf '%s' "$1" | sha256sum | cut -c1-32
   fi
 }
 
 CACHE_DIR="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
 mkdir -p "$CACHE_DIR"
-CACHE_FILE="$CACHE_DIR/$(hash_key "$URL" "$PROMPT").json"
+CACHE_FILE="$CACHE_DIR/$(hash_key "$URL").json"
 
-# Capture current validators from the origin. Follow redirects so the
-# validators match the URL the agent is actually talking to.
-HEAD_OUT=$(curl -sI -L --max-time 5 "$URL" 2>/dev/null || true)
+# Capture validators from the origin. Follow redirects so they match the
+# URL the agent actually talked to. Strip CR so awk's paragraph mode
+# recognises blank separators between response blocks on a redirect chain.
+HEAD_OUT=$(curl -sI -L --max-time 5 "$URL" 2>/dev/null | tr -d '\r' || true)
 
-# Parse only the headers of the final response (after last blank line),
-# to avoid picking up validators from intermediate 301/302 hops.
+# Take only the final response's headers (last paragraph) to avoid picking
+# up validators from intermediate 301/302 hops.
 FINAL_HEADERS=$(printf '%s' "$HEAD_OUT" | awk '
   BEGIN { RS = ""; last = "" }
   { last = $0 }
@@ -103,11 +91,10 @@ FINAL_HEADERS=$(printf '%s' "$HEAD_OUT" | awk '
 
 extract_header() {
   local name="$1"
-  printf '%s' "$FINAL_HEADERS" | awk -v IGNORECASE=1 -v h="$name" '
+  printf '%s' "$FINAL_HEADERS" | awk -v h="$name" '
     BEGIN { FS = ":" }
     tolower($1) == tolower(h) {
       sub(/^[^:]*:[ \t]*/, "")
-      gsub(/\r/, "")
       sub(/[ \t]+$/, "")
       print
       exit

--- a/hooks/sdd-cache-post.sh
+++ b/hooks/sdd-cache-post.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# sdd-cache-post.sh — PostToolUse hook for WebFetch
+#
+# After a successful WebFetch, stores the fetched content in
+# .claude/sdd-cache/<sha>.json together with the server's ETag and/or
+# Last-Modified headers captured via a HEAD request. The Pre hook uses
+# those validators to revalidate on the next fetch.
+#
+# The cache only stores entries for URLs whose servers emit ETag or
+# Last-Modified. Without a validator, the Pre hook cannot verify freshness,
+# so caching the entry would amount to trusting memory — exactly what the
+# skill forbids.
+#
+# Dependencies: jq, curl, shasum (or sha256sum)
+
+set -euo pipefail
+
+command -v jq   >/dev/null 2>&1 || exit 0
+command -v curl >/dev/null 2>&1 || exit 0
+command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 || exit 0
+
+if [ -t 0 ]; then INPUT="{}"; else INPUT=$(cat); fi
+
+# Debug logging: active when SDD_CACHE_DEBUG=1 is set, or when a sentinel
+# file exists at .claude/sdd-cache/.debug. Toggle with `touch` / `rm`.
+dbg() {
+  local dir="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
+  [ "${SDD_CACHE_DEBUG:-0}" = "1" ] || [ -f "$dir/.debug" ] || return 0
+  mkdir -p "$dir"
+  printf '%s [post] %s\n' "$(date -u +%FT%TZ)" "$*" >> "$dir/.debug.log"
+}
+dbg "fired, input=$(printf '%s' "$INPUT" | head -c 400)"
+
+URL=$(printf '%s'    "$INPUT" | jq -r '.tool_input.url    // empty' 2>/dev/null || true)
+PROMPT=$(printf '%s' "$INPUT" | jq -r '.tool_input.prompt // empty' 2>/dev/null || true)
+if [ -z "$URL" ]; then dbg "no url in tool_input, exit"; exit 0; fi
+dbg "url=$URL prompt=$(printf '%s' "$PROMPT" | head -c 80)"
+
+# WebFetch tool_response shape (Claude Code as of 2026-04): an object with
+# keys bytes, code, codeText, durationMs, result, url — content lives at
+# .result. The other keys (.output / .text / .content / .body) are kept as
+# defensive fallbacks in case the shape changes; jq returns empty if none
+# match. The string branch handles older/custom integrations.
+TOOL_RESPONSE_TYPE=$(printf '%s' "$INPUT" | jq -r '.tool_response | type' 2>/dev/null || echo "unknown")
+dbg "tool_response type=$TOOL_RESPONSE_TYPE keys=$(printf '%s' "$INPUT" | jq -r 'try (.tool_response | keys | join(",")) catch "n/a"' 2>/dev/null)"
+
+CONTENT=$(printf '%s' "$INPUT" | jq -r '
+  if (.tool_response | type) == "object" then
+    (.tool_response.result
+     // .tool_response.output
+     // .tool_response.text
+     // .tool_response.content
+     // .tool_response.body
+     // empty)
+  elif (.tool_response | type) == "string" then
+    .tool_response
+  else
+    empty
+  end
+' 2>/dev/null || true)
+
+if [ -z "$CONTENT" ]; then
+  dbg "could not extract content from tool_response, exit (shape unknown)"
+  exit 0
+fi
+dbg "extracted content bytes=${#CONTENT}"
+
+# Cache key is (url + normalized prompt) — must match the Pre hook. See
+# sdd-cache-pre.sh for the rationale behind normalization.
+normalize_prompt() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr -s '[:space:]' ' ' \
+    | sed -e 's/^ //' -e 's/ $//'
+}
+
+hash_key() {
+  local norm
+  norm=$(normalize_prompt "$2")
+  local key="$1"$'\x1f'"$norm"
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$key" | shasum -a 256 | cut -c1-32
+  else
+    printf '%s' "$key" | sha256sum | cut -c1-32
+  fi
+}
+
+CACHE_DIR="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
+mkdir -p "$CACHE_DIR"
+CACHE_FILE="$CACHE_DIR/$(hash_key "$URL" "$PROMPT").json"
+
+# Capture current validators from the origin. Follow redirects so the
+# validators match the URL the agent is actually talking to.
+HEAD_OUT=$(curl -sI -L --max-time 5 "$URL" 2>/dev/null || true)
+
+# Parse only the headers of the final response (after last blank line),
+# to avoid picking up validators from intermediate 301/302 hops.
+FINAL_HEADERS=$(printf '%s' "$HEAD_OUT" | awk '
+  BEGIN { RS = ""; last = "" }
+  { last = $0 }
+  END { print last }
+')
+
+extract_header() {
+  local name="$1"
+  printf '%s' "$FINAL_HEADERS" | awk -v IGNORECASE=1 -v h="$name" '
+    BEGIN { FS = ":" }
+    tolower($1) == tolower(h) {
+      sub(/^[^:]*:[ \t]*/, "")
+      gsub(/\r/, "")
+      sub(/[ \t]+$/, "")
+      print
+      exit
+    }
+  '
+}
+
+ETAG=$(extract_header "ETag")
+LAST_MOD=$(extract_header "Last-Modified")
+dbg "HEAD etag=$ETAG last_modified=$LAST_MOD"
+
+if [ -z "$ETAG" ] && [ -z "$LAST_MOD" ]; then
+  dbg "no validator from origin, removing any stale entry and exit"
+  rm -f "$CACHE_FILE"
+  exit 0
+fi
+
+NOW=$(date +%s)
+
+TMP="${CACHE_FILE}.$$.tmp"
+if jq -n \
+  --arg url           "$URL" \
+  --arg prompt        "$PROMPT" \
+  --arg etag          "$ETAG" \
+  --arg last_modified "$LAST_MOD" \
+  --arg content       "$CONTENT" \
+  --argjson fetched_at "$NOW" \
+  '{url: $url, prompt: $prompt, etag: $etag, last_modified: $last_modified, content: $content, fetched_at: $fetched_at}' \
+  > "$TMP"
+then
+  mv "$TMP" "$CACHE_FILE"
+  dbg "wrote cache file $CACHE_FILE"
+else
+  rm -f "$TMP"
+  dbg "jq failed, temp cleaned"
+fi
+
+exit 0

--- a/hooks/sdd-cache-pre.sh
+++ b/hooks/sdd-cache-pre.sh
@@ -1,21 +1,19 @@
 #!/bin/bash
-# sdd-cache-pre.sh — PreToolUse hook for WebFetch
+# sdd-cache-pre.sh — PreToolUse hook for WebFetch.
 #
-# Before every WebFetch, checks whether the target URL has a cached entry
-# in .claude/sdd-cache/. If so, issues a conditional HEAD request with
-# If-None-Match / If-Modified-Since. If the server responds 304 Not Modified,
-# the hook blocks the WebFetch (exit 2) and returns the cached content to the
-# agent via stderr. Otherwise it exits 0 and lets the fetch proceed.
+# HTTP resource cache keyed by URL. Freshness is delegated to the origin via
+# HTTP validators; 304 Not Modified is the only signal to serve from cache.
+# On hit, exits 2 and writes the cached body to stderr so Claude Code can
+# deliver it to the agent in place of the WebFetch result. Otherwise exits 0.
 #
-# Freshness is verified by the origin server on every call, so the skill's
-# "don't trust memory, verify against current docs" invariant still holds.
-# The hook only serves content the server has just confirmed is unchanged.
+# No TTL: if validators don't catch a change, nothing will. Entries without
+# ETag or Last-Modified are never cached (can't revalidate).
 #
-# A 24h hard TTL acts as a safety net in case a server misreports freshness.
-# Entries without ETag/Last-Modified are never cached, so nothing is served
-# without a validator.
+# Cached bodies are prompt-shaped (WebFetch post-processes through a model),
+# so the key is URL-only and the original prompt is surfaced in the hit
+# message so the next agent can tell if the earlier reading still applies.
 #
-# Dependencies: jq, curl, shasum (or sha256sum)
+# Dependencies: jq, curl, shasum (or sha256sum).
 
 set -euo pipefail
 
@@ -36,49 +34,27 @@ dbg() {
 }
 dbg "fired"
 
-URL=$(printf '%s'    "$INPUT" | jq -r '.tool_input.url    // empty' 2>/dev/null || true)
-PROMPT=$(printf '%s' "$INPUT" | jq -r '.tool_input.prompt // empty' 2>/dev/null || true)
+URL=$(printf '%s' "$INPUT" | jq -r '.tool_input.url // empty' 2>/dev/null || true)
 if [ -z "$URL" ]; then dbg "no url in tool_input, exit"; exit 0; fi
-dbg "url=$URL prompt=$(printf '%s' "$PROMPT" | head -c 80)"
+dbg "url=$URL"
 
-# Cache key is (url + normalized prompt): WebFetch output is prompt-dependent,
-# so the same URL with a different question must miss the cache. Prompt is
-# normalized (lowercase + whitespace collapse) so stylistic variants like
-# "Extract the signature" vs "extract   the\nsignature" hash to the same key.
-# Semantically different prompts still differ.
-normalize_prompt() {
-  printf '%s' "$1" \
-    | tr '[:upper:]' '[:lower:]' \
-    | tr -s '[:space:]' ' ' \
-    | sed -e 's/^ //' -e 's/ $//'
-}
-
+# Cache key is sha256(URL), truncated to 128 bits.
 hash_key() {
-  local norm
-  norm=$(normalize_prompt "$2")
-  local key="$1"$'\x1f'"$norm"
   if command -v shasum >/dev/null 2>&1; then
-    printf '%s' "$key" | shasum -a 256 | cut -c1-32
+    printf '%s' "$1" | shasum -a 256 | cut -c1-32
   else
-    printf '%s' "$key" | sha256sum | cut -c1-32
+    printf '%s' "$1" | sha256sum | cut -c1-32
   fi
 }
 
 CACHE_DIR="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
-CACHE_FILE="$CACHE_DIR/$(hash_key "$URL" "$PROMPT").json"
+CACHE_FILE="$CACHE_DIR/$(hash_key "$URL").json"
 
 if [ ! -f "$CACHE_FILE" ]; then dbg "no cache file at $CACHE_FILE, exit"; exit 0; fi
 dbg "cache file exists: $CACHE_FILE"
 
-# Hard TTL: 24h. If the entry is older, bypass the cache entirely.
 FETCHED_AT=$(jq -r '.fetched_at // 0' "$CACHE_FILE" 2>/dev/null || echo 0)
-NOW=$(date +%s)
-AGE=$((NOW - FETCHED_AT))
-if [ "$AGE" -gt 86400 ]; then
-  dbg "entry older than 24h (age=${AGE}s), bypass"
-  exit 0
-fi
-
+ORIGINAL_PROMPT=$(jq -r '.prompt // empty' "$CACHE_FILE" 2>/dev/null || true)
 ETAG=$(jq -r '.etag // empty' "$CACHE_FILE" 2>/dev/null || true)
 LAST_MOD=$(jq -r '.last_modified // empty' "$CACHE_FILE" 2>/dev/null || true)
 
@@ -112,16 +88,19 @@ VERIFIED_AT_ISO=$(date -u -r "$FETCHED_AT" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
               || date -u -d "@$FETCHED_AT" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
               || echo "unknown")
 
-cat >&2 <<EOF
-[sdd-cache] Cache hit for $URL
-
-Freshness just verified via HTTP 304 Not Modified. The origin server
-confirmed the content is unchanged since it was fetched at $VERIFIED_AT_ISO.
-No new fetch is needed. Use the cached content below as if WebFetch had
-just returned it:
-
------ BEGIN CACHED CONTENT -----
-$CONTENT
------ END CACHED CONTENT -----
-EOF
+# Emit the payload with printf so $CONTENT is never interpreted by the shell
+# (docs contain backticks, $vars, and backslashes in code examples; an
+# unquoted heredoc would treat them as command substitution).
+{
+  printf '[sdd-cache] Cache hit for %s\n\n' "$URL"
+  printf 'Revalidated via HTTP 304; unchanged since %s. Use the cached\n' "$VERIFIED_AT_ISO"
+  printf 'content below as if WebFetch had just returned it.\n\n'
+  if [ -n "$ORIGINAL_PROMPT" ]; then
+    printf 'Original WebFetch prompt: "%s". If your angle differs, judge\n' "$ORIGINAL_PROMPT"
+    printf 'whether this reading still covers it.\n\n'
+  fi
+  printf -- '----- BEGIN CACHED CONTENT -----\n'
+  printf '%s\n' "$CONTENT"
+  printf -- '----- END CACHED CONTENT -----\n'
+} >&2
 exit 2

--- a/hooks/sdd-cache-pre.sh
+++ b/hooks/sdd-cache-pre.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# sdd-cache-pre.sh — PreToolUse hook for WebFetch
+#
+# Before every WebFetch, checks whether the target URL has a cached entry
+# in .claude/sdd-cache/. If so, issues a conditional HEAD request with
+# If-None-Match / If-Modified-Since. If the server responds 304 Not Modified,
+# the hook blocks the WebFetch (exit 2) and returns the cached content to the
+# agent via stderr. Otherwise it exits 0 and lets the fetch proceed.
+#
+# Freshness is verified by the origin server on every call, so the skill's
+# "don't trust memory, verify against current docs" invariant still holds.
+# The hook only serves content the server has just confirmed is unchanged.
+#
+# A 24h hard TTL acts as a safety net in case a server misreports freshness.
+# Entries without ETag/Last-Modified are never cached, so nothing is served
+# without a validator.
+#
+# Dependencies: jq, curl, shasum (or sha256sum)
+
+set -euo pipefail
+
+# Graceful degradation: if any dependency is missing, let the fetch through.
+command -v jq   >/dev/null 2>&1 || exit 0
+command -v curl >/dev/null 2>&1 || exit 0
+command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 || exit 0
+
+if [ -t 0 ]; then INPUT="{}"; else INPUT=$(cat); fi
+
+# Debug logging: active when SDD_CACHE_DEBUG=1 is set, or when a sentinel
+# file exists at .claude/sdd-cache/.debug. Toggle with `touch` / `rm`.
+dbg() {
+  local dir="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
+  [ "${SDD_CACHE_DEBUG:-0}" = "1" ] || [ -f "$dir/.debug" ] || return 0
+  mkdir -p "$dir"
+  printf '%s [pre]  %s\n' "$(date -u +%FT%TZ)" "$*" >> "$dir/.debug.log"
+}
+dbg "fired"
+
+URL=$(printf '%s'    "$INPUT" | jq -r '.tool_input.url    // empty' 2>/dev/null || true)
+PROMPT=$(printf '%s' "$INPUT" | jq -r '.tool_input.prompt // empty' 2>/dev/null || true)
+if [ -z "$URL" ]; then dbg "no url in tool_input, exit"; exit 0; fi
+dbg "url=$URL prompt=$(printf '%s' "$PROMPT" | head -c 80)"
+
+# Cache key is (url + normalized prompt): WebFetch output is prompt-dependent,
+# so the same URL with a different question must miss the cache. Prompt is
+# normalized (lowercase + whitespace collapse) so stylistic variants like
+# "Extract the signature" vs "extract   the\nsignature" hash to the same key.
+# Semantically different prompts still differ.
+normalize_prompt() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr -s '[:space:]' ' ' \
+    | sed -e 's/^ //' -e 's/ $//'
+}
+
+hash_key() {
+  local norm
+  norm=$(normalize_prompt "$2")
+  local key="$1"$'\x1f'"$norm"
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$key" | shasum -a 256 | cut -c1-32
+  else
+    printf '%s' "$key" | sha256sum | cut -c1-32
+  fi
+}
+
+CACHE_DIR="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
+CACHE_FILE="$CACHE_DIR/$(hash_key "$URL" "$PROMPT").json"
+
+if [ ! -f "$CACHE_FILE" ]; then dbg "no cache file at $CACHE_FILE, exit"; exit 0; fi
+dbg "cache file exists: $CACHE_FILE"
+
+# Hard TTL: 24h. If the entry is older, bypass the cache entirely.
+FETCHED_AT=$(jq -r '.fetched_at // 0' "$CACHE_FILE" 2>/dev/null || echo 0)
+NOW=$(date +%s)
+AGE=$((NOW - FETCHED_AT))
+if [ "$AGE" -gt 86400 ]; then
+  dbg "entry older than 24h (age=${AGE}s), bypass"
+  exit 0
+fi
+
+ETAG=$(jq -r '.etag // empty' "$CACHE_FILE" 2>/dev/null || true)
+LAST_MOD=$(jq -r '.last_modified // empty' "$CACHE_FILE" 2>/dev/null || true)
+
+# No validator means we cannot verify freshness — never serve from cache.
+if [ -z "$ETAG" ] && [ -z "$LAST_MOD" ]; then
+  dbg "cached entry has no etag/last-modified, cannot revalidate, bypass"
+  exit 0
+fi
+
+HEADERS=()
+[ -n "$ETAG" ]     && HEADERS+=(-H "If-None-Match: $ETAG")
+[ -n "$LAST_MOD" ] && HEADERS+=(-H "If-Modified-Since: $LAST_MOD")
+
+STATUS=$(curl -sI -o /dev/null -w "%{http_code}" \
+  --max-time 5 -L \
+  "${HEADERS[@]}" \
+  "$URL" 2>/dev/null || echo "000")
+dbg "revalidation HEAD status=$STATUS"
+
+if [ "$STATUS" != "304" ]; then
+  dbg "not 304, letting WebFetch proceed"
+  exit 0
+fi
+
+# Server confirmed content unchanged. Serve cached copy to the agent.
+CONTENT=$(jq -r '.content // empty' "$CACHE_FILE" 2>/dev/null || true)
+if [ -z "$CONTENT" ]; then dbg "cache file has empty content field, bypass"; exit 0; fi
+dbg "cache HIT, blocking WebFetch with ${#CONTENT} bytes of cached content"
+
+VERIFIED_AT_ISO=$(date -u -r "$FETCHED_AT" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+              || date -u -d "@$FETCHED_AT" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+              || echo "unknown")
+
+cat >&2 <<EOF
+[sdd-cache] Cache hit for $URL
+
+Freshness just verified via HTTP 304 Not Modified. The origin server
+confirmed the content is unchanged since it was fetched at $VERIFIED_AT_ISO.
+No new fetch is needed. Use the cached content below as if WebFetch had
+just returned it:
+
+----- BEGIN CACHED CONTENT -----
+$CONTENT
+----- END CACHED CONTENT -----
+EOF
+exit 2


### PR DESCRIPTION
## Summary

Re-opens #74 with a completely different approach after @addyosmani's
feedback. The citation cache now lives in two **optional Claude Code
hooks**, not inside the skill.

- `hooks/sdd-cache-pre.sh` — PreToolUse on `WebFetch`. If a cached
  entry exists, it issues a `HEAD` with `If-None-Match` /
  `If-Modified-Since`. On `304 Not Modified` it blocks the fetch
  (exit 2) and returns the cached content via stderr. Otherwise it
  lets the fetch through.
- `hooks/sdd-cache-post.sh` — PostToolUse on `WebFetch`. Captures the
  response together with the origin's current `ETag` /
  `Last-Modified`. Entries without a validator are never stored.

The `source-driven-development` skill itself is untouched.

---

I’m considering moving this to draft because I still have a few concerns around correctness and long-term behavior.

- **TTL as safety net**  
  I understand the 24h TTL is meant to mitigate misbehaving origins, but it can also introduce unnecessary invalidations. In practice, many documentation sites are relatively stable, so entries may be evicted even when the origin would still return `304 Not Modified`.  

  This means we might lose valid cache hits and fall back to a full fetch despite the content being unchanged, even though freshness is already delegated to the origin via HTTP validators. I’m wondering if relying entirely on validators (and making TTL optional or configurable) would lead to more consistent behavior.

- **Prompt stability as part of the cache key**  
  Since the cache key depends on `(url + normalized_prompt)`, the hit rate relies on the agent reusing same prompt across sessions. Given that prompt phrasing is often not stable (even for the same intent), I’m wondering how reliable this is in real workflows, especially over time or across different agents or model versions.  

  In my tests (using Claude Haiku), this worked quite well in practice. Once a page had been fetched (e.g. `useState`), subsequent requests with similar prompts consistently hit the cache, so the agent effectively read from the cached content instead of triggering a new fetch.  

  However, I’m not sure how stable this behavior is under prompt drift, or when switching agents, models, or longer-lived sessions.

  However, I’m not sure how stable this behavior is under prompt drift, or when switching agents, models, or longer-lived sessions.

- **Use of HEAD for revalidation**  
  This is the part I’m least confident about. Many servers don’t implement `HEAD` consistently with `GET` (headers, caching behavior, etc.), which could lead to incorrect 304s or missed invalidations. Maybe a conditional `GET` would be more robust in practice, even if slightly more expensive, since it guarantees consistency with the actual fetch path.

That said, since this lives entirely in hooks and doesn’t affect the skill itself, I agree the risk surface is relatively contained and it’s easy to experiment with.

More generally: should HTTP validators be treated as the single source of truth for freshness, or is it acceptable to layer additional heuristics (like TTL) on top?

---

## How this addresses the previous feedback on #74

| Concern | Resolution |
|---|---|
| "Cache contradicts SDD's 'verify against current docs' rule" | Every reuse is verified by the origin via HTTP `304`. A hit is a just-completed verification, not a memory read. |
| "Skill complexity budget" | The skill is byte-for-byte unchanged. The cache is opt-in infrastructure, not a skill instruction. |
| "Cache invalidation is unsolved" | Invalidation is delegated to the server's `ETag` / `Last-Modified`. A hard 24h TTL is the safety net for misbehaving origins. |
| "This belongs at the tool level" | Implemented as Claude Code pre/post-tool-use hooks on `WebFetch` — the canonical tool-level extension point. |

---

## How it works

Cache key: `sha256(url + normalized_prompt)` (lowercase + whitespace
collapse). WebFetch output is prompt-dependent, so different prompts
on the same URL are separate entries. Stylistic variants
(`"Extract the signature"` vs `"extract   the\nsignature"`) hit the
same key; semantically different prompts still miss.

Full setup, testing, and debugging docs:
[`hooks/SDD-CACHE.md`](hooks/SDD-CACHE.md).

---

## Opt-in

Nothing happens until users explicitly register the hooks in
`.claude/settings.json`. The plugin manifest is not modified.
Follows the same opt-in pattern used by `simplify-ignore.sh` in this
repo.

---

## Test plan

- [x] Post hook writes one JSON file per `(url, prompt)` on cache
      miss, stores `ETag` / `Last-Modified`.
- [x] Pre hook returns exit 2 with stderr payload on `304`.
- [x] Pre hook returns exit 0 silently on non-`304` (cache miss or
      server change).
- [x] Prompt normalization: case + whitespace variants hit the same
      cache entry; semantically different prompts miss.
- [x] Servers without validators are never cached (entries without
      `ETag`/`Last-Modified` are skipped on write and removed on next
      revalidation attempt).
- [x] 24h TTL bypass verified.
- [x] End-to-end in a real Claude Code session (`react.dev`):
      WebFetch → cached → same prompt re-fetch → `304` → cached content
      returned to the agent.
- [ ] Reviewer smoke test — follow steps in `hooks/SDD-CACHE.md`.

Closes #74 (once this is accepted or rejected).