### PR TITLE
ci: add markdown lint baseline for skills

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,31 @@
+name: Markdown lint
+
+on:
+  pull_request:
+    paths:
+      - ".markdownlint-cli2.jsonc"
+      - "CONTRIBUTING.md"
+      - "docs/**/*.md"
+      - "skills/**/SKILL.md"
+      - ".github/workflows/markdownlint.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".markdownlint-cli2.jsonc"
+      - "CONTRIBUTING.md"
+      - "docs/**/*.md"
+      - "skills/**/SKILL.md"
+      - ".github/workflows/markdownlint.yml"
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v23.2.0
+        with:
+          globs: |
+            CONTRIBUTING.md
+            docs/**/*.md
+            skills/**/SKILL.md

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,14 @@
+{
+  "globs": [
+    "CONTRIBUTING.md",
+    "docs/**/*.md",
+    "skills/**/SKILL.md"
+  ],
+  "config": {
+    "default": false,
+    "MD009": true,
+    "MD010": true,
+    "MD012": true,
+    "MD047": true
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,10 @@ Run Markdown linting before opening PRs that touch skills or docs:
 npx markdownlint-cli2
 ```
 
+The current lint scope is intentionally limited to `CONTRIBUTING.md`,
+`docs/**/*.md`, and `skills/**/SKILL.md`; root-level project docs and reference
+folders can be added after the baseline expands.
+
 The current lint baseline intentionally starts with low-risk whitespace rules:
 
 - no trailing spaces

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,24 @@ This works cleanly when `jq` lives in its own directory (e.g. `/opt/homebrew/bin
 
 The hook's `command -v jq` check fails under the stripped `PATH`, the `INFO`-priority fallback runs, and the test asserts the `jq is required` guidance message instead of the normal payload.
 
+## Markdown Formatting
+
+Run Markdown linting before opening PRs that touch skills or docs:
+
+```bash
+npx markdownlint-cli2
+```
+
+The current lint baseline intentionally starts with low-risk whitespace rules:
+
+- no trailing spaces
+- no hard tabs
+- no multiple consecutive blank lines
+- files end with a single newline
+
+Keep new `SKILL.md` files consistent with these rules. Broader style rules can
+be enabled later after existing documents are standardized.
+
 ## Reporting Issues
 
 Open an issue if you find:

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -316,7 +316,6 @@ npx lhci autorun
 
 For detailed performance checklists, optimization commands, and anti-pattern reference, see `references/performance-checklist.md`.
 
-
 ## Common Rationalizations
 
 | Rationalization | Reality |


### PR DESCRIPTION
## Summary
- add a `markdownlint-cli2` baseline for skill and docs Markdown files
- add a GitHub Actions workflow that runs the lint check on relevant PRs
- document the Markdown formatting command, current low-risk rule set, and intentionally limited lint scope in `CONTRIBUTING.md`
- remove one existing extra blank line so the new baseline passes immediately

Refs #137

## Rationale
This PR intentionally starts with low-friction whitespace rules to freeze a clean baseline before broader heading, bullet, and frontmatter standardization work is added later.

## Validation
- `npx markdownlint-cli2`