### PR TITLE
docs(copilot): fix agent file naming — use *.agent.md extension

### DIFF
--- a/docs/copilot-setup.md
+++ b/docs/copilot-setup.md
@@ -16,15 +16,20 @@ cat /path/to/agent-skills/skills/code-review-and-quality/SKILL.md > .github/skil
 
 For more details, refer [Creating agent skills for GitHub Copilot](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-skills).
 
-### Agent Personas (agents.md)
+### Agent Personas (*.agent.md)
 
 Copilot supports specialized agent personas. Use the agent-skills agents:
 
+> **Important:** GitHub Copilot requires custom agent files to be named `*.agent.md`.
+> Files named `*.md` are silently ignored by Copilot.
+> See [VS Code custom agents docs](https://code.visualstudio.com/docs/copilot/customization/custom-agents#_custom-agent-file-structure) for details.
+
 ```bash
-# Copy agent definitions
-cp /path/to/agent-skills/agents/code-reviewer.md .github/agents/code-reviewer.md
-cp /path/to/agent-skills/agents/test-engineer.md .github/agents/test-engineer.md
-cp /path/to/agent-skills/agents/security-auditor.md .github/agents/security-auditor.md
+# Create the agents directory and copy agent definitions
+mkdir -p .github/agents
+cp /path/to/agent-skills/agents/code-reviewer.md .github/agents/code-reviewer.agent.md
+cp /path/to/agent-skills/agents/test-engineer.md .github/agents/test-engineer.agent.md
+cp /path/to/agent-skills/agents/security-auditor.md .github/agents/security-auditor.agent.md
 ```
 
 Invoke agents in Copilot Chat:


### PR DESCRIPTION
## Summary

Closes #179.

The Copilot setup guide told users to copy agent persona files with a plain `.md` extension:

```bash
cp agents/code-reviewer.md .github/agents/code-reviewer.md
```

GitHub Copilot requires custom agent files to be named `*.agent.md` ([VS Code docs](https://code.visualstudio.com/docs/copilot/customization/custom-agents#_custom-agent-file-structure)). Files that do not match this pattern are silently ignored, so `@code-reviewer`, `@test-engineer`, and `@security-auditor` would never appear in Copilot Chat when following the old instructions.

## Changes (`docs/copilot-setup.md`)

- Rename all three `cp` targets to use the `.agent.md` suffix
- Add `mkdir -p .github/agents` (was missing — `cp` would have failed without the directory)
- Add a callout block explaining the naming requirement with a link to the VS Code custom agents docs
- Update the section heading from `(agents.md)` → `(*.agent.md)` to make the convention visible at a glance

## Test plan

- [ ] Follow the updated instructions in a fresh repo and verify `@code-reviewer` appears in Copilot Chat
- [ ] Confirm no other docs reference the old `.md`-only naming for Copilot agents