### PR TITLE
fix: escape session-start hook JSON

### DIFF
--- a/hooks/session-start-test.sh
+++ b/hooks/session-start-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# session-start-test.sh - Tests for the SessionStart hook JSON payload
+
+set -euo pipefail
+
+tmp_payload="$(mktemp)"
+trap 'rm -f "$tmp_payload"' EXIT
+
+payload="$(bash hooks/session-start.sh)"
+printf '%s' "$payload" > "$tmp_payload"
+
+PAYLOAD_PATH="$tmp_payload" node <<'NODE'
+const fs = require('fs');
+
+const payload = JSON.parse(fs.readFileSync(process.env.PAYLOAD_PATH, 'utf8'));
+
+if (payload.priority !== 'IMPORTANT') {
+  throw new Error(`expected IMPORTANT priority, got ${payload.priority}`);
+}
+
+if (!payload.message.includes('agent-skills loaded.')) {
+  throw new Error('message is missing startup preface');
+}
+
+if (!payload.message.includes('# Using Agent Skills')) {
+  throw new Error('message is missing using-agent-skills content');
+}
+
+console.log('session-start JSON payload OK');
+NODE

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -7,14 +7,16 @@ SKILLS_DIR="$(dirname "$SCRIPT_DIR")/skills"
 META_SKILL="$SKILLS_DIR/using-agent-skills/SKILL.md"
 
 if [ -f "$META_SKILL" ]; then
-  CONTENT=$(cat "$META_SKILL")
-  # Output as JSON for Claude Code hook consumption
-  cat <<EOF
-{
-  "priority": "IMPORTANT",
-  "message": "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.\n\n$CONTENT"
-}
-EOF
+  # Use JSON.stringify so quotes, backslashes, and newlines in SKILL.md cannot
+  # break Claude Code's hook payload parser.
+  META_SKILL="$META_SKILL" node <<'NODE'
+const fs = require('fs');
+
+const content = fs.readFileSync(process.env.META_SKILL, 'utf8');
+const message = `agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.\n\n${content}`;
+
+process.stdout.write(JSON.stringify({ priority: 'IMPORTANT', message }) + '\n');
+NODE
 else
   echo '{"priority": "INFO", "message": "agent-skills: using-agent-skills meta-skill not found. Skills may still be available individually."}'
 fi


### PR DESCRIPTION
## Summary
- Generate the SessionStart hook payload with `JSON.stringify` so Markdown quotes, backslashes, and newlines cannot corrupt the JSON output.
- Add an executable hook test that parses the payload and checks the injected using-agent-skills content is present.

Fixes #89.

## Verification
- Red repro before fix: `bash hooks/session-start.sh | python3 -c 'import sys,json; json.loads(sys.stdin.read())'` failed with `Invalid control character`.
- `git diff --check --cached`
- LF-normalized staged snapshot: `bash -n hooks/session-start.sh && bash -n hooks/session-start-test.sh && bash hooks/session-start-test.sh`
- LF-normalized staged snapshot: `bash hooks/session-start.sh | python3 -c 'import sys,json; payload=json.loads(sys.stdin.read()); assert payload["priority"] == "IMPORTANT"; assert "# Using Agent Skills" in payload["message"]'`