### PR TITLE
docs: add global installation guide for OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ Add skill contents to your Windsurf rules configuration. See [docs/windsurf-setu
 
 Uses agent-driven skill execution via AGENTS.md and the `skill` tool.
 
-See [docs/opencode-setup.md](docs/opencode-setup.md).
+**Workspace-local:** Copy `AGENTS.md` + `skills/` into your project.  
+**Global (all projects):** Install skills to `~/.agents/skills/` and reference a global `AGENTS.md` from `~/.claude/CLAUDE.md`.
+
+See [docs/opencode-setup.md](docs/opencode-setup.md) for both approaches.
 
 </details>
 

--- a/docs/opencode-setup.md
+++ b/docs/opencode-setup.md
@@ -43,6 +43,139 @@ No additional installation is required.
 
 ---
 
+## Global Installation (All Projects)
+
+The workspace-local approach above requires copying `AGENTS.md` and `skills/` into every project. You can also install skills **globally** so they apply to any OpenCode session without per-project setup.
+
+### Why Global?
+
+OpenCode's built-in `skill` tool only recognizes a small set of natively registered skills. The skills in this repository (`spec-driven-development`, `debugging-and-error-recovery`, `code-review-and-quality`, etc.) are **not** automatically discoverable by that tool. To use them across all projects, we inject the skill definitions into OpenCode's global context.
+
+### How It Works
+
+OpenCode loads `~/.claude/CLAUDE.md` into **every** session, regardless of working directory. By placing a global `AGENTS.md` in `~/.claude/` and referencing it from `~/.claude/CLAUDE.md`, the agent receives the skill-mapping instructions on every request.
+
+When a skill applies, the agent reads the skill definition directly from `~/.agents/skills/<skill-name>/SKILL.md` using the `read` tool and follows it exactly.
+
+### Step-by-Step Setup
+
+1. **Clone the repository** (if you haven't already):
+
+```bash
+git clone https://github.com/addyosmani/agent-skills.git
+cd agent-skills
+```
+
+2. **Copy the skills to the global agents directory:**
+
+```bash
+mkdir -p ~/.agents/skills
+cp -R skills/* ~/.agents/skills/
+```
+
+3. **Create the global `AGENTS.md`:**
+
+Copy the following into `~/.claude/AGENTS.md`:
+
+```markdown
+# Global Agent Skills — OpenCode Integration
+
+These instructions apply to ALL projects. Skills are located in `~/.agents/skills/`.
+
+## Core Rules
+
+- If a task matches a skill, you MUST use it
+- Skills are located in `~/.agents/skills/<skill-name>/SKILL.md`
+- Never implement directly if a skill applies
+- Always follow the skill instructions exactly (do not partially apply them)
+- When invoking a skill, use the `read` tool to load its `SKILL.md` and follow it strictly
+
+## Intent → Skill Mapping
+
+- Feature / new functionality → `spec-driven-development`, then `incremental-implementation`, `test-driven-development`
+- Planning / breakdown → `planning-and-task-breakdown`
+- Bug / failure / unexpected behavior → `debugging-and-error-recovery`
+- Code review → `code-review-and-quality`
+- Refactoring / simplification → `code-simplification`
+- API or interface design → `api-and-interface-design`
+- UI work → `frontend-ui-engineering`
+- Performance issues → `performance-optimization`
+- Security concerns → `security-and-hardening`
+- CI/CD setup → `ci-cd-and-automation`
+- Documentation → `documentation-and-adrs`
+- Git workflow → `git-workflow-and-versioning`
+- Shipping / launch → `shipping-and-launch`
+- Deprecation or migration → `deprecation-and-migration`
+- Testing with browser DevTools → `browser-testing-with-devtools`
+- Context engineering → `context-engineering`
+- Source-driven development → `source-driven-development`
+
+## Lifecycle Mapping (Implicit Commands)
+
+OpenCode does not support slash commands like `/spec` or `/plan`.
+
+Instead, the agent must internally follow this lifecycle:
+
+- DEFINE → `spec-driven-development`
+- PLAN → `planning-and-task-breakdown`
+- BUILD → `incremental-implementation` + `test-driven-development`
+- VERIFY → `debugging-and-error-recovery`
+- REVIEW → `code-review-and-quality`
+- SHIP → `shipping-and-launch`
+
+## Execution Model
+
+For every request:
+
+1. Determine if any skill applies (even 1% chance)
+2. Read the appropriate skill from `~/.agents/skills/<skill-name>/SKILL.md`
+3. Follow the skill workflow strictly
+4. Only proceed to implementation after required steps (spec, plan, etc.) are complete
+
+## Anti-Rationalization
+
+The following thoughts are incorrect and must be ignored:
+
+- "This is too small for a skill"
+- "I can just quickly implement this"
+- "I'll gather context first"
+
+Correct behavior:
+
+- Always check for and use skills first
+```
+
+4. **Reference it from your global `CLAUDE.md`:**
+
+Ensure `~/.claude/CLAUDE.md` includes:
+
+```
+@AGENTS.md
+```
+
+If the file already has other includes (e.g., `@RTK.md`), add `@AGENTS.md` on its own line.
+
+5. **Verify it works:**
+
+Open any project in OpenCode and try a natural-language prompt that triggers a skill, e.g.:
+
+```
+Design a feature for adding user authentication
+```
+
+The agent should:
+- Detect that `spec-driven-development` applies
+- Read `~/.agents/skills/spec-driven-development/SKILL.md`
+- Follow the spec-writing workflow before writing any code
+
+### Limitations of Global Setup
+
+- **OpenCode `skill` tool incompatibility:** The native `skill` tool will not list these skills in `available_skills`. They are loaded on-demand via `read` instead.
+- **Project-specific overrides:** If a project has its own `AGENTS.md` in the workspace root, it takes precedence. The global setup acts as a fallback.
+- **Model compliance:** As with the workspace-local setup, skill adherence depends on the model following the instructions in `AGENTS.md`.
+
+---
+
 ## How It Works
 
 ### 1. Skill Discovery


### PR DESCRIPTION
OpenCode's built-in skill tool only recognizes a small set of natively registered skills. The skills in this repo are not automatically discoverable by that tool, making the per-workspace setup the only option.

This adds a 'Global Installation (All Projects)' section to the OpenCode setup guide that explains how to use the skills across all projects by:

1. Copying skills to ~/.agents/skills/
2. Creating a global ~/.claude/AGENTS.md with intent mapping
3. Referencing it from ~/.claude/CLAUDE.md (loaded in every session)

The agent then reads skill definitions on-demand via the read tool instead of the skill tool.

Also updates the README to mention both workspace-local and global options in the OpenCode quick-start summary.