### PR TITLE
docs: modernize Windsurf integration with Rules engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,12 @@ gemini skills install ./agent-skills/skills/
 <details>
 <summary><b>Windsurf</b></summary>
 
-Add skill contents to your Windsurf rules configuration. See [docs/windsurf-setup.md](docs/windsurf-setup.md).
+Uses Windsurf's modern Rules engine (global rules, workspace rules with activation modes, AGENTS.md).
+
+**Global (all projects):** Run `bash scripts/install-windsurf.sh` to install global rules and copy skills.  
+**Workspace-local:** Create `.windsurf/rules/*.md` with `trigger: model_decision` for on-demand skill activation.
+
+See [docs/windsurf-setup.md](docs/windsurf-setup.md) for full setup.
 
 </details>
 

--- a/docs/windsurf-setup.md
+++ b/docs/windsurf-setup.md
@@ -27,7 +27,7 @@ Windsurf's Rules system supports activation modes. We can define a global rule t
 
 ### How It Works
 
-1. **Global Rules** (`global_rules.md`) contain the base intent mapping and anti-rationalization rules
+1. **Global Rules** (`global_rules.md`) contain the base intent mapping and lifecycle rules
 2. **Workspace Rules** (`.windsurf/rules/*.md`) contain individual skills with `trigger: model_decision` — Cascade reads the full skill only when the description matches the user's intent
 3. **AGENTS.md** in the workspace root acts as an always-on rule for project-specific conventions
 
@@ -48,90 +48,33 @@ bash scripts/install-windsurf.sh
 
 This script will:
 - Detect your OS
-- Create `~/.codeium/windsurf/memories/global_rules.md` with intent mapping
-- Copy skills to `~/.agents/skills/` for on-demand reading
+- Create `~/.codeium/windsurf/memories/global_rules.md` with intent mapping **generated dynamically** from `skills/*/SKILL.md` frontmatter (never drifts)
+- Copy skills to `~/.agents/skills/` for on-demand reading, with a **confirmation prompt and automatic backup** if the directory already exists
 - Optionally install workspace rules in your current project
 
 #### 3. Manual setup (if you prefer)
 
-**Create Global Rules:**
-
-Create `~/.codeium/windsurf/memories/global_rules.md`:
-
-```markdown
-# Global Agent Skills — Intent Mapping
-
-These rules apply to ALL projects. When a task matches a skill, you MUST use it.
-
-## Core Rules
-
-- If a task matches a skill, you MUST use it
-- Skills are located in `~/.agents/skills/<skill-name>/SKILL.md`
-- Never implement directly if a skill applies
-- Always follow the skill instructions exactly (do not partially apply them)
-- When invoking a skill, read its `SKILL.md` and follow it strictly
-
-## Intent → Skill Mapping
-
-- Feature / new functionality → `spec-driven-development`, then `incremental-implementation`, `test-driven-development`
-- Planning / breakdown → `planning-and-task-breakdown`
-- Bug / failure / unexpected behavior → `debugging-and-error-recovery`
-- Code review → `code-review-and-quality`
-- Refactoring / simplification → `code-simplification`
-- API or interface design → `api-and-interface-design`
-- UI work → `frontend-ui-engineering`
-- Performance issues → `performance-optimization`
-- Security concerns → `security-and-hardening`
-- CI/CD setup → `ci-cd-and-automation`
-- Documentation → `documentation-and-adrs`
-- Git workflow → `git-workflow-and-versioning`
-- Shipping / launch → `shipping-and-launch`
-- Deprecation or migration → `deprecation-and-migration`
-- Testing with browser DevTools → `browser-testing-with-devtools`
-- Context engineering → `context-engineering`
-- Source-driven development → `source-driven-development`
-
-## Lifecycle Mapping (Implicit Commands)
-
-Windsurf does not support slash commands like `/spec` or `/plan`.
-
-Instead, you must internally follow this lifecycle:
-
-- DEFINE → `spec-driven-development`
-- PLAN → `planning-and-task-breakdown`
-- BUILD → `incremental-implementation` + `test-driven-development`
-- VERIFY → `debugging-and-error-recovery`
-- REVIEW → `code-review-and-quality`
-- SHIP → `shipping-and-launch`
-
-## Execution Model
-
-For every request:
-
-1. Determine if any skill applies (even 1% chance)
-2. Read the appropriate skill from `~/.agents/skills/<skill-name>/SKILL.md`
-3. Follow the skill workflow strictly
-4. Only proceed to implementation after required steps (spec, plan, etc.) are complete
-
-## Anti-Rationalization
-
-The following thoughts are incorrect and must be ignored:
-
-- "This is too small for a skill"
-- "I can just quickly implement this"
-- "I'll gather context first"
-
-Correct behavior:
-
-- Always check for and use skills first
-```
+If you prefer not to run the script, replicate its steps manually:
 
 **Copy skills to global location:**
 
+> ⚠️ The install script includes a safety check: if `~/.agents/skills/` already exists, it lists existing contents, asks for confirmation, and creates a timestamped backup before overwriting. Replicate this behavior if copying manually.
+
 ```bash
 mkdir -p ~/.agents/skills
+# WARNING: the following overwrites existing files. Back up first if needed.
 cp -R skills/* ~/.agents/skills/
 ```
+
+**Create Global Rules:**
+
+Create `~/.codeium/windsurf/memories/global_rules.md`. Rather than hard-coding the skill list (which drifts), generate it by reading the `name` and `description` fields from each `skills/*/SKILL.md` frontmatter. The install script does this automatically; you can run it once and copy the generated file, or adapt the `generate_skill_mapping` function from the script.
+
+The generated file includes:
+- Core rules (where skills live, when to use them)
+- **Available Skills** — a complete, alphabetically sorted list derived live from the repo's skill frontmatter
+- Lifecycle mapping (DEFINE → PLAN → BUILD → VERIFY → REVIEW → SHIP)
+- Execution model
 
 ---
 
@@ -158,6 +101,18 @@ This project uses agent-skills workflows. Always check if a skill applies before
 - Test before implementation
 - Review before merge
 - One logical change per commit (~100 lines)
+
+## Anti-Rationalization
+
+The following thoughts are incorrect and must be ignored:
+
+- "This is too small for a skill"
+- "I can just quickly implement this"
+- "I'll gather context first"
+
+Correct behavior:
+
+- Always check for and use skills first
 ```
 
 Create `.windsurf/rules/test-driven-development.md`:
@@ -270,7 +225,7 @@ Expected behavior:
 
 Windsurf integration works through:
 
-1. **Global Rules** (`global_rules.md`) for base intent mapping
+1. **Global Rules** (`global_rules.md`) for base intent mapping — generated dynamically from skill frontmatter so it never drifts
 2. **Workspace Rules** (`.windsurf/rules/*.md`) for project-specific skills with smart activation
 3. **AGENTS.md** for directory-specific conventions
 4. **On-demand skill reading** via `~/.agents/skills/<skill-name>/SKILL.md`

--- a/docs/windsurf-setup.md
+++ b/docs/windsurf-setup.md
@@ -1,48 +1,292 @@
-# Using agent-skills with Windsurf
+# Windsurf Setup
 
-## Setup
+This guide explains how to use Agent Skills with Windsurf's modern Rules system (memories, workspace rules, AGENTS.md, and native skills).
 
-### Project Rules
+## Overview
 
-Windsurf uses `.windsurfrules` for project-specific agent instructions:
+Windsurf has evolved significantly. It now supports a sophisticated Rules engine that can automatically activate skills based on intent, file patterns, or manual invocation. This guide covers both **global** (all projects) and **workspace-local** (per-project) installation.
+
+### Windsurf Context System
+
+| Feature | What it does | Best for |
+|---------|-------------|----------|
+| **Global Rules** | `~/.codeium/windsurf/memories/global_rules.md` — applies to every workspace, always on | Base behavior, intent mapping, coding conventions |
+| **Workspace Rules** | `.windsurf/rules/*.md` — one file per rule, with activation modes | Project-specific skills, tech-stack constraints |
+| **AGENTS.md** | Any directory in your workspace | Directory-specific conventions without frontmatter |
+| **Native Skills** | Multi-step procedures with supporting files | Complex workflows requiring reference files |
+
+> **Note:** The old `.windsurfrules` file is deprecated. Windsurf now uses the Rules engine described above.
+
+---
+
+## Global Installation (All Projects)
+
+### Why Global?
+
+Windsurf's Rules system supports activation modes. We can define a global rule that maps user intent to skills, and workspace rules that activate only when relevant. This avoids copying skills into every project.
+
+### How It Works
+
+1. **Global Rules** (`global_rules.md`) contain the base intent mapping and anti-rationalization rules
+2. **Workspace Rules** (`.windsurf/rules/*.md`) contain individual skills with `trigger: model_decision` — Cascade reads the full skill only when the description matches the user's intent
+3. **AGENTS.md** in the workspace root acts as an always-on rule for project-specific conventions
+
+### Step-by-Step Setup
+
+#### 1. Clone the repository
 
 ```bash
-# Create a combined rules file from your most important skills
-cat /path/to/agent-skills/skills/test-driven-development/SKILL.md > .windsurfrules
-echo "\n---\n" >> .windsurfrules
-cat /path/to/agent-skills/skills/incremental-implementation/SKILL.md >> .windsurfrules
-echo "\n---\n" >> .windsurfrules
-cat /path/to/agent-skills/skills/code-review-and-quality/SKILL.md >> .windsurfrules
+git clone https://github.com/addyosmani/agent-skills.git
+cd agent-skills
 ```
 
-### Global Rules
+#### 2. Run the install script
 
-For skills you want across all projects, add them to Windsurf's global rules:
-
-1. Open Windsurf → Settings → AI → Global Rules
-2. Paste the content of your most-used skills
-
-## Recommended Configuration
-
-Keep `.windsurfrules` focused on 2-3 essential skills to stay within context limits:
-
+```bash
+bash scripts/install-windsurf.sh
 ```
-# .windsurfrules
-# Essential agent-skills for this project
 
-[Paste test-driven-development SKILL.md]
+This script will:
+- Detect your OS
+- Create `~/.codeium/windsurf/memories/global_rules.md` with intent mapping
+- Copy skills to `~/.agents/skills/` for on-demand reading
+- Optionally install workspace rules in your current project
+
+#### 3. Manual setup (if you prefer)
+
+**Create Global Rules:**
+
+Create `~/.codeium/windsurf/memories/global_rules.md`:
+
+```markdown
+# Global Agent Skills — Intent Mapping
+
+These rules apply to ALL projects. When a task matches a skill, you MUST use it.
+
+## Core Rules
+
+- If a task matches a skill, you MUST use it
+- Skills are located in `~/.agents/skills/<skill-name>/SKILL.md`
+- Never implement directly if a skill applies
+- Always follow the skill instructions exactly (do not partially apply them)
+- When invoking a skill, read its `SKILL.md` and follow it strictly
+
+## Intent → Skill Mapping
+
+- Feature / new functionality → `spec-driven-development`, then `incremental-implementation`, `test-driven-development`
+- Planning / breakdown → `planning-and-task-breakdown`
+- Bug / failure / unexpected behavior → `debugging-and-error-recovery`
+- Code review → `code-review-and-quality`
+- Refactoring / simplification → `code-simplification`
+- API or interface design → `api-and-interface-design`
+- UI work → `frontend-ui-engineering`
+- Performance issues → `performance-optimization`
+- Security concerns → `security-and-hardening`
+- CI/CD setup → `ci-cd-and-automation`
+- Documentation → `documentation-and-adrs`
+- Git workflow → `git-workflow-and-versioning`
+- Shipping / launch → `shipping-and-launch`
+- Deprecation or migration → `deprecation-and-migration`
+- Testing with browser DevTools → `browser-testing-with-devtools`
+- Context engineering → `context-engineering`
+- Source-driven development → `source-driven-development`
+
+## Lifecycle Mapping (Implicit Commands)
+
+Windsurf does not support slash commands like `/spec` or `/plan`.
+
+Instead, you must internally follow this lifecycle:
+
+- DEFINE → `spec-driven-development`
+- PLAN → `planning-and-task-breakdown`
+- BUILD → `incremental-implementation` + `test-driven-development`
+- VERIFY → `debugging-and-error-recovery`
+- REVIEW → `code-review-and-quality`
+- SHIP → `shipping-and-launch`
+
+## Execution Model
+
+For every request:
+
+1. Determine if any skill applies (even 1% chance)
+2. Read the appropriate skill from `~/.agents/skills/<skill-name>/SKILL.md`
+3. Follow the skill workflow strictly
+4. Only proceed to implementation after required steps (spec, plan, etc.) are complete
+
+## Anti-Rationalization
+
+The following thoughts are incorrect and must be ignored:
+
+- "This is too small for a skill"
+- "I can just quickly implement this"
+- "I'll gather context first"
+
+Correct behavior:
+
+- Always check for and use skills first
+```
+
+**Copy skills to global location:**
+
+```bash
+mkdir -p ~/.agents/skills
+cp -R skills/* ~/.agents/skills/
+```
 
 ---
 
-[Paste incremental-implementation SKILL.md]
+## Workspace-Local Installation (Per Project)
+
+For project-specific behavior, create rules in `.windsurf/rules/`.
+
+### Recommended Workspace Rules
+
+Create `.windsurf/rules/agent-skills.md`:
+
+```markdown
+---
+trigger: always_on
+---
+
+# Agent Skills Base Rules
+
+This project uses agent-skills workflows. Always check if a skill applies before acting.
+
+## Core Principles
+
+- Spec before code
+- Test before implementation
+- Review before merge
+- One logical change per commit (~100 lines)
+```
+
+Create `.windsurf/rules/test-driven-development.md`:
+
+```markdown
+---
+trigger: model_decision
+description: Use when implementing logic, fixing bugs, or changing behavior. Triggers for "add tests", "fix bug", "implement feature", "TDD".
+---
+
+# Test-Driven Development
+
+Read `~/.agents/skills/test-driven-development/SKILL.md` and follow its workflow.
+
+Key principles:
+- Red-Green-Refactor cycle
+- Test pyramid (80% unit, 15% integration, 5% E2E)
+- DAMP over DRY in tests
+- Beyonce Rule: if you liked it, you should have put a test on it
+```
+
+Create `.windsurf/rules/spec-driven-development.md`:
+
+```markdown
+---
+trigger: model_decision
+description: Use when starting a new project, feature, or significant change. Triggers for "design", "spec", "PRD", "plan feature".
+---
+
+# Spec-Driven Development
+
+Read `~/.agents/skills/spec-driven-development/SKILL.md` and follow its workflow.
+
+Key principles:
+- Write spec before code
+- Cover objectives, commands, structure, code style, testing, boundaries
+```
+
+### Activation Modes Explained
+
+| Mode | `trigger:` value | When it activates | Context cost |
+|------|------------------|-------------------|--------------|
+| Always On | `always_on` | Every message | Every message |
+| Model Decision | `model_decision` | When description matches intent | Description always; full content on demand |
+| Glob | `glob` | When touching matching files | Only when matching files are touched |
+| Manual | `manual` | When `@rule-name` is typed | Only when @mentioned |
+
+**Recommendation:** Use `model_decision` for most skills. Cascade only reads the full skill content when it decides the skill is relevant, keeping context usage minimal.
 
 ---
 
-[Paste code-review-and-quality SKILL.md]
+## AGENTS.md Integration
+
+Windsurf natively supports `AGENTS.md` files in any workspace directory:
+
+- **Root-level** `AGENTS.md` = always-on rules for the entire project
+- **Subdirectory** `AGENTS.md` = applies only to that directory (auto-glob)
+
+Create an `AGENTS.md` in your project root:
+
+```markdown
+# AGENTS.md
+
+## Project Context
+
+[Describe your project here]
+
+## Agent Behavior
+
+- Always check if a skill applies before implementing
+- If a skill applies, you MUST use it
+- Never skip required workflows (spec, plan, test, review)
 ```
 
-## Usage Tips
+---
 
-1. **Be selective** — Windsurf's context is limited. Choose skills that address your biggest quality gaps.
-2. **Reference in conversation** — Paste additional skill content into the chat when working on specific phases (e.g., paste `security-and-hardening` when building auth).
-3. **Use references as checklists** — Paste `references/security-checklist.md` and ask Windsurf to verify each item.
+## Verification
+
+After setup, test with natural language prompts:
+
+```
+Design a feature for user authentication
+```
+
+Expected behavior:
+- Cascade detects `spec-driven-development` applies
+- Reads `~/.agents/skills/spec-driven-development/SKILL.md`
+- Follows the spec-writing workflow before coding
+
+```
+This endpoint is returning 500 errors
+```
+
+Expected behavior:
+- Cascade detects `debugging-and-error-recovery` applies
+- Reads `~/.agents/skills/debugging-and-error-recovery/SKILL.md`
+- Follows the five-step triage workflow
+
+---
+
+## Limitations
+
+- **No native skill tool:** Unlike Claude Code, Windsurf does not have a `/skill` command. Skills are triggered via intent mapping in rules.
+- **Context limits:** Workspace rules are limited to 12,000 characters each; global rules to 6,000. Large skills should reference external files rather than being pasted inline.
+- **Model compliance:** As with all agent-driven workflows, skill adherence depends on the model following the instructions.
+
+---
+
+## Summary
+
+Windsurf integration works through:
+
+1. **Global Rules** (`global_rules.md`) for base intent mapping
+2. **Workspace Rules** (`.windsurf/rules/*.md`) for project-specific skills with smart activation
+3. **AGENTS.md** for directory-specific conventions
+4. **On-demand skill reading** via `~/.agents/skills/<skill-name>/SKILL.md`
+
+This creates a **fully agent-driven, production-grade engineering workflow** without requiring manual skill invocation or pasting large files into context.
+
+---
+
+## Recommended Workflow
+
+Just use natural language:
+
+- "Design a feature"
+- "Plan this change"
+- "Implement this"
+- "Fix this bug"
+- "Review this"
+
+The agent will automatically select and execute the correct skills.

--- a/scripts/install-windsurf.sh
+++ b/scripts/install-windsurf.sh
@@ -1,0 +1,293 @@
+#!/bin/bash
+set -e
+
+# Agent Skills — Windsurf Global Installer
+# Installs agent-skills globally for Windsurf IDE
+
+AGENTS_DIR="${HOME}/.agents/skills"
+WINDSURF_MEMORIES_DIR=""
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Detect OS and set Windsurf memories directory
+detect_os() {
+    case "$(uname -s)" in
+        Darwin*)
+            WINDSURF_MEMORIES_DIR="${HOME}/.codeium/windsurf/memories"
+            ;;
+        Linux*)
+            WINDSURF_MEMORIES_DIR="${HOME}/.codeium/windsurf/memories"
+            ;;
+        CYGWIN*|MINGW32*|MSYS*|MINGW*)
+            WINDSURF_MEMORIES_DIR="${USERPROFILE}/.codeium/windsurf/memories"
+            ;;
+        *)
+            echo "Unsupported OS. Please install manually."
+            exit 1
+            ;;
+    esac
+}
+
+# Check if running from the agent-skills repository
+check_repo() {
+    if [ ! -f "${REPO_DIR}/AGENTS.md" ] || [ ! -d "${REPO_DIR}/skills" ]; then
+        echo "Error: This script must be run from the agent-skills repository."
+        echo "Please clone https://github.com/addyosmani/agent-skills.git and run:"
+        echo "  bash scripts/install-windsurf.sh"
+        exit 1
+    fi
+}
+
+# Copy skills to global location
+install_skills() {
+    echo "📦 Installing skills to ${AGENTS_DIR}..."
+    mkdir -p "${AGENTS_DIR}"
+    cp -R "${REPO_DIR}/skills/"* "${AGENTS_DIR}/"
+    echo "✅ Installed $(ls -1 "${AGENTS_DIR}" | wc -l | tr -d ' ') skills"
+}
+
+# Create global rules file
+create_global_rules() {
+    echo "🌐 Creating global rules for Windsurf..."
+    mkdir -p "${WINDSURF_MEMORIES_DIR}"
+    
+    cat > "${WINDSURF_MEMORIES_DIR}/global_rules.md" << 'EOF'
+# Global Agent Skills — Intent Mapping
+
+These rules apply to ALL projects. When a task matches a skill, you MUST use it.
+
+## Core Rules
+
+- If a task matches a skill, you MUST use it
+- Skills are located in `~/.agents/skills/<skill-name>/SKILL.md`
+- Never implement directly if a skill applies
+- Always follow the skill instructions exactly (do not partially apply them)
+- When invoking a skill, read its `SKILL.md` and follow it strictly
+
+## Intent → Skill Mapping
+
+- Feature / new functionality → `spec-driven-development`, then `incremental-implementation`, `test-driven-development`
+- Planning / breakdown → `planning-and-task-breakdown`
+- Bug / failure / unexpected behavior → `debugging-and-error-recovery`
+- Code review → `code-review-and-quality`
+- Refactoring / simplification → `code-simplification`
+- API or interface design → `api-and-interface-design`
+- UI work → `frontend-ui-engineering`
+- Performance issues → `performance-optimization`
+- Security concerns → `security-and-hardening`
+- CI/CD setup → `ci-cd-and-automation`
+- Documentation → `documentation-and-adrs`
+- Git workflow → `git-workflow-and-versioning`
+- Shipping / launch → `shipping-and-launch`
+- Deprecation or migration → `deprecation-and-migration`
+- Testing with browser DevTools → `browser-testing-with-devtools`
+- Context engineering → `context-engineering`
+- Source-driven development → `source-driven-development`
+
+## Lifecycle Mapping (Implicit Commands)
+
+Windsurf does not support slash commands like `/spec` or `/plan`.
+
+Instead, you must internally follow this lifecycle:
+
+- DEFINE → `spec-driven-development`
+- PLAN → `planning-and-task-breakdown`
+- BUILD → `incremental-implementation` + `test-driven-development`
+- VERIFY → `debugging-and-error-recovery`
+- REVIEW → `code-review-and-quality`
+- SHIP → `shipping-and-launch`
+
+## Execution Model
+
+For every request:
+
+1. Determine if any skill applies (even 1% chance)
+2. Read the appropriate skill from `~/.agents/skills/<skill-name>/SKILL.md`
+3. Follow the skill workflow strictly
+4. Only proceed to implementation after required steps (spec, plan, etc.) are complete
+
+## Anti-Rationalization
+
+The following thoughts are incorrect and must be ignored:
+
+- "This is too small for a skill"
+- "I can just quickly implement this"
+- "I'll gather context first"
+
+Correct behavior:
+
+- Always check for and use skills first
+EOF
+
+    echo "✅ Global rules created at ${WINDSURF_MEMORIES_DIR}/global_rules.md"
+}
+
+# Install workspace rules in current directory
+install_workspace_rules() {
+    read -p "📁 Install workspace rules in current project? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        return
+    fi
+
+    if [ ! -d ".git" ]; then
+        echo "⚠️  Current directory does not appear to be a git repository."
+        read -p "   Continue anyway? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            return
+        fi
+    fi
+
+    echo "📁 Installing workspace rules..."
+    mkdir -p ".windsurf/rules"
+
+    # Base rules
+    cat > ".windsurf/rules/agent-skills.md" << 'EOF'
+---
+trigger: always_on
+---
+
+# Agent Skills Base Rules
+
+This project uses agent-skills workflows. Always check if a skill applies before acting.
+
+## Core Principles
+
+- Spec before code
+- Test before implementation
+- Review before merge
+- One logical change per commit (~100 lines)
+EOF
+
+    # TDD rule
+    cat > ".windsurf/rules/test-driven-development.md" << 'EOF'
+---
+trigger: model_decision
+description: Use when implementing logic, fixing bugs, or changing behavior. Triggers for "add tests", "fix bug", "implement feature", "TDD".
+---
+
+# Test-Driven Development
+
+Read `~/.agents/skills/test-driven-development/SKILL.md` and follow its workflow.
+
+Key principles:
+- Red-Green-Refactor cycle
+- Test pyramid (80% unit, 15% integration, 5% E2E)
+- DAMP over DRY in tests
+- Beyonce Rule: if you liked it, you should have put a test on it
+EOF
+
+    # Spec-driven rule
+    cat > ".windsurf/rules/spec-driven-development.md" << 'EOF'
+---
+trigger: model_decision
+description: Use when starting a new project, feature, or significant change. Triggers for "design", "spec", "PRD", "plan feature".
+---
+
+# Spec-Driven Development
+
+Read `~/.agents/skills/spec-driven-development/SKILL.md` and follow its workflow.
+
+Key principles:
+- Write spec before code
+- Cover objectives, commands, structure, code style, testing, boundaries
+EOF
+
+    # Debugging rule
+    cat > ".windsurf/rules/debugging-and-error-recovery.md" << 'EOF'
+---
+trigger: model_decision
+description: Use when tests fail, builds break, or behavior is unexpected. Triggers for "fix bug", "debug", "error", "crash", "500".
+---
+
+# Debugging and Error Recovery
+
+Read `~/.agents/skills/debugging-and-error-recovery/SKILL.md` and follow its workflow.
+
+Key principles:
+- Reproduce → Localize → Reduce → Fix → Guard
+- Stop-the-line rule
+- Safe fallbacks
+EOF
+
+    # Code review rule
+    cat > ".windsurf/rules/code-review-and-quality.md" << 'EOF'
+---
+trigger: model_decision
+description: Use before merging any change. Triggers for "review", "PR", "quality", "check this code".
+---
+
+# Code Review and Quality
+
+Read `~/.agents/skills/code-review-and-quality/SKILL.md` and follow its workflow.
+
+Key principles:
+- Five-axis review (correctness, design, readability, testing, maintainability)
+- Change sizing (~100 lines)
+- Severity labels (Nit/Optional/FYI)
+EOF
+
+    echo "✅ Workspace rules installed in .windsurf/rules/"
+    echo ""
+    echo "Installed rules:"
+    ls -1 ".windsurf/rules/" | sed 's/^/  - /'
+}
+
+# Create AGENTS.md template
+create_agents_md() {
+    if [ -f "AGENTS.md" ]; then
+        echo "📄 AGENTS.md already exists. Skipping."
+        return
+    fi
+
+    read -p "📄 Create AGENTS.md in current project? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        return
+    fi
+
+    cat > "AGENTS.md" << 'EOF'
+# AGENTS.md
+
+## Project Context
+
+[Describe your project here — tech stack, architecture, team conventions]
+
+## Agent Behavior
+
+- Always check if a skill applies before implementing
+- If a skill applies, you MUST use it
+- Never skip required workflows (spec, plan, test, review)
+- Follow the lifecycle: DEFINE → PLAN → BUILD → VERIFY → REVIEW → SHIP
+EOF
+
+    echo "✅ AGENTS.md created"
+}
+
+# Main
+main() {
+    echo "🌊 Agent Skills — Windsurf Installer"
+    echo "====================================="
+    echo ""
+
+    detect_os
+    check_repo
+    install_skills
+    create_global_rules
+    install_workspace_rules
+    create_agents_md
+
+    echo ""
+    echo "====================================="
+    echo "✅ Installation complete!"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Restart Windsurf if it's already running"
+    echo "  2. Open any project and try: 'Design a feature for adding login'"
+    echo "  3. Cascade should detect the skill and follow its workflow"
+    echo ""
+    echo "Documentation: https://github.com/addyosmani/agent-skills/blob/main/docs/windsurf-setup.md"
+}
+
+main "$@"

--- a/scripts/install-windsurf.sh
+++ b/scripts/install-windsurf.sh
@@ -38,85 +38,107 @@ check_repo() {
     fi
 }
 
-# Copy skills to global location
+# Extract a YAML value from frontmatter in a SKILL.md file
+get_yaml_value() {
+    local file="$1" key="$2"
+    sed -n '/^---$/,/^---$/p' "$file" | grep "^${key}:" | head -1 | sed "s/^${key}: *//"
+}
+
+# Generate the Intent → Skill Mapping section by reading all skill frontmatter
+generate_skill_mapping() {
+    local skills_dir="$1"
+    local tmpfile
+    tmpfile=$(mktemp)
+
+    for skill_file in "${skills_dir}"/*/SKILL.md; do
+        [ -f "$skill_file" ] || continue
+        local name desc
+        name=$(get_yaml_value "$skill_file" "name")
+        desc=$(get_yaml_value "$skill_file" "description")
+        if [ -n "$name" ] && [ -n "$desc" ]; then
+            printf -- "- \`%s\` — %s\n" "$name" "$desc" >> "$tmpfile"
+        fi
+    done
+
+    sort "$tmpfile"
+    rm -f "$tmpfile"
+}
+
+# Copy skills to global location with safety checks
 install_skills() {
     echo "📦 Installing skills to ${AGENTS_DIR}..."
     mkdir -p "${AGENTS_DIR}"
+
+    # Safety check: if directory already has content, warn and backup
+    if [ -d "${AGENTS_DIR}" ] && [ "$(ls -A "${AGENTS_DIR}" 2>/dev/null)" ]; then
+        echo ""
+        echo "⚠️  ${AGENTS_DIR} already exists and contains files."
+        echo "   Existing contents:"
+        ls -1 "${AGENTS_DIR}" | sed 's/^/     - /'
+        echo ""
+        read -p "   Overwrite? This will create a backup first. (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "❌ Installation cancelled."
+            exit 1
+        fi
+
+        local backup_dir="${AGENTS_DIR}.backup.$(date +%Y%m%d-%H%M%S)"
+        echo "   Creating backup at ${backup_dir}..."
+        cp -R "${AGENTS_DIR}" "${backup_dir}"
+        echo "   ✅ Backup created"
+    fi
+
     cp -R "${REPO_DIR}/skills/"* "${AGENTS_DIR}/"
     echo "✅ Installed $(ls -1 "${AGENTS_DIR}" | wc -l | tr -d ' ') skills"
 }
 
-# Create global rules file
+# Create global rules file (generated dynamically from skill frontmatter)
 create_global_rules() {
     echo "🌐 Creating global rules for Windsurf..."
     mkdir -p "${WINDSURF_MEMORIES_DIR}"
-    
-    cat > "${WINDSURF_MEMORIES_DIR}/global_rules.md" << 'EOF'
+
+    local skill_mapping
+    skill_mapping=$(generate_skill_mapping "${REPO_DIR}/skills")
+
+    cat > "${WINDSURF_MEMORIES_DIR}/global_rules.md" << EOF
 # Global Agent Skills — Intent Mapping
 
-These rules apply to ALL projects. When a task matches a skill, you MUST use it.
+These rules provide optional workflow guidance. For projects that have opted into agent-skills, check if a skill applies before acting.
 
 ## Core Rules
 
-- If a task matches a skill, you MUST use it
-- Skills are located in `~/.agents/skills/<skill-name>/SKILL.md`
+- Skills are located in \`~/.agents/skills/<skill-name>/SKILL.md\`
+- If a substantive task matches a skill, use it
 - Never implement directly if a skill applies
 - Always follow the skill instructions exactly (do not partially apply them)
-- When invoking a skill, read its `SKILL.md` and follow it strictly
+- When invoking a skill, read its \`SKILL.md\` and follow it strictly
 
-## Intent → Skill Mapping
+## Available Skills
 
-- Feature / new functionality → `spec-driven-development`, then `incremental-implementation`, `test-driven-development`
-- Planning / breakdown → `planning-and-task-breakdown`
-- Bug / failure / unexpected behavior → `debugging-and-error-recovery`
-- Code review → `code-review-and-quality`
-- Refactoring / simplification → `code-simplification`
-- API or interface design → `api-and-interface-design`
-- UI work → `frontend-ui-engineering`
-- Performance issues → `performance-optimization`
-- Security concerns → `security-and-hardening`
-- CI/CD setup → `ci-cd-and-automation`
-- Documentation → `documentation-and-adrs`
-- Git workflow → `git-workflow-and-versioning`
-- Shipping / launch → `shipping-and-launch`
-- Deprecation or migration → `deprecation-and-migration`
-- Testing with browser DevTools → `browser-testing-with-devtools`
-- Context engineering → `context-engineering`
-- Source-driven development → `source-driven-development`
+${skill_mapping}
 
 ## Lifecycle Mapping (Implicit Commands)
 
-Windsurf does not support slash commands like `/spec` or `/plan`.
+Windsurf does not support slash commands like \`/spec\` or \`/plan\`.
 
 Instead, you must internally follow this lifecycle:
 
-- DEFINE → `spec-driven-development`
-- PLAN → `planning-and-task-breakdown`
-- BUILD → `incremental-implementation` + `test-driven-development`
-- VERIFY → `debugging-and-error-recovery`
-- REVIEW → `code-review-and-quality`
-- SHIP → `shipping-and-launch`
+- DEFINE → \`spec-driven-development\`
+- PLAN → \`planning-and-task-breakdown\`
+- BUILD → \`incremental-implementation\` + \`test-driven-development\`
+- VERIFY → \`debugging-and-error-recovery\`
+- REVIEW → \`code-review-and-quality\`
+- SHIP → \`shipping-and-launch\`
 
 ## Execution Model
 
-For every request:
+For substantive requests:
 
-1. Determine if any skill applies (even 1% chance)
-2. Read the appropriate skill from `~/.agents/skills/<skill-name>/SKILL.md`
+1. Determine if any skill applies
+2. Read the appropriate skill from \`~/.agents/skills/<skill-name>/SKILL.md\`
 3. Follow the skill workflow strictly
 4. Only proceed to implementation after required steps (spec, plan, etc.) are complete
-
-## Anti-Rationalization
-
-The following thoughts are incorrect and must be ignored:
-
-- "This is too small for a skill"
-- "I can just quickly implement this"
-- "I'll gather context first"
-
-Correct behavior:
-
-- Always check for and use skills first
 EOF
 
     echo "✅ Global rules created at ${WINDSURF_MEMORIES_DIR}/global_rules.md"
@@ -142,7 +164,7 @@ install_workspace_rules() {
     echo "📁 Installing workspace rules..."
     mkdir -p ".windsurf/rules"
 
-    # Base rules
+    # Base rules (includes anti-rationalization, scoped to opted-in projects)
     cat > ".windsurf/rules/agent-skills.md" << 'EOF'
 ---
 trigger: always_on
@@ -158,6 +180,18 @@ This project uses agent-skills workflows. Always check if a skill applies before
 - Test before implementation
 - Review before merge
 - One logical change per commit (~100 lines)
+
+## Anti-Rationalization
+
+The following thoughts are incorrect and must be ignored:
+
+- "This is too small for a skill"
+- "I can just quickly implement this"
+- "I'll gather context first"
+
+Correct behavior:
+
+- Always check for and use skills first
 EOF
 
     # TDD rule


### PR DESCRIPTION
## Problem
The existing `docs/windsurf-setup.md` was outdated. It described:
- Manual copy-paste of skills into `.windsurfrules` (deprecated)
- Pasting content into Global Rules via UI (no automation)
- No mention of activation modes, AGENTS.md, or the modern Rules engine
Windsurf has evolved significantly. It now supports:
- **Global Rules** (`global_rules.md`) — applies to all workspaces
- **Workspace Rules** (`.windsurf/rules/*.md`) — with activation modes (`always_on`, `model_decision`, `glob`, `manual`)
- **AGENTS.md** — native support in any workspace directory
- **Native Skills** — multi-step procedures with reference files
## Solution
This PR modernizes the Windsurf integration to match the current platform capabilities:
### Changes
1. **Rewrites `docs/windsurf-setup.md`** completely:
   - Documents the modern Rules engine context system
   - Adds **Global Installation** section with `global_rules.md` for intent mapping across all projects
   - Adds **Workspace-Local Installation** section with `.windsurf/rules/*.md` and activation modes
   - Documents `AGENTS.md` integration
   - Includes verification steps and limitations
   - Replaces the deprecated `.windsurfrules` approach
2. **Adds `scripts/install-windsurf.sh`** — automated installer that:
   - Detects OS (macOS, Linux, Windows)
   - Copies skills to `~/.agents/skills/`
   - Creates `global_rules.md` with full intent mapping and lifecycle rules
   - Optionally installs workspace rules (`agent-skills.md`, `test-driven-development.md`, `spec-driven-development.md`, `debugging-and-error-recovery.md`, `code-review-and-quality.md`)
   - Optionally creates `AGENTS.md` template
3. **Updates `README.md`** — Windsurf quick-start summary now mentions both global (`install-windsurf.sh`) and workspace-local options
### Verification
Tested locally on macOS:
- Ran `bash scripts/install-windsurf.sh`
- Confirmed `~/.codeium/windsurf/memories/global_rules.md` created
- Confirmed `~/.agents/skills/` populated with 21 skills
- Confirmed workspace rules created in `.windsurf/rules/`
### Why This Matters
This brings the Windsurf integration to parity with the OpenCode and Claude Code integrations:
- **Automatic skill selection** via intent mapping (no manual `/command` needed)
- **Global availability** (no per-project setup required)
- **Context-efficient** (`model_decision` only loads skills when relevant)
- **Agent-driven workflow** (the model decides which skill to apply)
---
**Files changed:** 3 files (+568 lines, -26 lines)
---