### PR TITLE
fix: resolve #150 — Recommended way to handle V2 features without polluting V1 spec?

### DIFF
--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -13,3 +13,12 @@ Begin by understanding what the user wants to build. Ask clarifying questions ab
 Then generate a structured spec covering all six core areas: objective, commands, project structure, code style, testing strategy, and boundaries.
 
 Save the spec as SPEC.md in the project root and confirm with the user before proceeding.
+
+## Version Management
+
+When evolving specifications from V1 to V2:
+
+1. **Version Labeling**: Clearly mark specifications with version identifiers (V1, V2) in the document title and filename
+2. **Separation**: Maintain distinct specification documents for each major version to avoid feature pollution
+3. **Migration Planning**: Document technology migrations (e.g., SQLite to PostgreSQL) and architectural changes in a separate V2 backlog
+4. **Incremental Development**: Add new features incrementally with clear version tracking rather than mixing versions

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,17 @@
 
 agent-skills works with any AI coding agent that accepts Markdown instructions. This guide covers the universal approach. For tool-specific setup, see the dedicated guides.
 
+## Version Management and Feature Development
+
+To prevent specification pollution and maintain clean architectural progression:
+
+1. **Mark version boundaries** - Use clear version tags in your skill files (e.g., v1.0, v2.0) to indicate stable releases
+2. **Maintain feature backlogs** - Keep future enhancements in separate tracking files rather than embedding in active skills
+3. **Incremental requirements** - Add new capabilities through additive changes, preserving existing workflows
+4. **Technology migrations** - When evolving tools or frameworks, create parallel skills for transition periods
+
+This approach ensures skills remain focused and prevents accumulation of speculative features.
+
 ## How Skills Work
 
 Each skill is a Markdown file (`SKILL.md`) that describes a specific engineering workflow. When loaded into an agent's context, the agent follows the workflow — including verification steps, anti-patterns to avoid, and exit criteria.

--- a/skills/deprecation-and-migration/SKILL.md
+++ b/skills/deprecation-and-migration/SKILL.md
@@ -140,7 +140,15 @@ Create an adapter that translates calls from the old interface to the new implem
 class LegacyTaskService implements OldTaskAPI {
   constructor(private newService: NewTaskService) {}
 
-  // Old method signature, delegates to new implementation
+  // Old method signature, deleg
+
+## Version Boundary Management
+
+When managing deprecations across major versions, establish clear boundaries between old and new specifications:
+
+- **V1 Specifications**: Maintain in their current form until full migration is complete
+- **V2 Feature Planning**: Develop new features separately to avoid polluting V1 with forward-looking changes
+- **Clean Separation**: Use feature flags or separate branches to isolate version-specific logic during transition periodsates to new implementation
   getTask(id: number): OldTask {
     const task = this.newService.findById(String(id));
     return this.toOldFormat(task);


### PR DESCRIPTION
## Summary

fix: resolve #150 — Recommended way to handle V2 features without polluting V1 spec?

## Problem

**Severity**: `Medium` | **File**: `.claude/commands/spec.md`

The spec.md file should include guidance on how to handle version progression from V1 to V2 while maintaining clean separation between versions. This addresses the user's concern about not polluting V1 specs with V2 features.

## Solution

Add a section to spec.md that explains: 1) How to clearly mark specifications as V1, 2) Recommendations for maintaining a V2 backlog or roadmap, 3) Process for evolving from V1 to V2 including technology migrations (SQLite to PostgreSQL example), and 4) Best practices for incremental feature development.

## Changes

- `.claude/commands/spec.md` (modified)
- `docs/getting-started.md` (modified)
- `skills/deprecation-and-migration/SKILL.md` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced