### PR TITLE
add https installation guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,6 @@ Skills also activate automatically based on what you're doing — designing an A
 > claude plugin install agent-skills@addy-agent-skills
 > ```
 
-```
-claude plugin marketplace add https://github.com/addyosmani/agent-skills.git
-
-```
-
-
 **Local / development:**
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Skills also activate automatically based on what you're doing — designing an A
 /plugin install agent-skills@addy-agent-skills
 ```
 
-> **SSH errors?** The marketplace clones repos via SSH. If you don't have SSH keys set up on GitHub, either [add your SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) or run the commands below in your terminal (not Claude Code):
+> **SSH errors?** The marketplace clones repos via SSH. If you don't have SSH keys set up on GitHub, either [add your SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) or use the full HTTPS URL to force the HTTPS cloning:
 > ```bash
-> claude plugin marketplace add https://github.com/addyosmani/agent-skills.git
-> claude plugin install agent-skills@addy-agent-skills
+> /plugin marketplace add https://github.com/addyosmani/agent-skills.git
+> /plugin install agent-skills@addy-agent-skills
 > ```
 
 **Local / development:**

--- a/README.md
+++ b/README.md
@@ -45,10 +45,17 @@ Skills also activate automatically based on what you're doing — designing an A
 /plugin install agent-skills@addy-agent-skills
 ```
 
-> **SSH errors?** The marketplace clones repos via SSH. If you don't have SSH keys set up on GitHub, either [add your SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) or switch to HTTPS for fetches only:
+> **SSH errors?** The marketplace clones repos via SSH. If you don't have SSH keys set up on GitHub, either [add your SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) or run the commands below in your terminal (not Claude Code):
 > ```bash
-> git config --global url."https://github.com/".insteadOf "git@github.com:"
+> claude plugin marketplace add https://github.com/addyosmani/agent-skills.git
+> claude plugin install agent-skills@addy-agent-skills
 > ```
+
+```
+claude plugin marketplace add https://github.com/addyosmani/agent-skills.git
+
+```
+
 
 **Local / development:**
 


### PR DESCRIPTION
The README solution for installing the skill with HTTPS is a bit unnecessarily complex. Claude Code allows users to add marketplace plugins and install plugins over HTTPS, not SSH, if the full repo URL is provided.


<img width="1448" height="338" alt="ScreenShot 2026-05-01 at 04 19 43@2x" src="https://github.com/user-attachments/assets/9cd1db67-9d52-4d0d-aa69-b976cab621ab" />



After installing the plugin, running ⁠git remote -v in the directory where Claude installed the skill shows that the repository was cloned using ⁠https instead of ⁠ssh.

<img width="1168" height="274" alt="ScreenShot 2026-05-01 at 04 20 41@2x" src="https://github.com/user-attachments/assets/9e7131f5-8e77-470a-8cca-549685fdb8e4" />

Here's also screenshot of the `/plugins menu` 

<img width="1582" height="424" alt="ScreenShot 2026-05-01 at 04 29 25@2x" src="https://github.com/user-attachments/assets/3b52b19d-9cc6-42bc-9214-cd2641d17cef" />

And it can be updated using the menu just as any other plugin.

<img width="2188" height="690" alt="ScreenShot 2026-05-01 at 04 31 01@2x" src="https://github.com/user-attachments/assets/cfd93a56-b297-42db-9d7e-d3188b8fade2" />


