### PR TITLE
docs: clarify README skill count

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ Skills are plain Markdown - they work with any agent that accepts system prompts
 
 ---
 
-## All 21 Skills
+## All 22 Skills
 
-The commands above are entry points. The pack includes 21 skills total — each a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
+The commands above are entry points. The pack includes 22 skills total — 21 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
 
 ### Meta - Discover which skill applies
 
@@ -248,7 +248,7 @@ Every skill follows a consistent anatomy:
 
 ```
 agent-skills/
-├── skills/                            # 21 core skills (SKILL.md per directory)
+├── skills/                            # 22 skills (21 lifecycle + 1 meta)
 │   ├── idea-refine/                   #   Define
 │   ├── spec-driven-development/       #   Define
 │   ├── planning-and-task-breakdown/   #   Plan


### PR DESCRIPTION
Fixes #158

## Summary
- Update README skill count from 21 to 22.
- Clarify that the repository has 21 lifecycle skills plus the `using-agent-skills` meta-skill.
- Update the project structure comment to match the current `skills/` directory count.

## Verification
- Counted 22 directories under `skills/`.
- Checked README no longer contains stale `21 skills` count references.
- Ran `git diff --check`.
