### PR TITLE
Feature: spec directory

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -13,4 +13,8 @@ Read the existing spec (SPEC.md or equivalent) and the relevant codebase section
 5. Add checkpoints between phases
 6. Present the plan for human review
 
-Save the plan to tasks/plan.md and task list to tasks/todo.md.
+Save the plan and task list to the same feature directory:
+- docs/features/[feature-name]/plan.md
+- docs/features/[feature-name]/todo.md
+
+This keeps all feature artifacts together and enables multiple simultaneous features.

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -12,4 +12,8 @@ Begin by understanding what the user wants to build. Ask clarifying questions ab
 
 Then generate a structured spec covering all six core areas: objective, commands, project structure, code style, testing strategy, and boundaries.
 
-Save the spec as SPEC.md in the project root and confirm with the user before proceeding.
+Save the spec to a feature-specific directory: docs/features/[feature-name]/spec.md
+
+First, determine the feature name based on the objective (e.g., "user-authentication", "payment-integration", "dashboard-analytics"). Create the directory structure docs/features/[feature-name]/ and save the spec as spec.md within that directory.
+
+This prevents spec overwriting and enables multiple simultaneous features. Confirm with the user before proceeding.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -127,11 +127,12 @@ Load a reference when you need detailed patterns beyond what the skill covers.
 
 ## Spec and task artifacts
 
-The `/spec` and `/plan` commands create working artifacts (`SPEC.md`, `tasks/plan.md`, `tasks/todo.md`). Treat them as **living documents** while the work is in progress:
+The `/spec` and `/plan` commands create working artifacts in feature-specific directories (`docs/features/[feature-name]/spec.md`, `docs/features/[feature-name]/plan.md`, `docs/features/[feature-name]/todo.md`). Treat them as **living documents** while the work is in progress:
 
 - Keep them in version control during development so the human and the agent have a shared source of truth.
 - Update them when scope or decisions change.
-- If your repo doesn’t want these files long‑term, delete them before merge or add the folder to `.gitignore` — the workflow doesn’t require them to be permanent.
+- Feature-specific organization prevents overwriting and enables multiple simultaneous features.
+- If your repo doesn't want these files long-term, delete them before merge or add `docs/features/` to `.gitignore` - the workflow doesn't require them to be permanent.
 
 ## Tips
 


### PR DESCRIPTION
source from https://github.com/addyosmani/agent-skills/pull/73/changes/87de68f85dbb61e2c2509a41aa2c0329477bb161

## Changes
- Update spec command to save specs to docs/features/[feature-name]/spec.md
- Update plan command to read specs from and save plans to feature directories
- Update getting-started documentation to reflect new directory structure
- Enable multiple simultaneous features without overwriting artifacts

## New Directory Structure
docs/features/[feature-name]/
  - spec.md     # Feature specification
  - plan.md     # Implementation plan
  - todo.md     # Task list