### PR TITLE
docs(skills): add WHEN: trigger phrases to 20 skill descriptions

### DIFF
--- a/skills/api-and-interface-design/SKILL.md
+++ b/skills/api-and-interface-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-and-interface-design
-description: Guides stable API and interface design. Use when designing APIs, module boundaries, or any public interface. Use when creating REST or GraphQL endpoints, defining type contracts between modules, or establishing boundaries between frontend and backend.
+description: "Guides stable API and interface design. Use when designing APIs, module boundaries, or any public interface. Use when creating REST or GraphQL endpoints, defining type contracts between modules, or establishing boundaries between frontend and backend. WHEN: \"design an API\", \"REST endpoint\", \"GraphQL schema\", \"module boundary\", \"interface contract\"."
 ---
 
 # API and Interface Design

--- a/skills/ci-cd-and-automation/SKILL.md
+++ b/skills/ci-cd-and-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-cd-and-automation
-description: Automates CI/CD pipeline setup. Use when setting up or modifying build and deployment pipelines. Use when you need to automate quality gates, configure test runners in CI, or establish deployment strategies.
+description: "Automates CI/CD pipeline setup. Use when setting up or modifying build and deployment pipelines. Use when you need to automate quality gates, configure test runners in CI, or establish deployment strategies. WHEN: \"set up CI\", \"CI/CD pipeline\", \"GitHub Actions workflow\", \"quality gates\", \"deployment pipeline\"."
 ---
 
 # CI/CD and Automation

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review-and-quality
-description: Conducts multi-axis code review. Use before merging any change. Use when reviewing code written by yourself, another agent, or a human. Use when you need to assess code quality across multiple dimensions before it enters the main branch.
+description: "Conducts multi-axis code review. Use before merging any change. Use when reviewing code written by yourself, another agent, or a human. Use when you need to assess code quality across multiple dimensions before it enters the main branch. WHEN: \"review this code\", \"code review\", \"before merging\", \"review my PR\", \"assess code quality\"."
 ---
 
 # Code Review and Quality

--- a/skills/code-simplification/SKILL.md
+++ b/skills/code-simplification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-simplification
-description: Simplifies code for clarity. Use when refactoring code for clarity without changing behavior. Use when code works but is harder to read, maintain, or extend than it should be. Use when reviewing code that has accumulated unnecessary complexity.
+description: "Simplifies code for clarity. Use when refactoring code for clarity without changing behavior. Use when code works but is harder to read, maintain, or extend than it should be. Use when reviewing code that has accumulated unnecessary complexity. WHEN: \"simplify this\", \"refactor for clarity\", \"clean up this code\", \"reduce complexity\", \"make this readable\"."
 ---
 
 # Code Simplification

--- a/skills/context-engineering/SKILL.md
+++ b/skills/context-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context-engineering
-description: Optimizes agent context setup. Use when starting a new session, when agent output quality degrades, when switching between tasks, or when you need to configure rules files and context for a project.
+description: "Optimizes agent context setup. Use when starting a new session, when agent output quality degrades, when switching between tasks, or when you need to configure rules files and context for a project. WHEN: \"set up context\", \"new agent session\", \"configure agent rules\", \"CLAUDE.md\", \"project conventions for agents\"."
 ---
 
 # Context Engineering

--- a/skills/debugging-and-error-recovery/SKILL.md
+++ b/skills/debugging-and-error-recovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging-and-error-recovery
-description: Guides systematic root-cause debugging. Use when tests fail, builds break, behavior doesn't match expectations, or you encounter any unexpected error. Use when you need a systematic approach to finding and fixing the root cause rather than guessing.
+description: "Guides systematic root-cause debugging. Use when tests fail, builds break, behavior doesn't match expectations, or you encounter any unexpected error. Use when you need a systematic approach to finding and fixing the root cause rather than guessing. WHEN: \"debug this\", \"tests are failing\", \"build is broken\", \"unexpected error\", \"find the root cause\"."
 ---
 
 # Debugging and Error Recovery

--- a/skills/deprecation-and-migration/SKILL.md
+++ b/skills/deprecation-and-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deprecation-and-migration
-description: Manages deprecation and migration. Use when removing old systems, APIs, or features. Use when migrating users from one implementation to another. Use when deciding whether to maintain or sunset existing code.
+description: "Manages deprecation and migration. Use when removing old systems, APIs, or features. Use when migrating users from one implementation to another. Use when deciding whether to maintain or sunset existing code. WHEN: \"deprecate this\", \"migrate users\", \"sunset feature\", \"remove old API\", \"migration plan\"."
 ---
 
 # Deprecation and Migration

--- a/skills/documentation-and-adrs/SKILL.md
+++ b/skills/documentation-and-adrs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: documentation-and-adrs
-description: Records decisions and documentation. Use when making architectural decisions, changing public APIs, shipping features, or when you need to record context that future engineers and agents will need to understand the codebase.
+description: "Records decisions and documentation. Use when making architectural decisions, changing public APIs, shipping features, or when you need to record context that future engineers and agents will need to understand the codebase. WHEN: \"write an ADR\", \"architecture decision\", \"document this\", \"record context\", \"update the docs\"."
 ---
 
 # Documentation and ADRs

--- a/skills/doubt-driven-development/SKILL.md
+++ b/skills/doubt-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doubt-driven-development
-description: Subjects every non-trivial decision to a fresh-context adversarial review before it stands. Use when correctness matters more than speed, when working in unfamiliar code, when stakes are high (production, security-sensitive logic, irreversible operations), or any time a confident output would be cheaper to verify now than to debug later.
+description: "Subjects every non-trivial decision to a fresh-context adversarial review before it stands. Use when correctness matters more than speed, when working in unfamiliar code, when stakes are high (production, security-sensitive logic, irreversible operations), or any time a confident output would be cheaper to verify now than to debug later. WHEN: \"verify this assumption\", \"double-check this\", \"adversarial review\", \"before I commit\", \"high-stakes change\"."
 ---
 
 # Doubt-Driven Development

--- a/skills/frontend-ui-engineering/SKILL.md
+++ b/skills/frontend-ui-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-ui-engineering
-description: Builds production-quality UIs. Use when building or modifying user-facing interfaces. Use when creating components, implementing layouts, managing state, or when the output needs to look and feel production-quality rather than AI-generated.
+description: "Builds production-quality UIs. Use when building or modifying user-facing interfaces. Use when creating components, implementing layouts, managing state, or when the output needs to look and feel production-quality rather than AI-generated. WHEN: \"build a UI\", \"create a component\", \"design a layout\", \"polish the UI\", \"production-quality frontend\"."
 ---
 
 # Frontend UI Engineering

--- a/skills/git-workflow-and-versioning/SKILL.md
+++ b/skills/git-workflow-and-versioning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow-and-versioning
-description: Structures git workflow practices. Use when making any code change. Use when committing, branching, resolving conflicts, or when you need to organize work across multiple parallel streams.
+description: "Structures git workflow practices. Use when making any code change. Use when committing, branching, resolving conflicts, or when you need to organize work across multiple parallel streams. WHEN: \"create a branch\", \"commit message\", \"resolve merge conflict\", \"git workflow\", \"parallel work\"."
 ---
 
 # Git Workflow and Versioning

--- a/skills/incremental-implementation/SKILL.md
+++ b/skills/incremental-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: incremental-implementation
-description: Delivers changes incrementally. Use when implementing any feature or change that touches more than one file. Use when you're about to write a large amount of code at once, or when a task feels too big to land in one step.
+description: "Delivers changes incrementally. Use when implementing any feature or change that touches more than one file. Use when you're about to write a large amount of code at once, or when a task feels too big to land in one step. WHEN: \"implement this feature\", \"ship in increments\", \"break this down\", \"feature is too big\", \"stepwise change\"."
 ---
 
 # Incremental Implementation

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-optimization
-description: Optimizes application performance. Use when performance requirements exist, when you suspect performance regressions, or when Core Web Vitals or load times need improvement. Use when profiling reveals bottlenecks that need fixing.
+description: "Optimizes application performance. Use when performance requirements exist, when you suspect performance regressions, or when Core Web Vitals or load times need improvement. Use when profiling reveals bottlenecks that need fixing. WHEN: \"optimize performance\", \"slow page\", \"Core Web Vitals\", \"performance regression\", \"profile this\"."
 ---
 
 # Performance Optimization

--- a/skills/planning-and-task-breakdown/SKILL.md
+++ b/skills/planning-and-task-breakdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: planning-and-task-breakdown
-description: Breaks work into ordered tasks. Use when you have a spec or clear requirements and need to break work into implementable tasks. Use when a task feels too large to start, when you need to estimate scope, or when parallel work is possible.
+description: "Breaks work into ordered tasks. Use when you have a spec or clear requirements and need to break work into implementable tasks. Use when a task feels too large to start, when you need to estimate scope, or when parallel work is possible. WHEN: \"break down this work\", \"create tasks\", \"plan the work\", \"estimate scope\", \"task breakdown\"."
 ---
 
 # Planning and Task Breakdown

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-and-hardening
-description: Hardens code against vulnerabilities. Use when handling user input, authentication, data storage, or external integrations. Use when building any feature that accepts untrusted data, manages user sessions, or interacts with third-party services.
+description: "Hardens code against vulnerabilities. Use when handling user input, authentication, data storage, or external integrations. Use when building any feature that accepts untrusted data, manages user sessions, or interacts with third-party services. WHEN: \"security review\", \"harden this\", \"auth flow\", \"validate input\", \"audit for vulnerabilities\"."
 ---
 
 # Security and Hardening

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shipping-and-launch
-description: Prepares production launches. Use when preparing to deploy to production. Use when you need a pre-launch checklist, when setting up monitoring, when planning a staged rollout, or when you need a rollback strategy.
+description: "Prepares production launches. Use when preparing to deploy to production. Use when you need a pre-launch checklist, when setting up monitoring, when planning a staged rollout, or when you need a rollback strategy. WHEN: \"ready to ship\", \"production launch\", \"rollout plan\", \"rollback strategy\", \"pre-launch checklist\"."
 ---
 
 # Shipping and Launch

--- a/skills/source-driven-development/SKILL.md
+++ b/skills/source-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: source-driven-development
-description: Grounds every implementation decision in official documentation. Use when you want authoritative, source-cited code free from outdated patterns. Use when building with any framework or library where correctness matters.
+description: "Grounds every implementation decision in official documentation. Use when you want authoritative, source-cited code free from outdated patterns. Use when building with any framework or library where correctness matters. WHEN: \"check the docs\", \"official documentation\", \"source-cited code\", \"verify against docs\", \"framework conventions\"."
 ---
 
 # Source-Driven Development

--- a/skills/spec-driven-development/SKILL.md
+++ b/skills/spec-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-driven-development
-description: Creates specs before coding. Use when starting a new project, feature, or significant change and no specification exists yet. Use when requirements are unclear, ambiguous, or only exist as a vague idea.
+description: "Creates specs before coding. Use when starting a new project, feature, or significant change and no specification exists yet. Use when requirements are unclear, ambiguous, or only exist as a vague idea. WHEN: \"write a spec\", \"new feature spec\", \"before coding\", \"clarify requirements\", \"spec this out\"."
 ---
 
 # Spec-Driven Development

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-driven-development
-description: Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior. Use when you need to prove that code works, when a bug report arrives, or when you're about to modify existing functionality.
+description: "Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior. Use when you need to prove that code works, when a bug report arrives, or when you're about to modify existing functionality. WHEN: \"write tests first\", \"TDD\", \"test-driven\", \"red green refactor\", \"test this behavior\"."
 ---
 
 # Test-Driven Development

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-agent-skills
-description: Discovers and invokes agent skills. Use when starting a session or when you need to discover which skill applies to the current task. This is the meta-skill that governs how all other skills are discovered and invoked.
+description: "Discovers and invokes agent skills. Use when starting a session or when you need to discover which skill applies to the current task. This is the meta-skill that governs how all other skills are discovered and invoked. WHEN: \"which skill applies\", \"find a skill\", \"skill discovery\", \"meta-skill\", \"how do skills work\"."
 ---
 
 # Using Agent Skills


### PR DESCRIPTION
## Summary

Adds an explicit `WHEN: "phrase1", "phrase2", ...` clause to the description of **20 of the 22 skills**, preserving every existing `Use when...` sentence unchanged. The other 2 skills (`idea-refine`, `browser-testing-with-devtools`) are handled by #174 and were skipped here to avoid merge conflicts — happy to follow up if both PRs land.

This is **purely additive**: no skill body content was touched, no `Use when...` prose was removed, no behavior changes. Just richer machine-readable trigger metadata.

## Why this matters

The frontmatter `description` is the only thing an agent sees when deciding whether to invoke a skill. `AGENTS.md` line 109 already calls out the desired format:

> *"description: {One sentence describing when to use this skill. Include trigger phrases like `\"Deploy my app\"`, `\"Check logs\"`, etc.}"*

But the actual skills in the repo only used prose like `Use when implementing any feature...`. That works for full-sentence semantic matching, but loses signal for agents and orchestrators that route on **short, distinctive keyword tokens**. Adding a `WHEN:` clause with 4–5 quoted phrases per skill closes that gap without changing how a human or LLM reads the description.

Concretely, before this PR the skills would only fire on agents that semantically parse "Use when..." clauses. After this PR they also fire on direct intent keywords like:

- `"create a branch"` → `git-workflow-and-versioning`
- `"Core Web Vitals"` → `performance-optimization`
- `"write an ADR"` → `documentation-and-adrs`
- `"red green refactor"` → `test-driven-development`
- `"adversarial review"` → `doubt-driven-development`

…and so on across all 20 touched skills.

## What changed — pattern

Every edit follows the same shape. Example (`api-and-interface-design`):

```diff
- description: Guides stable API and interface design. Use when designing APIs, module boundaries, or any public interface. Use when creating REST or GraphQL endpoints, defining type contracts between modules, or establishing boundaries between frontend and backend.
+ description: "Guides stable API and interface design. Use when designing APIs, module boundaries, or any public interface. Use when creating REST or GraphQL endpoints, defining type contracts between modules, or establishing boundaries between frontend and backend. WHEN: \"design an API\", \"REST endpoint\", \"GraphQL schema\", \"module boundary\", \"interface contract\"."
```

Two mechanical things happen on every line:

1. The bare YAML scalar is wrapped in double quotes so the inner quoted phrases are unambiguous to parsers. Inner `"` are escaped as `\"` per YAML spec.
2. A `WHEN: "...", "...", "...", "...", "..."` clause is appended at the end. Phrases were chosen to be distinctive (avoiding overlap with adjacent skills like `code-review-and-quality` vs `code-simplification`).

## Files touched (20)

`api-and-interface-design`, `ci-cd-and-automation`, `code-review-and-quality`, `code-simplification`, `context-engineering`, `debugging-and-error-recovery`, `deprecation-and-migration`, `documentation-and-adrs`, `doubt-driven-development`, `frontend-ui-engineering`, `git-workflow-and-versioning`, `incremental-implementation`, `performance-optimization`, `planning-and-task-breakdown`, `security-and-hardening`, `shipping-and-launch`, `source-driven-development`, `spec-driven-development`, `test-driven-development`, `using-agent-skills`.

## How this was driven

The audit and pattern came from [**sensei**](https://github.com/spboyer/sensei), a Ralph-loop tool for scoring and improving skill frontmatter compliance across a catalog. Sensei scored every skill in this repo and surfaced the same gap on 21 of 22: no explicit trigger keywords. This PR applies the lower-risk *additive* variant — meaning sensei's preferred `WHEN:` markers coexist with the repo's documented `Use when...` prose rather than replacing it. Two other sensei findings were intentionally **not** applied:

- **Token trimming.** Sensei's 500-token soft limit doesn't match this repo's workflow-skill style; every skill is well under the 5k hard limit and the body content is intentional. Not in scope.
- **Classification prefixes** (`**WORKFLOW SKILL**`, etc.). Cosmetic; not worth 22 files of churn.

## Testing

This repo is documentation-only (`AGENTS.md`: *"npm test — Not applicable"*), so verification is by structural checks. Verified locally with a Python YAML parser:

- ✅ All 22 SKILL.md frontmatters parse as valid YAML
- ✅ All 22 descriptions are within the 1024-character hard limit
- ✅ All 22 still begin with a third-person action verb
- ✅ All 22 still contain a `Use when...` clause (additive guarantee)
- ✅ `git diff` shows exactly 20 files, 20 insertions, 20 deletions — no body changes

### One soft tradeoff to acknowledge

Sensei recommends descriptions stay under 60 words. After this PR, a handful (`doubt-driven-development` at 62, `incremental-implementation` at 57, `planning-and-task-breakdown` at 57) sit slightly over that soft target — the natural cost of keeping the original `Use when...` prose **and** adding `WHEN:` phrases. They are all comfortably under the 1024-character hard limit. If you'd prefer I trim the `Use when...` clauses on those few to stay strictly ≤60 words, happy to follow up.

## Relationship to #174

Independent and stackable. #174 fixes the two outlier skills (`idea-refine` description was too short; `browser-testing-with-devtools` had its MCP dependency buried). This PR upgrades the trigger metadata across the rest of the catalog. Either can merge first; no conflict either way.
