### PR TITLE
fix(spec-driven-development): add explicit cross-skill paths

### DIFF
--- a/skills/spec-driven-development/SKILL.md
+++ b/skills/spec-driven-development/SKILL.md
@@ -160,7 +160,7 @@ Break the plan into discrete, implementable tasks:
 
 ### Phase 4: Implement
 
-Execute tasks one at a time following `incremental-implementation` and `test-driven-development` skills. Use `context-engineering` to load the right spec sections and source files at each step rather than flooding the agent with the entire spec.
+Execute tasks one at a time following `skills/incremental-implementation/SKILL.md` (`incremental-implementation`) and `skills/test-driven-development/SKILL.md` (`test-driven-development`). Use `skills/context-engineering/SKILL.md` (`context-engineering`) to load the right spec sections and source files at each step rather than flooding the agent with the entire spec.
 
 ## Keeping the Spec Alive
 


### PR DESCRIPTION
Closes #67.\n\nThis updates the Phase 4 implementation guidance in spec-driven-development to reference the concrete SKILL.md paths for incremental-implementation, test-driven-development, and context-engineering while preserving the existing skill names.\n\nThe change helps file-based agents such as Codex resolve cross-skill references consistently instead of relying on name-only lookup.\n\nValidation: git diff --check.