### PR TITLE
docs: remove deprecated Cursor Notepads from cursor-setup.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,11 @@ Thanks for your interest in contributing! This project is a collection of produc
 1. Create a directory under `skills/` with a kebab-case name
 2. Add a `SKILL.md` following the format in [docs/skill-anatomy.md](docs/skill-anatomy.md)
 3. Include YAML frontmatter with `name` and `description` fields
-4. Ensure the `description` briefly says what the skill does (third person), then includes `Use when` trigger conditions
+4. Write the `description` as one sentence stating what the skill does (third person), followed by `Use when` trigger conditions. Maximum 1024 characters. Example:
+
+   ```yaml
+   description: Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior.
+   ```
 
 ### Skill Quality Bar
 
@@ -20,12 +24,12 @@ Skills should be:
 
 ### Structure
 
-Every new skill must have:
+Every new skill **must** have:
 
 - `SKILL.md` in the skill directory
 - YAML frontmatter with valid `name` and `description`
 
-New skills should generally follow the standard anatomy:
+New skills **should** include these sections (recommended, not required):
 
 - **Overview** — What this skill does and why it matters
 - **When to Use** — Triggering conditions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,7 @@ Thanks for your interest in contributing! This project is a collection of produc
 1. Create a directory under `skills/` with a kebab-case name
 2. Add a `SKILL.md` following the format in [docs/skill-anatomy.md](docs/skill-anatomy.md)
 3. Include YAML frontmatter with `name` and `description` fields
-4. Write the `description` as one sentence stating what the skill does (third person), followed by `Use when` trigger conditions. Maximum 1024 characters. Example:
-
-   ```yaml
-   description: Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior.
-   ```
+4. Ensure the `description` briefly says what the skill does (third person), then includes `Use when` trigger conditions
 
 ### Skill Quality Bar
 
@@ -24,12 +20,12 @@ Skills should be:
 
 ### Structure
 
-Every new skill **must** have:
+Every new skill must have:
 
 - `SKILL.md` in the skill directory
 - YAML frontmatter with valid `name` and `description`
 
-New skills **should** include these sections (recommended, not required):
+New skills should generally follow the standard anatomy:
 
 - **Overview** — What this skill does and why it matters
 - **When to Use** — Triggering conditions

--- a/docs/cursor-setup.md
+++ b/docs/cursor-setup.md
@@ -29,15 +29,6 @@ echo "\n---\n" >> .cursorrules
 cat /path/to/agent-skills/skills/code-review-and-quality/SKILL.md >> .cursorrules
 ```
 
-### Option 3: Notepads
-
-Cursor's Notepads feature lets you store reusable context. Create a notepad for each skill you use frequently:
-
-1. Open Cursor → Settings → Notepads
-2. Create a new notepad named "swe: Test-Driven Development"
-3. Paste the content of `skills/test-driven-development/SKILL.md`
-4. Reference it in chat with `@notepad swe: Test-Driven Development`
-
 ## Recommended Configuration
 
 ### Essential Skills (Always Load)
@@ -48,20 +39,27 @@ Add these to `.cursor/rules/`:
 2. `code-review-and-quality.md` — Five-axis review
 3. `incremental-implementation.md` — Build in small verifiable slices
 
-### Phase-Specific Skills (Load as Notepads)
+### Phase-Specific Skills (Load on Demand)
 
-Create notepads for skills you use contextually:
+Copy skills into `.cursor/rules/` when working on tasks that need them, and remove when done:
 
-- "swe: Spec Development" → `spec-driven-development/SKILL.md`
-- "swe: Frontend UI" → `frontend-ui-engineering/SKILL.md`
-- "swe: Security" → `security-and-hardening/SKILL.md`
-- "swe: Performance" → `performance-optimization/SKILL.md`
+```bash
+# When starting spec work
+cp /path/to/agent-skills/skills/spec-driven-development/SKILL.md .cursor/rules/spec-driven-development.md
 
-Reference them with `@notepad` when working on relevant tasks.
+# When doing frontend work
+cp /path/to/agent-skills/skills/frontend-ui-engineering/SKILL.md .cursor/rules/frontend-ui-engineering.md
+
+# When hardening security
+cp /path/to/agent-skills/skills/security-and-hardening/SKILL.md .cursor/rules/security-and-hardening.md
+
+# When optimizing performance
+cp /path/to/agent-skills/skills/performance-optimization/SKILL.md .cursor/rules/performance-optimization.md
+```
 
 ## Usage Tips
 
-1. **Don't load all skills at once** — Cursor has context limits. Load 2-3 skills as rules and keep others as notepads.
+1. **Don't load all skills at once** — Cursor has context limits. Keep only the 2-3 skills relevant to your current task in `.cursor/rules/`.
 2. **Reference skills explicitly** — Tell Cursor "Follow the test-driven-development rules for this change" to ensure it reads the loaded rules.
 3. **Use agents for review** — Copy `agents/code-reviewer.md` content and tell Cursor to "review this diff using this code review framework."
-4. **Load references on demand** — When working on performance, reference `@notepad performance-checklist` or paste the checklist content.
+4. **Paste context on demand** — For one-off tasks, paste the relevant `SKILL.md` content directly into the chat instead of adding it to rules.


### PR DESCRIPTION
## Summary

**Fixes #44, closes #69** — Remove the deprecated Notepads option from `docs/cursor-setup.md`.

Cursor removed the Notepads feature; leaving these instructions active misleads users who try to follow them. This PR:

- Removes the "Option 3: Notepads" setup section entirely
- Replaces the "Phase-Specific Skills (Load as Notepads)" recommendation with equivalent `cp`-into-`.cursor/rules/` commands — consistent with Options 1 and 2 and actually working today
- Updates Usage Tips to remove all `@notepad` references

## Files changed

| File | Change |
|---|---|
| `docs/cursor-setup.md` | Remove Option 3 (Notepads), replace Notepads recommendation with on-demand `.cursor/rules/` workflow, update Usage Tips |

## How tested

- Verified all remaining commands match the `.cursor/rules/` pattern documented in Options 1 and 2
- Confirmed no other files in the repo reference the Notepads workflow

> Note: This PR was written with the assistance of Claude (AI). All changes are documentation-only with no logic or code impact.