### PR TITLE
docs(docker): integrate Docker Compose deployment guidance

### DIFF
--- a/references/docker-compose-checklist.md
+++ b/references/docker-compose-checklist.md
@@ -1,0 +1,198 @@
+# Docker Compose Deployment Checklist
+
+Reference for containerized deployments using Docker Compose. Apply this checklist before any deploy. For image build and push in CI pipelines, see the "Containerized Services" section of `ci-cd-and-automation`.
+
+---
+
+## Naming: Lock project and container names
+
+Without explicit names, Compose derives them from the working directory path. Path changes create duplicate containers instead of replacing existing ones.
+
+```yaml
+# docker-compose.yml
+name: myproject                    # locks network/volume prefixes across machines
+
+services:
+  app:
+    container_name: myproject-app  # stable name for logs, exec, and monitoring
+  db:
+    container_name: myproject-db
+```
+
+**Checklist:**
+- [ ] `name:` is set at the top of `docker-compose.yml`
+- [ ] Every service that needs a stable identity has `container_name`
+
+---
+
+## Image Tags: Never `latest` in production
+
+`latest` cannot be rolled back, diffed, or audited.
+
+```yaml
+services:
+  app:
+    image: myapp:${IMAGE_TAG}   # set IMAGE_TAG in .env or CI environment
+```
+
+Set in `.env`:
+```
+IMAGE_TAG=1.4.2
+# or: IMAGE_TAG=a3f8c1d  (git SHA from CI)
+```
+
+**Before any deploy**, record the current tag for rollback:
+```bash
+PREV_TAG=$(docker inspect myproject-app --format '{{.Config.Image}}' | cut -d: -f2)
+```
+
+**Checklist:**
+- [ ] All images use explicit version tags
+- [ ] `IMAGE_TAG` is pinned in `.env` or CI environment, not `latest`
+- [ ] Previous tag is recorded before deploying
+
+---
+
+## Secrets: Runtime injection, not baked-in
+
+`ARG` and `ENV` values in a Dockerfile persist in image layer history and are visible via `docker history` and `docker inspect`.
+
+```yaml
+services:
+  app:
+    env_file:
+      - .env         # gitignored; populated locally or by CI
+    environment:
+      NODE_ENV: production   # non-secret config only
+```
+
+Commit `.env.example` with placeholder values:
+```
+DATABASE_URL=postgres://user:password@db:5432/mydb
+SECRET_KEY=replace-me
+```
+
+Add to `.gitignore`:
+```
+.env
+.env.prod
+.env.staging
+```
+
+**Checklist:**
+- [ ] No secrets in `Dockerfile` `ARG`/`ENV` or Compose `environment`
+- [ ] `.env` is in `.gitignore`
+- [ ] `.env.example` is committed with placeholder values
+
+---
+
+## Volumes: Named volumes for persistent data
+
+Host bind mounts with relative paths break when the working directory changes and can expose the host filesystem.
+
+```yaml
+volumes:
+  db-data:       # named volume — survives container recreation
+  app-uploads:
+
+services:
+  db:
+    volumes:
+      - db-data:/var/lib/postgresql/data   # ✅
+      # NOT: - ./data:/var/lib/postgresql/data
+
+  app:
+    volumes:
+      - app-uploads:/app/uploads            # ✅
+      - ./src:/app/src                      # ✅ bind mount is fine for source code in dev
+```
+
+**Warning:** `docker compose down -v` deletes named volumes. Use bare `docker compose down` to preserve data.
+
+**Checklist:**
+- [ ] Stateful services (databases, file storage) use named volumes
+- [ ] Bind mounts are only used for dev-time source code, not production data
+
+---
+
+## Networks: Explicit isolation
+
+Without custom networks, all services share the default bridge. Explicit networks limit blast radius and enable DNS resolution by service name.
+
+```yaml
+networks:
+  backend:    # db, cache, workers
+  frontend:   # app, proxy
+
+services:
+  app:
+    networks: [backend, frontend]
+  db:
+    networks: [backend]          # not reachable from frontend
+  proxy:
+    networks: [frontend]
+    ports:
+      - "80:80"                  # only the proxy exposes ports to the host
+```
+
+**Checklist:**
+- [ ] Services use custom named networks
+- [ ] Only the ingress/proxy service exposes ports to the host
+
+---
+
+## Health Checks and Startup Order
+
+`depends_on` by default waits for the container to start, not the service inside it. Use `condition: service_healthy` to wait for readiness.
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  app:
+    depends_on:
+      db:
+        condition: service_healthy
+```
+
+For HTTP services:
+```yaml
+healthcheck:
+  test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+  interval: 15s
+  timeout: 5s
+  retries: 3
+```
+
+**Checklist:**
+- [ ] Every service others depend on has a `healthcheck`
+- [ ] All `depends_on` entries for databases or caches use `condition: service_healthy`
+
+---
+
+## Post-Deploy Verification
+
+```bash
+# All services show "Up (healthy)"
+docker compose ps
+
+# No crash loops or startup errors
+docker compose logs --tail=50 app
+
+# Inspect health state
+docker inspect myproject-app | jq '.[0].State.Health.Status'
+```
+
+**Rollback:**
+```bash
+# Deploy previous image tag
+IMAGE_TAG=${PREV_TAG} docker compose up -d --no-deps app
+docker compose ps
+```

--- a/skills/ci-cd-and-automation/SKILL.md
+++ b/skills/ci-cd-and-automation/SKILL.md
@@ -280,6 +280,77 @@ Production secrets  → Stored in deployment platform / vault
 
 CI should never have production secrets. Use separate secrets for CI testing.
 
+## Containerized Services
+
+When the project builds and deploys Docker images, the CI pipeline owns image building, tagging, and pushing. The runtime deployment config (Compose files, named volumes, networks, health checks) lives in `references/docker-compose-checklist.md`.
+
+### Image Tagging Strategy
+
+Tag every image with the git commit SHA. Never use `latest` — it cannot be rolled back or audited.
+
+```bash
+IMAGE_TAG=$(git rev-parse --short HEAD)
+docker build -t myapp:${IMAGE_TAG} .
+docker push myapp:${IMAGE_TAG}
+```
+
+Pass the tag downstream to deployment:
+```bash
+echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
+```
+
+### Multi-Stage Build in CI
+
+Use multi-stage Dockerfiles so the CI runner produces a minimal runtime image without dev dependencies or build tools:
+
+```dockerfile
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+USER node
+CMD ["node", "dist/index.js"]
+```
+
+### GitHub Actions: Build and Push
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set image tag
+        run: echo "IMAGE_TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ env.IMAGE_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+```
+
+**Never bake secrets into the image.** Pass runtime secrets via environment variables at deploy time, not as `ARG` or `ENV` in the Dockerfile — they persist in image layer history.
+
 ## Automation Beyond CI
 
 ### Dependabot / Renovate

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -66,6 +66,15 @@ Ship with confidence. The goal is not just to deploy — it's to deploy safely, 
 - [ ] Logging and error reporting configured
 - [ ] Health check endpoint exists and responds
 
+**If deploying with Docker Compose**, also verify (see `references/docker-compose-checklist.md`):
+
+- [ ] `name:` set in `docker-compose.yml`; all services have `container_name`
+- [ ] All images use explicit version tags, not `latest`
+- [ ] Secrets injected via `env_file`, not baked into the image
+- [ ] Stateful services use named volumes, not host bind mounts
+- [ ] Every `depends_on` uses `condition: service_healthy` where startup order matters
+- [ ] Rollback image tag is recorded before deploying
+
 ### Documentation
 
 - [ ] README updated with any new setup requirements


### PR DESCRIPTION
## Summary

- Add `references/docker-compose-checklist.md` — a standalone checklist covering the most common Docker Compose deployment pitfalls: naming stability, image tag pinning, secret injection, named volumes, network isolation, health checks, and rollback procedure.
- Extend `skills/ci-cd-and-automation` with a "Containerized Services" section covering CI-side concerns: image tagging strategy (git SHA, never `latest`), multi-stage Dockerfiles, and a GitHub Actions build-and-push workflow example.
- Extend `skills/shipping-and-launch` with a Docker Compose–specific pre-deploy checklist block that cross-references the new checklist file.

## Motivation

The project had no guidance for containerized deployments. Agents working on Docker Compose projects would fall through to generic deployment advice and miss concrete failure modes (container name drift, `latest` tag rollback failures, secrets baked into image layers). This change fills that gap without adding a new top-level skill — Docker concerns are distributed into the phase that owns them (CI pipeline → ci-cd-and-automation, deploy checklist → shipping-and-launch).

## Test Plan

- [x] `references/docker-compose-checklist.md` follows the reference file convention (in `references/`, not inside a skill directory)
- [x] Cross-references in ci-cd-and-automation and shipping-and-launch point to `references/docker-compose-checklist.md` by correct relative path
- [x] No content is duplicated between the two SKILL.md files — both defer detail to the checklist
