### PR TITLE
docs(skills): tighten frontmatter for idea-refine and browser-testing-with-devtools

### DIFF
--- a/skills/browser-testing-with-devtools/SKILL.md
+++ b/skills/browser-testing-with-devtools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-testing-with-devtools
-description: Tests in real browsers. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data via Chrome DevTools MCP.
+description: Tests in real browsers via Chrome DevTools MCP. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data. Requires the chrome-devtools MCP server to be configured.
 ---
 
 # Browser Testing with DevTools

--- a/skills/idea-refine/SKILL.md
+++ b/skills/idea-refine/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: idea-refine
-description: Refines ideas iteratively. Refine ideas through structured divergent and convergent thinking. Use "idea-refine" or "ideate" to trigger.
+description: Refines raw ideas into sharp, actionable concepts through structured divergent and convergent thinking. Use when an idea is still vague, when you need to stress-test assumptions before committing to a plan, or when you want to expand options before converging on one. Triggers on "ideate", "refine this idea", or "stress-test my plan".
 ---
 
 # Idea Refine


### PR DESCRIPTION
## Summary

Tightens the frontmatter description on two skills so the entire skill catalog reads consistently to the agents that route based on it. Two small, surgical edits — no body changes, no behavioral changes.

| Skill | Issue |
|---|---|
| `idea-refine` | 135-char description, redundant first two sentences, uses the skill's own name as the trigger phrase. Out of step with the "Use when..." convention every other skill follows. |
| `browser-testing-with-devtools` | Chrome DevTools MCP dependency is buried at the end of the description, with no explicit "requires" marker for agents that route by MCP availability. |

## What changed

**`skills/idea-refine/SKILL.md`**

```diff
- description: Refines ideas iteratively. Refine ideas through structured divergent and convergent thinking. Use "idea-refine" or "ideate" to trigger.
+ description: Refines raw ideas into sharp, actionable concepts through structured divergent and convergent thinking. Use when an idea is still vague, when you need to stress-test assumptions before committing to a plan, or when you want to expand options before converging on one. Triggers on "ideate", "refine this idea", or "stress-test my plan".
```

**`skills/browser-testing-with-devtools/SKILL.md`**

```diff
- description: Tests in real browsers. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data via Chrome DevTools MCP.
+ description: Tests in real browsers via Chrome DevTools MCP. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data. Requires the chrome-devtools MCP server to be configured.
```

## Why this matters

The frontmatter `description` is the **only** thing most agents see when deciding whether to invoke a skill. `AGENTS.md` already codifies the convention:

> "Description starts with what the skill does (third person), followed by trigger conditions ('Use when...')"

These two skills were the only ones in the catalog not fully aligned with that rule:

- **`idea-refine`** had no `Use when...` clause at all, so the skill was effectively only discoverable by its own name. Agents trying to route on intent ("help me think through this idea", "stress-test my plan") had nothing to match on.
- **`browser-testing-with-devtools`** mentioned its hard dependency on Chrome DevTools MCP only as a trailing prepositional phrase. Moving "via Chrome DevTools MCP" to the lead sentence and adding an explicit `Requires the chrome-devtools MCP server` clause makes the dependency visible to agents that pre-filter by available MCP servers.

Both descriptions stay well within the 1024-character spec limit and under 60 words — they match the structural shape of the other 20 skills in the catalog.

## How this was audited

The audit was run with [**sensei**](https://github.com/spboyer/sensei), a Ralph-loop tool for scoring and improving skill frontmatter compliance. It checks every `SKILL.md` against criteria like:

- Description length (≥ 150 chars, ≤ 60 words, ≤ 1024 chars)
- Presence of trigger phrases
- Routing clarity for MCP-dependent skills
- Token budget for the SKILL.md body

Running sensei across this repo's 22 skills surfaced exactly these two outliers; the other 20 already conform to the house style and were intentionally left untouched. Notable things sensei flagged that this PR deliberately does **not** change:

- sensei's preferred trigger syntax is `WHEN: "..."` rather than the prose `Use when ...` — but `AGENTS.md` documents the prose form as the house convention, so converting all 22 skills would fight the documented standard. Not done.
- sensei's soft token budget for `SKILL.md` is 500 tokens; every workflow skill in this repo is 1.7k–4.1k. All are under the 5k hard limit and the depth is intentional. Not changed.
- Classification prefixes like `**WORKFLOW SKILL**` are optional sensei sugar; skipped to avoid 22-file cosmetic churn.

## Testing

This repo is documentation-only (per `AGENTS.md`: *"npm test — Not applicable"*), so verification is by inspection:

- ✅ Both files still parse as valid YAML frontmatter (verified by re-reading after edit)
- ✅ Each description stays under 1024 chars and 60 words
- ✅ Each description begins with a third-person action verb and contains a `Use when...` clause, matching `AGENTS.md`
- ✅ No changes to skill bodies, scripts, or behavior
- ✅ `git diff --stat` shows exactly 2 files, 2 insertions, 2 deletions

## Out of scope

Anything that would touch the other 20 skills (token trimming, `WHEN:` syntax migration, classification prefixes). Happy to open separate issues for any of those if maintainers want to track them.
