### PR TITLE
test: add session-start JSON regression coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,35 @@ New skills should generally follow the standard anatomy:
 - Preserve the existing structure and tone
 - Test that YAML frontmatter remains valid after edits
 
+## Testing Hooks
+
+The session-start hook (`hooks/session-start.sh`) injects the `using-agent-skills` meta-skill into every new Claude Code session. A regression test at `hooks/session-start-test.sh` validates the hook's JSON payload — both when `jq` is available and when it isn't.
+
+Run it before opening any PR that touches:
+
+- `hooks/session-start.sh`
+- `skills/using-agent-skills/SKILL.md` (the meta-skill content embedded by the hook)
+
+```bash
+bash hooks/session-start-test.sh
+```
+
+Expected output: `session-start JSON payload OK`. The script exits non-zero on any assertion failure.
+
+### Reproducing the no-jq fallback
+
+The hook gracefully degrades to an `INFO`-priority payload when `jq` isn't on `PATH`. To exercise that branch locally, strip `jq`'s directory from `PATH` for the test invocation:
+
+```bash
+JQ_DIR=$(dirname "$(command -v jq)")
+PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "^${JQ_DIR}$" | tr '\n' ':' | sed 's/:$//') \
+  bash hooks/session-start-test.sh
+```
+
+This works cleanly when `jq` lives in its own directory (e.g. `/opt/homebrew/bin` from Homebrew, `/usr/local/bin` from a manual install). If your `jq` shares a system bin with other tools the test depends on (such as `mktemp` in `/usr/bin`), the simpler approach is to install `jq` via a separate package manager so it has its own bin directory, then re-run.
+
+The hook's `command -v jq` check fails under the stripped `PATH`, the `INFO`-priority fallback runs, and the test asserts the `jq is required` guidance message instead of the normal payload.
+
 ## Reporting Issues
 
 Open an issue if you find:

--- a/hooks/session-start-test.sh
+++ b/hooks/session-start-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# session-start-test.sh - Tests for the SessionStart hook JSON payload
+
+set -euo pipefail
+
+tmp_payload="$(mktemp)"
+trap 'rm -f "$tmp_payload"' EXIT
+
+has_jq=0
+if command -v jq >/dev/null 2>&1; then
+  has_jq=1
+fi
+
+payload="$(bash hooks/session-start.sh)"
+printf '%s' "$payload" > "$tmp_payload"
+
+HAS_JQ="$has_jq" PAYLOAD_PATH="$tmp_payload" node <<'NODE'
+const fs = require('fs');
+
+const payload = JSON.parse(fs.readFileSync(process.env.PAYLOAD_PATH, 'utf8'));
+const hasJq = process.env.HAS_JQ === '1';
+
+if (hasJq) {
+  if (payload.priority !== 'IMPORTANT') {
+    throw new Error(`expected IMPORTANT priority, got ${payload.priority}`);
+  }
+
+  if (!payload.message.includes('agent-skills loaded.')) {
+    throw new Error('message is missing startup preface');
+  }
+
+  if (!payload.message.includes('# Using Agent Skills')) {
+    throw new Error('message is missing using-agent-skills content');
+  }
+} else {
+  if (payload.priority !== 'INFO') {
+    throw new Error(`expected INFO priority when jq is missing, got ${payload.priority}`);
+  }
+
+  if (!payload.message.includes('jq is required')) {
+    throw new Error('message is missing jq fallback guidance');
+  }
+}
+
+console.log('session-start JSON payload OK');
+NODE


### PR DESCRIPTION
## Summary
- Add the focused `session-start` hook regression test from #90 on top of current `main`.
- Parse the hook output as JSON and assert the meta-skill content is injected when `jq` is available.
- Keep the test compatible with `main`'s INFO fallback when `jq` is absent.

Follow-up to #90 per @addyosmani's request.

## Verification
- Red check: LF-normalized temp fixture using pre-fix `a63f54b` fails with `JSON.parse` on the unescaped hook payload.
- `git diff --check HEAD~1..HEAD`
- LF-normalized `HEAD` fixture with temporary `jq` shim: `bash -n hooks/session-start.sh && bash -n hooks/session-start-test.sh && bash hooks/session-start-test.sh`
- LF-normalized `HEAD` fixture without `jq` in `PATH`: `bash hooks/session-start-test.sh`