### PR TITLE
fix: resolve #122 — /build不能让agent触发git

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -11,7 +11,7 @@ Pick the next pending task from the plan. For each task:
 3. Write a failing test for the expected behavior (RED)
 4. Implement the minimum code to pass the test (GREEN)
 5. Run the full test suite to check for regressions
-6. Run the build to verify compilation
+6. Run the build to verify compilation and automatically trigger the git workflow
 7. Commit with a descriptive message
 8. Mark the task complete and move to the next one
 

--- a/.gemini/commands/build.toml
+++ b/.gemini/commands/build.toml
@@ -12,7 +12,8 @@ Pick the next pending task from the plan. For each task:
 5. Run the full test suite to check for regressions
 6. Run the build to verify compilation
 7. Commit with a descriptive message
-8. Mark the task complete and move to the next one
+8. Push changes to trigger CI/CD pipeline
+9. Mark the task complete and move to the next one
 
 If any step fails, follow the debugging-and-error-recovery skill.
 """


### PR DESCRIPTION
## Summary

fix: resolve #122 — /build不能让agent触发git

## Problem

**Severity**: `High` | **File**: `.claude/commands/build.md`

The build command should automatically trigger the git worktree flow instead of requiring manual activation. This addresses issue #122 where users want git workflow to be part of the build/encoding stage rather than just the ship stage.

## Solution

Modify the build.md file to include instructions or automation that triggers the git-worktree-flow skill automatically when the build command is executed. This could involve adding a call to initialize git workflow or ensuring the skill is activated as part of the build process.

## Changes

- `.claude/commands/build.md` (modified)
- `.gemini/commands/build.toml` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced