### PR TITLE
Fix: JSON-escape hook content in session-start hook

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -8,13 +8,12 @@ META_SKILL="$SKILLS_DIR/using-agent-skills/SKILL.md"
 
 if [ -f "$META_SKILL" ]; then
   CONTENT=$(cat "$META_SKILL")
-  # Output as JSON for Claude Code hook consumption
-  cat <<EOF
-{
-  "priority": "IMPORTANT",
-  "message": "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.\n\n$CONTENT"
-}
-EOF
+  # Use jq to properly escape and construct valid JSON
+  jq -cn \
+    --arg message "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.
+
+$CONTENT" \
+    '{priority: "IMPORTANT", message: $message}'
 else
   echo '{"priority": "INFO", "message": "agent-skills: using-agent-skills meta-skill not found. Skills may still be available individually."}'
 fi

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -6,6 +6,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$(dirname "$SCRIPT_DIR")/skills"
 META_SKILL="$SKILLS_DIR/using-agent-skills/SKILL.md"
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo '{"priority": "INFO", "message": "agent-skills: jq is required for the session-start hook but was not found on PATH. Install jq (e.g. `brew install jq` or `apt-get install jq`) to enable meta-skill injection. Skills remain available individually."}'
+  exit 0
+fi
+
 if [ -f "$META_SKILL" ]; then
   CONTENT=$(cat "$META_SKILL")
   # Use jq to properly escape and construct valid JSON


### PR DESCRIPTION
Fixes #89

## Problem
The session-start hook was outputting invalid JSON when SKILL.md contained quotes or control characters like newlines. This broke JSON parsing for Claude Code hook consumers.

## Solution
Use `jq -cn` with `--arg` to properly construct and escape the JSON output. This ensures all special characters in the markdown content are safely escaped in the JSON string.

## Verification
- Tested with `bash hooks/session-start.sh | jq .` - now produces valid JSON
- Original issue: `json.JSONDecodeError: Invalid control character` - now fixed
- Works with markdown containing quotes, newlines, and other special characters