### PR TITLE
fix(marketplace): use relative path source to bypass install bug

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,7 @@
   "plugins": [
     {
       "name": "agent-skills",
-      "source": {
-        "source": "github",
-        "repo": "addyosmani/agent-skills"
-      },
+      "source": "./",
       "description": "Production-grade engineering skills covering every phase of software development: spec, plan, build, verify, review, and ship."
     }
   ]


### PR DESCRIPTION
## Summary

`/plugin install agent-skills@addy-agent-skills` fails on Claude Code **v2.1.112** with:

```
Error: Failed to install: Failed to clone repository: Cloning into '/Users/.../.claude/plugins/cache/temp_github_...'...
remote: Repository not found.
fatal: repository 'https://github.com/:addyosmani/agent-skills.git/' not found
```

Note the malformed URL: `:addyosmani` (literal `:` prefix) and trailing `/` after `.git`. Claude Code's URL template for the `{ "source": "github", "repo": "..." }` source form is not interpolating `:owner/:repo` correctly. Reproduces regardless of marketplace add transport (github shorthand, full HTTPS URL, or local path).

## Fix

Since the plugin lives in the **same repo** as the marketplace manifest, switch the plugin entry to a relative-path source:

```diff
-      "source": {
-        "source": "github",
-        "repo": "addyosmani/agent-skills"
-      },
+      "source": "./",
```

This sidesteps the buggy github source path entirely. The relative source resolves against whatever directory Claude Code clones / reads the marketplace from, so it works for every marketplace add transport (github, https, ssh, local).

Per the [official plugin marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces.md#plugin-sources), relative paths are a first-class source type.

## Why this is safe

- No change to plugin contents, location, or `plugin.json`.
- Only changes how the marketplace points to the plugin (which is itself).
- Existing CI workflow `.github/workflows/test-plugin-install.yml` already runs `claude plugin marketplace add ./` followed by `claude plugin install agent-skills@addy-agent-skills`, so the relative-source path is validated on every push.

## Test plan

- [x] CI `Test plugin installation` workflow runs against this PR
- [x] Manual: `claude plugin marketplace add https://github.com/git-clone-abhinav/agent-skills.git` (branch checked out) → `claude plugin install agent-skills@addy-agent-skills` succeeds on v2.1.112
- [ ] Maintainer verification on a clean machine

## Related

- Closed issue #32 (same root cause: install fails)
- Open issue #77 covers a separate SSH/HTTPS bug that this PR does not address.