### PR TITLE
docs: add pull request readiness workflow

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,43 @@
+---
+description: Prepare a reviewable pull request with clean commits, evidence, and follow-up plan
+---
+
+Invoke the agent-skills:git-workflow-and-versioning skill. If the change includes code or behavior changes, also invoke agent-skills:code-review-and-quality before creating the PR.
+
+Prepare the current branch for a pull request:
+
+1. Inspect repository contribution rules, PR template, branch target, and required checks.
+2. Review `git status`, staged changes, unstaged changes, and recent commits.
+3. Confirm the diff is focused; split unrelated changes before opening the PR.
+4. Run the smallest relevant verification commands and capture exact command output.
+5. Ensure commits are atomic, descriptive, and signed-off if the repository requires DCO.
+6. Draft a PR title and body that explains the problem, the fix, tests run, and any known risks.
+7. Check for duplicate open PRs or issues before publishing.
+8. If the user explicitly asked to publish, push the branch and open the PR with the repository's preferred tool.
+
+## Output
+
+```markdown
+## PR Readiness
+
+### Scope
+- [What changed and why]
+
+### Verification
+- [Exact commands run and result]
+
+### Risk
+- [Known risk, follow-up, or "None identified"]
+
+### PR
+- Title: [...]
+- Body: [...]
+- Link: [URL if opened, otherwise "not opened"]
+```
+
+## Rules
+
+1. Do not open or push a PR unless the user explicitly asked for a public action in this turn.
+2. Do not include unrelated cleanup, generated clutter, secrets, local config, or hidden tool attribution.
+3. Do not paper over failing tests; explain any known failure clearly in the PR body.
+4. After opening the PR, watch initial CI long enough to catch immediate bot failures.

--- a/.gemini/commands/pr.toml
+++ b/.gemini/commands/pr.toml
@@ -1,0 +1,43 @@
+description = "Prepare a reviewable pull request with clean commits, evidence, and follow-up plan"
+
+prompt = """
+Invoke the git-workflow-and-versioning skill. If the change includes code or behavior changes, also invoke code-review-and-quality before creating the PR.
+
+Prepare the current branch for a pull request:
+
+1. Inspect repository contribution rules, PR template, branch target, and required checks.
+2. Review `git status`, staged changes, unstaged changes, and recent commits.
+3. Confirm the diff is focused; split unrelated changes before opening the PR.
+4. Run the smallest relevant verification commands and capture exact command output.
+5. Ensure commits are atomic, descriptive, and signed-off if the repository requires DCO.
+6. Draft a PR title and body that explains the problem, the fix, tests run, and any known risks.
+7. Check for duplicate open PRs or issues before publishing.
+8. If the user explicitly asked to publish, push the branch and open the PR with the repository's preferred tool.
+
+## Output
+
+```markdown
+## PR Readiness
+
+### Scope
+- [What changed and why]
+
+### Verification
+- [Exact commands run and result]
+
+### Risk
+- [Known risk, follow-up, or "None identified"]
+
+### PR
+- Title: [...]
+- Body: [...]
+- Link: [URL if opened, otherwise "not opened"]
+```
+
+## Rules
+
+1. Do not open or push a PR unless the user explicitly asked for a public action in this turn.
+2. Do not include unrelated cleanup, generated clutter, secrets, local config, or hidden tool attribution.
+3. Do not paper over failing tests; explain any known failure clearly in the PR body.
+4. After opening the PR, watch initial CI long enough to catch immediate bot failures.
+"""

--- a/README.md
+++ b/README.md
@@ -23,18 +23,19 @@ Skills encode the workflows, quality gates, and best practices that senior engin
 
 8 slash commands that map to the development lifecycle. Each one activates the right skills automatically.
 
-| What you're doing | Command | Key principle |
-|-------------------|---------|---------------|
-| Define what to build | `/spec` | Spec before code |
-| Plan how to build it | `/plan` | Small, atomic tasks |
-| Build incrementally | `/build` | One slice at a time |
-| Prove it works | `/test` | Tests are proof |
-| Review before merge | `/review` | Improve code health |
-| Audit web performance | `/webperf` | Measure before you optimize |
-| Simplify the code | `/code-simplify` | Clarity over cleverness |
-| Ship to production | `/ship` | Faster is safer |
+| What you're doing      | Command          | Key principle                     |
+| ---------------------- | ---------------- | --------------------------------- |
+| Define what to build   | `/spec`          | Spec before code                  |
+| Plan how to build it   | `/plan`          | Small, atomic tasks               |
+| Build incrementally    | `/build`         | One slice at a time               |
+| Prove it works         | `/test`          | Tests are proof                   |
+| Review before merge    | `/review`        | Improve code health               |
+| Prepare a pull request | `/pr`            | Reviewable change, clean evidence |
+| Audit web performance  | `/webperf`       | Measure before you optimize       |
+| Simplify the code      | `/code-simplify` | Clarity over cleverness           |
+| Ship to production     | `/ship`          | Faster is safer                   |
 
-Want fewer manual steps once the spec exists? **`/build auto`** generates the plan and implements every task in a single approved pass — you approve the plan once, then it runs autonomously. It removes the human stepping *between* tasks, not the verification: every task is still test-driven and committed individually, and it pauses on failures or risky steps.
+Want fewer manual steps once the spec exists? **`/build auto`** generates the plan and implements every task in a single approved pass — you approve the plan once, then it runs autonomously. It removes the human stepping _between_ tasks, not the verification: every task is still test-driven and committed individually, and it pauses on failures or risky steps.
 
 Skills also activate automatically based on what you're doing — designing an API triggers `api-and-interface-design`, building UI triggers `frontend-ui-engineering`, and so on.
 
@@ -70,12 +71,14 @@ Prefer a native integration? Pick your tool below.
 ```
 
 > **SSH errors?** The marketplace clones repos via SSH. If you don't have SSH keys set up on GitHub, either [add your SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) or use the full HTTPS URL to force HTTPS cloning during the marketplace-add step:
+>
 > ```bash
 > /plugin marketplace add https://github.com/addyosmani/agent-skills.git
 > /plugin install agent-skills@addy-agent-skills
 > ```
 >
 > If `/plugin install` still fails with `git@github.com: Permission denied (publickey)` on Windows or macOS, the recommended workaround is to configure Git once to rewrite GitHub SSH URLs to HTTPS for subprocess clones:
+>
 > ```bash
 > git config --global url."https://github.com/".insteadOf git@github.com:
 > ```
@@ -183,8 +186,6 @@ Skills are plain Markdown - they work with any agent that accepts system prompts
 
 </details>
 
-
-
 ---
 
 ## Adoption
@@ -199,62 +200,62 @@ The commands above are entry points. The pack includes 24 skills total — 23 li
 
 ### Meta - Discover which skill applies
 
-| Skill | What It Does | Use When |
-|-------|-------------|----------|
+| Skill                                                    | What It Does                                                                      | Use When                                           |
+| -------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------------------------- |
 | [using-agent-skills](skills/using-agent-skills/SKILL.md) | Maps incoming work to the right skill workflow and defines shared operating rules | Starting a session or deciding which skill applies |
 
 ### Define - Clarify what to build
 
-| Skill | What It Does | Use When |
-|-------|-------------|----------|
-| [interview-me](skills/interview-me/SKILL.md) | One-question-at-a-time interview that extracts what the user actually wants instead of what they think they should want, until ~95% confidence | The ask is underspecified, or the user invokes "interview me" / "grill me" |
-| [idea-refine](skills/idea-refine/SKILL.md) | Structured divergent/convergent thinking to turn vague ideas into concrete proposals | You have a rough concept that needs exploration |
-| [spec-driven-development](skills/spec-driven-development/SKILL.md) | Write a PRD covering objectives, commands, structure, code style, testing, and boundaries before any code | Starting a new project, feature, or significant change |
+| Skill                                                              | What It Does                                                                                                                                   | Use When                                                                   |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| [interview-me](skills/interview-me/SKILL.md)                       | One-question-at-a-time interview that extracts what the user actually wants instead of what they think they should want, until ~95% confidence | The ask is underspecified, or the user invokes "interview me" / "grill me" |
+| [idea-refine](skills/idea-refine/SKILL.md)                         | Structured divergent/convergent thinking to turn vague ideas into concrete proposals                                                           | You have a rough concept that needs exploration                            |
+| [spec-driven-development](skills/spec-driven-development/SKILL.md) | Write a PRD covering objectives, commands, structure, code style, testing, and boundaries before any code                                      | Starting a new project, feature, or significant change                     |
 
 ### Plan - Break it down
 
-| Skill | What It Does | Use When |
-|-------|-------------|----------|
+| Skill                                                                      | What It Does                                                                                  | Use When                                     |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------- |
 | [planning-and-task-breakdown](skills/planning-and-task-breakdown/SKILL.md) | Decompose specs into small, verifiable tasks with acceptance criteria and dependency ordering | You have a spec and need implementable units |
 
 ### Build - Write the code
 
-| Skill | What It Does | Use When |
-|-------|-------------|----------|
-| [incremental-implementation](skills/incremental-implementation/SKILL.md) | Thin vertical slices - implement, test, verify, commit. Feature flags, safe defaults, rollback-friendly changes | Any change touching more than one file |
-| [test-driven-development](skills/test-driven-development/SKILL.md) | Red-Green-Refactor, test pyramid (80/15/5), test sizes, DAMP over DRY, Beyonce Rule, browser testing | Implementing logic, fixing bugs, or changing behavior |
-| [context-engineering](skills/context-engineering/SKILL.md) | Feed agents the right information at the right time - rules files, context packing, MCP integrations | Starting a session, switching tasks, or when output quality drops |
-| [source-driven-development](skills/source-driven-development/SKILL.md) | Ground every framework decision in official documentation - verify, cite sources, flag what's unverified | You want authoritative, source-cited code for any framework or library |
-| [doubt-driven-development](skills/doubt-driven-development/SKILL.md) | Adversarial fresh-context review of every non-trivial decision in-flight - CLAIM → EXTRACT → DOUBT → RECONCILE → STOP, with optional user-authorized cross-model escalation | Stakes are high (production, security, irreversible), working in unfamiliar code, or a confident output is cheaper to verify now than to debug later |
-| [frontend-ui-engineering](skills/frontend-ui-engineering/SKILL.md) | Component architecture, design systems, state management, responsive design, WCAG 2.1 AA accessibility | Building or modifying user-facing interfaces |
-| [api-and-interface-design](skills/api-and-interface-design/SKILL.md) | Contract-first design, Hyrum's Law, One-Version Rule, error semantics, boundary validation | Designing APIs, module boundaries, or public interfaces |
+| Skill                                                                    | What It Does                                                                                                                                                                | Use When                                                                                                                                             |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [incremental-implementation](skills/incremental-implementation/SKILL.md) | Thin vertical slices - implement, test, verify, commit. Feature flags, safe defaults, rollback-friendly changes                                                             | Any change touching more than one file                                                                                                               |
+| [test-driven-development](skills/test-driven-development/SKILL.md)       | Red-Green-Refactor, test pyramid (80/15/5), test sizes, DAMP over DRY, Beyonce Rule, browser testing                                                                        | Implementing logic, fixing bugs, or changing behavior                                                                                                |
+| [context-engineering](skills/context-engineering/SKILL.md)               | Feed agents the right information at the right time - rules files, context packing, MCP integrations                                                                        | Starting a session, switching tasks, or when output quality drops                                                                                    |
+| [source-driven-development](skills/source-driven-development/SKILL.md)   | Ground every framework decision in official documentation - verify, cite sources, flag what's unverified                                                                    | You want authoritative, source-cited code for any framework or library                                                                               |
+| [doubt-driven-development](skills/doubt-driven-development/SKILL.md)     | Adversarial fresh-context review of every non-trivial decision in-flight - CLAIM → EXTRACT → DOUBT → RECONCILE → STOP, with optional user-authorized cross-model escalation | Stakes are high (production, security, irreversible), working in unfamiliar code, or a confident output is cheaper to verify now than to debug later |
+| [frontend-ui-engineering](skills/frontend-ui-engineering/SKILL.md)       | Component architecture, design systems, state management, responsive design, WCAG 2.1 AA accessibility                                                                      | Building or modifying user-facing interfaces                                                                                                         |
+| [api-and-interface-design](skills/api-and-interface-design/SKILL.md)     | Contract-first design, Hyrum's Law, One-Version Rule, error semantics, boundary validation                                                                                  | Designing APIs, module boundaries, or public interfaces                                                                                              |
 
 ### Verify - Prove it works
 
-| Skill | What It Does | Use When |
-|-------|-------------|----------|
+| Skill                                                                          | What It Does                                                                                                    | Use When                                              |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
 | [browser-testing-with-devtools](skills/browser-testing-with-devtools/SKILL.md) | Chrome DevTools MCP for live runtime data - DOM inspection, console logs, network traces, performance profiling | Building or debugging anything that runs in a browser |
-| [debugging-and-error-recovery](skills/debugging-and-error-recovery/SKILL.md) | Five-step triage: reproduce, localize, reduce, fix, guard. Stop-the-line rule, safe fallbacks | Tests fail, builds break, or behavior is unexpected |
+| [debugging-and-error-recovery](skills/debugging-and-error-recovery/SKILL.md)   | Five-step triage: reproduce, localize, reduce, fix, guard. Stop-the-line rule, safe fallbacks                   | Tests fail, builds break, or behavior is unexpected   |
 
 ### Review - Quality gates before merge
 
-| Skill | What It Does | Use When |
-|-------|-------------|----------|
-| [code-review-and-quality](skills/code-review-and-quality/SKILL.md) | Five-axis review, change sizing (~100 lines), severity labels (Nit/Optional/FYI), review speed norms, splitting strategies | Before merging any change |
-| [code-simplification](skills/code-simplification/SKILL.md) | Chesterton's Fence, Rule of 500, reduce complexity while preserving exact behavior | Code works but is harder to read or maintain than it should be |
-| [security-and-hardening](skills/security-and-hardening/SKILL.md) | OWASP Top 10 prevention, auth patterns, secrets management, dependency auditing, three-tier boundary system | Handling user input, auth, data storage, or external integrations |
-| [performance-optimization](skills/performance-optimization/SKILL.md) | Measure-first approach - Core Web Vitals targets, profiling workflows, bundle analysis, anti-pattern detection | Performance requirements exist or you suspect regressions |
+| Skill                                                                | What It Does                                                                                                               | Use When                                                          |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [code-review-and-quality](skills/code-review-and-quality/SKILL.md)   | Five-axis review, change sizing (~100 lines), severity labels (Nit/Optional/FYI), review speed norms, splitting strategies | Before merging any change                                         |
+| [code-simplification](skills/code-simplification/SKILL.md)           | Chesterton's Fence, Rule of 500, reduce complexity while preserving exact behavior                                         | Code works but is harder to read or maintain than it should be    |
+| [security-and-hardening](skills/security-and-hardening/SKILL.md)     | OWASP Top 10 prevention, auth patterns, secrets management, dependency auditing, three-tier boundary system                | Handling user input, auth, data storage, or external integrations |
+| [performance-optimization](skills/performance-optimization/SKILL.md) | Measure-first approach - Core Web Vitals targets, profiling workflows, bundle analysis, anti-pattern detection             | Performance requirements exist or you suspect regressions         |
 
 ### Ship - Deploy with confidence
 
-| Skill | What It Does | Use When |
-|-------|-------------|----------|
-| [git-workflow-and-versioning](skills/git-workflow-and-versioning/SKILL.md) | Trunk-based development, atomic commits, change sizing (~100 lines), the commit-as-save-point pattern | Making any code change (always) |
-| [ci-cd-and-automation](skills/ci-cd-and-automation/SKILL.md) | Shift Left, Faster is Safer, feature flags, quality gate pipelines, failure feedback loops | Setting up or modifying build and deploy pipelines |
-| [deprecation-and-migration](skills/deprecation-and-migration/SKILL.md) | Code-as-liability mindset, compulsory vs advisory deprecation, migration patterns, zombie code removal | Removing old systems, migrating users, or sunsetting features |
-| [documentation-and-adrs](skills/documentation-and-adrs/SKILL.md) | Architecture Decision Records, API docs, inline documentation standards - document the *why* | Making architectural decisions, changing APIs, or shipping features |
-| [observability-and-instrumentation](skills/observability-and-instrumentation/SKILL.md) | Structured logging, RED metrics, OpenTelemetry tracing, symptom-based alerting - instrument as you build | Adding telemetry, or shipping anything that runs in production |
-| [shipping-and-launch](skills/shipping-and-launch/SKILL.md) | Pre-launch checklists, feature flag lifecycle, staged rollouts, rollback procedures, monitoring setup | Preparing to deploy to production |
+| Skill                                                                                  | What It Does                                                                                                                  | Use When                                                            |
+| -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| [git-workflow-and-versioning](skills/git-workflow-and-versioning/SKILL.md)             | Trunk-based development, atomic commits, pull request readiness, change sizing (~100 lines), the commit-as-save-point pattern | Making any code change (always)                                     |
+| [ci-cd-and-automation](skills/ci-cd-and-automation/SKILL.md)                           | Shift Left, Faster is Safer, feature flags, quality gate pipelines, failure feedback loops                                    | Setting up or modifying build and deploy pipelines                  |
+| [deprecation-and-migration](skills/deprecation-and-migration/SKILL.md)                 | Code-as-liability mindset, compulsory vs advisory deprecation, migration patterns, zombie code removal                        | Removing old systems, migrating users, or sunsetting features       |
+| [documentation-and-adrs](skills/documentation-and-adrs/SKILL.md)                       | Architecture Decision Records, API docs, inline documentation standards - document the _why_                                  | Making architectural decisions, changing APIs, or shipping features |
+| [observability-and-instrumentation](skills/observability-and-instrumentation/SKILL.md) | Structured logging, RED metrics, OpenTelemetry tracing, symptom-based alerting - instrument as you build                      | Adding telemetry, or shipping anything that runs in production      |
+| [shipping-and-launch](skills/shipping-and-launch/SKILL.md)                             | Pre-launch checklists, feature flag lifecycle, staged rollouts, rollback procedures, monitoring setup                         | Preparing to deploy to production                                   |
 
 ---
 
@@ -262,11 +263,11 @@ The commands above are entry points. The pack includes 24 skills total — 23 li
 
 Pre-configured specialist personas for targeted reviews:
 
-| Agent | Role | Perspective |
-|-------|------|-------------|
-| [code-reviewer](agents/code-reviewer.md) | Senior Staff Engineer | Five-axis code review with "would a staff engineer approve this?" standard |
-| [test-engineer](agents/test-engineer.md) | QA Specialist | Test strategy, coverage analysis, and the Prove-It pattern |
-| [security-auditor](agents/security-auditor.md) | Security Engineer | Vulnerability detection, threat modeling, OWASP assessment |
+| Agent                                                        | Role                     | Perspective                                                                                  |
+| ------------------------------------------------------------ | ------------------------ | -------------------------------------------------------------------------------------------- |
+| [code-reviewer](agents/code-reviewer.md)                     | Senior Staff Engineer    | Five-axis code review with "would a staff engineer approve this?" standard                   |
+| [test-engineer](agents/test-engineer.md)                     | QA Specialist            | Test strategy, coverage analysis, and the Prove-It pattern                                   |
+| [security-auditor](agents/security-auditor.md)               | Security Engineer        | Vulnerability detection, threat modeling, OWASP assessment                                   |
 | [web-performance-auditor](agents/web-performance-auditor.md) | Web Performance Engineer | Core Web Vitals audit with Quick/Deep modes and a metric-honesty rule; run it via `/webperf` |
 
 See [docs/agents.md](docs/agents.md) for the decision matrix, orchestration rules, and how personas compose with skills and slash commands.
@@ -277,15 +278,15 @@ See [docs/agents.md](docs/agents.md) for the decision matrix, orchestration rule
 
 Quick-reference material that skills pull in when needed:
 
-| Reference | Covers |
-|-----------|--------|
-| [definition-of-done.md](references/definition-of-done.md) | Project-wide standing bar every change clears, contrasted with per-task acceptance criteria |
-| [testing-patterns.md](references/testing-patterns.md) | Test structure, naming, mocking, React/API/E2E examples, anti-patterns |
-| [security-checklist.md](references/security-checklist.md) | Pre-commit checks, auth, input validation, headers, CORS, OWASP Top 10 |
-| [performance-checklist.md](references/performance-checklist.md) | Core Web Vitals targets, frontend/backend checklists, measurement commands |
-| [accessibility-checklist.md](references/accessibility-checklist.md) | Keyboard nav, screen readers, visual design, ARIA, testing tools |
-| [observability-checklist.md](references/observability-checklist.md) | On-call questions, structured logging, RED/USE metrics, tracing, symptom-based alerting, pre-launch gate |
-| [orchestration-patterns.md](references/orchestration-patterns.md) | Endorsed multi-persona orchestration patterns, anti-patterns, and the "personas don't invoke personas" rule |
+| Reference                                                           | Covers                                                                                                      |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| [definition-of-done.md](references/definition-of-done.md)           | Project-wide standing bar every change clears, contrasted with per-task acceptance criteria                 |
+| [testing-patterns.md](references/testing-patterns.md)               | Test structure, naming, mocking, React/API/E2E examples, anti-patterns                                      |
+| [security-checklist.md](references/security-checklist.md)           | Pre-commit checks, auth, input validation, headers, CORS, OWASP Top 10                                      |
+| [performance-checklist.md](references/performance-checklist.md)     | Core Web Vitals targets, frontend/backend checklists, measurement commands                                  |
+| [accessibility-checklist.md](references/accessibility-checklist.md) | Keyboard nav, screen readers, visual design, ARIA, testing tools                                            |
+| [observability-checklist.md](references/observability-checklist.md) | On-call questions, structured logging, RED/USE metrics, tracing, symptom-based alerting, pre-launch gate    |
+| [orchestration-patterns.md](references/orchestration-patterns.md)   | Endorsed multi-persona orchestration patterns, anti-patterns, and the "personas don't invoke personas" rule |
 
 ---
 
@@ -301,7 +302,7 @@ Every skill follows a consistent anatomy:
 │  │ name: lowercase-hyphen-name               │  │
 │  │ description: Guides agents through [task].│  │
 │  │              Use when…                    │  │
-│  └───────────────────────────────────────────┘  │                                                                                                
+│  └───────────────────────────────────────────┘  │
 │  Overview         → What this skill does        │
 │  When to Use      → Triggering conditions       │
 │  Process          → Step-by-step workflow       │
@@ -365,7 +366,7 @@ agent-skills/
 
 AI coding agents default to the shortest path - which often means skipping specs, tests, security reviews, and the practices that make software reliable. Agent Skills gives agents structured workflows that enforce the same discipline senior engineers bring to production code.
 
-Each skill encodes hard-won engineering judgment: *when* to write a spec, *what* to test, *how* to review, and *when* to ship. These aren't generic prompts - they're the kind of opinionated, process-driven workflows that separate production-quality work from prototype-quality work.
+Each skill encodes hard-won engineering judgment: _when_ to write a spec, _what_ to test, _how_ to review, and _when_ to ship. These aren't generic prompts - they're the kind of opinionated, process-driven workflows that separate production-quality work from prototype-quality work.
 
 Skills bake in best practices from Google's engineering culture — including concepts from [Software Engineering at Google](https://abseil.io/resources/swe-book) and Google's [engineering practices guide](https://google.github.io/eng-practices/). You'll find Hyrum's Law in API design, the Beyonce Rule and test pyramid in testing, change sizing and review speed norms in code review, Chesterton's Fence in simplification, trunk-based development in git workflow, Shift Left and feature flags in CI/CD, and a dedicated deprecation skill treating code as a liability. These aren't abstract principles — they're embedded directly into the step-by-step workflows agents follow.
 
@@ -389,11 +390,11 @@ See [docs/skill-anatomy.md](docs/skill-anatomy.md) for the format specification 
 
 agent-skills is built and maintained by:
 
-| | Name | GitHub | Role |
-|---|------|--------|------|
-| <img src="https://github.com/addyosmani.png?size=120" width="60" height="60" alt="Addy Osmani"> | **Addy Osmani** | [@addyosmani](https://github.com/addyosmani) | Creator |
+|                                                                                                           | Name                 | GitHub                                                 | Role         |
+| --------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------------------------ | ------------ |
+| <img src="https://github.com/addyosmani.png?size=120" width="60" height="60" alt="Addy Osmani">           | **Addy Osmani**      | [@addyosmani](https://github.com/addyosmani)           | Creator      |
 | <img src="https://github.com/federicobartoli.png?size=120" width="60" height="60" alt="Federico Bartoli"> | **Federico Bartoli** | [@federicobartoli](https://github.com/federicobartoli) | Collaborator |
-| <img src="https://github.com/nucliweb.png?size=120" width="60" height="60" alt="Joan León"> | **Joan León** | [@nucliweb](https://github.com/nucliweb) | Collaborator |
+| <img src="https://github.com/nucliweb.png?size=120" width="60" height="60" alt="Joan León">               | **Joan León**        | [@nucliweb](https://github.com/nucliweb)               | Collaborator |
 
 ---
 

--- a/docs/gemini-cli-setup.md
+++ b/docs/gemini-cli-setup.md
@@ -107,18 +107,19 @@ This is useful when you want to ensure a specific workflow is followed without w
 
 ## Slash Commands
 
-The repo ships 8 slash commands under `.gemini/commands/`: 7 lifecycle commands plus the `/webperf` specialist audit. Gemini CLI auto-discovers them when you run from the project root.
+The repo ships 8 slash commands under `.gemini/commands/` that map to the development lifecycle, plus the `/webperf` specialist audit. Gemini CLI auto-discovers them when you run from the project root.
 
-| Command | What it does |
-|---------|--------------|
-| `/spec` | Write a structured spec before writing code |
-| `/planning` | Break work into small, verifiable tasks |
-| `/build` | Implement the next task incrementally |
-| `/test` | Run TDD workflow — red, green, refactor |
-| `/review` | Five-axis code review |
-| `/code-simplify` | Reduce complexity without changing behavior |
-| `/ship` | Pre-launch checklist via parallel persona fan-out |
-| `/webperf` | Audit browser-facing apps for Core Web Vitals and performance issues |
+| Command          | What it does                                                         |
+| ---------------- | -------------------------------------------------------------------- |
+| `/spec`          | Write a structured spec before writing code                          |
+| `/planning`      | Break work into small, verifiable tasks                              |
+| `/build`         | Implement the next task incrementally                                |
+| `/test`          | Run TDD workflow — red, green, refactor                              |
+| `/review`        | Five-axis code review                                                |
+| `/pr`            | Prepare a reviewable pull request                                    |
+| `/code-simplify` | Reduce complexity without changing behavior                          |
+| `/ship`          | Pre-launch checklist via parallel persona fan-out                    |
+| `/webperf`       | Audit browser-facing apps for Core Web Vitals and performance issues |
 
 Each command invokes the corresponding skill automatically — no manual skill loading required.
 
@@ -127,6 +128,6 @@ Each command invokes the corresponding skill automatically — no manual skill l
 ## Usage Tips
 
 1. **Prefer skills over GEMINI.md** — Skills activate on demand and keep your context window focused. Only put skills in GEMINI.md if you want them always loaded.
-2. **Skill descriptions matter** — Each SKILL.md has a `description` field in its frontmatter that tells agents when to activate it. The descriptions in this repo are optimized for auto-discovery across all supported tools (Claude Code, Gemini CLI, etc.) by clearly stating both *what* the skill does and *when* it should be triggered.
+2. **Skill descriptions matter** — Each SKILL.md has a `description` field in its frontmatter that tells agents when to activate it. The descriptions in this repo are optimized for auto-discovery across all supported tools (Claude Code, Gemini CLI, etc.) by clearly stating both _what_ the skill does and _when_ it should be triggered.
 3. **Use agents for review** — Copy `agents/code-reviewer.md` content when requesting structured code reviews.
 4. **Combine with references** — Reference checklists from `references/` when working on specific quality areas like testing or performance.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,6 +19,7 @@ git clone https://github.com/addyosmani/agent-skills.git
 ### 2. Choose a skill
 
 Browse the `skills/` directory. Each subdirectory contains a `SKILL.md` with:
+
 - **When to use** — triggers that indicate this skill applies
 - **Process** — step-by-step workflow
 - **Verification** — how to confirm the work is done
@@ -93,11 +94,11 @@ See [skill-anatomy.md](skill-anatomy.md) for the full specification.
 
 The `agents/` directory contains pre-configured agent personas:
 
-| Agent | Purpose |
-|-------|---------|
-| `code-reviewer.md` | Five-axis code review |
-| `test-engineer.md` | Test strategy and writing |
-| `security-auditor.md` | Vulnerability detection |
+| Agent                        | Purpose                                              |
+| ---------------------------- | ---------------------------------------------------- |
+| `code-reviewer.md`           | Five-axis code review                                |
+| `test-engineer.md`           | Test strategy and writing                            |
+| `security-auditor.md`        | Vulnerability detection                              |
 | `web-performance-auditor.md` | Core Web Vitals & performance audit (via `/webperf`) |
 
 Load an agent definition when you need specialized review. For example, ask your coding agent to "review this change using the code-reviewer agent persona" and provide the agent definition.
@@ -106,17 +107,18 @@ Load an agent definition when you need specialized review. For example, ask your
 
 The `.claude/commands/` directory contains slash commands for Claude Code:
 
-| Command | Skill Invoked |
-|---------|---------------|
-| `/spec` | spec-driven-development |
-| `/plan` | planning-and-task-breakdown |
-| `/build` | incremental-implementation + test-driven-development |
-| `/build auto` | planning-and-task-breakdown → incremental-implementation + test-driven-development (whole plan, one approval) |
-| `/test` | test-driven-development |
-| `/review` | code-review-and-quality |
-| `/code-simplify` | code-simplification |
-| `/ship` | shipping-and-launch |
-| `/webperf` | web-performance-auditor (specialist agent, web apps only) |
+| Command          | Skill Invoked                                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------------------------------- |
+| `/spec`          | spec-driven-development                                                                                       |
+| `/plan`          | planning-and-task-breakdown                                                                                   |
+| `/build`         | incremental-implementation + test-driven-development                                                          |
+| `/build auto`    | planning-and-task-breakdown → incremental-implementation + test-driven-development (whole plan, one approval) |
+| `/test`          | test-driven-development                                                                                       |
+| `/review`        | code-review-and-quality                                                                                       |
+| `/pr`            | git-workflow-and-versioning                                                                                   |
+| `/code-simplify` | code-simplification                                                                                           |
+| `/ship`          | shipping-and-launch                                                                                           |
+| `/webperf`       | web-performance-auditor (specialist agent, web apps only)                                                     |
 
 > **Note:** When installed as a Claude Code plugin you may see a warning like
 > _"Default commands/ folder is ignored because the manifest sets 'commands'"_.
@@ -128,15 +130,15 @@ The `.claude/commands/` directory contains slash commands for Claude Code:
 
 The `references/` directory contains supplementary checklists:
 
-| Reference | Use With |
-|-----------|----------|
-| `testing-patterns.md` | test-driven-development |
-| `performance-checklist.md` | performance-optimization |
-| `security-checklist.md` | security-and-hardening |
-| `accessibility-checklist.md` | frontend-ui-engineering |
-| `definition-of-done.md` | all skills / every change |
+| Reference                    | Use With                          |
+| ---------------------------- | --------------------------------- |
+| `testing-patterns.md`        | test-driven-development           |
+| `performance-checklist.md`   | performance-optimization          |
+| `security-checklist.md`      | security-and-hardening            |
+| `accessibility-checklist.md` | frontend-ui-engineering           |
+| `definition-of-done.md`      | all skills / every change         |
 | `observability-checklist.md` | observability-and-instrumentation |
-| `orchestration-patterns.md` | context-engineering |
+| `orchestration-patterns.md`  | context-engineering               |
 
 Load a reference when you need detailed patterns beyond what the skill covers.
 

--- a/skills/git-workflow-and-versioning/SKILL.md
+++ b/skills/git-workflow-and-versioning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow-and-versioning
-description: Structures git workflow practices. Use when making any code change. Use when committing, branching, resolving conflicts, or when you need to organize work across multiple parallel streams. Use when cutting a release, choosing a semantic version bump, tagging, or writing a changelog.
+description: Structures git workflow practices. Use when making any code change. Use when committing, branching, opening pull requests, resolving conflicts, or when you need to organize work across multiple parallel streams. Use when cutting a release, choosing a semantic version bump, tagging, or writing a changelog.
 ---
 
 # Git Workflow and Versioning
@@ -64,7 +64,7 @@ x1y2z3a Add task feature, fix sidebar, update deps, refactor utils
 
 ### 3. Descriptive Messages
 
-Commit messages explain the *why*, not just the *what*:
+Commit messages explain the _why_, not just the _what_:
 
 ```
 # Good: Explains intent
@@ -79,6 +79,7 @@ update auth.ts
 ```
 
 **Format:**
+
 ```
 <type>: <short description>
 
@@ -86,6 +87,7 @@ update auth.ts
 ```
 
 **Types:**
+
 - `feat` — New feature
 - `fix` — Bug fix
 - `refactor` — Code change that neither fixes a bug nor adds a feature
@@ -165,6 +167,7 @@ git worktree remove ../project-feature-a
 ```
 
 Benefits:
+
 - Multiple agents can work on different features simultaneously
 - No branch switching needed (each directory has its own branch)
 - If one experiment fails, delete the worktree — nothing is lost
@@ -207,6 +210,86 @@ POTENTIAL CONCERNS:
 ```
 
 This pattern catches wrong assumptions early and gives reviewers a clear map of the change. The "DIDN'T TOUCH" section is especially important — it shows you exercised scope discipline and didn't go on an unsolicited renovation.
+
+## Pull Request Workflow
+
+Opening a pull request is a quality gate, not a mechanical upload. The PR should make review easy, show evidence, and leave no ambiguity about what is in scope.
+
+### 1. Check the Contribution Surface
+
+Before pushing:
+
+```bash
+git remote -v
+git branch --show-current
+git status --short
+git log --oneline --decorate -5
+```
+
+- Read `CONTRIBUTING.md`, PR templates, DCO/CLA notes, and required test commands.
+- Confirm the target branch (`main`, `master`, `develop`, release branch) before creating the PR.
+- Search open PRs and issues for duplicate work.
+- For open-source contributions, use an author identity that matches the contributor account and any CLA/DCO requirements.
+
+### 2. Make the Diff Reviewable
+
+Before opening the PR:
+
+- Keep one logical change per PR.
+- Split refactors, formatting, generated output, and behavior changes unless the repository explicitly wants them together.
+- Include generated files only when the repository expects them.
+- Remove local artifacts, debug logs, `.env` files, editor config, and hidden tool attribution.
+- Rebase or merge from the target branch if the repository requires an up-to-date branch.
+
+### 3. Verify and Capture Evidence
+
+Run the smallest commands that prove the change:
+
+```bash
+git diff --stat
+git diff --check
+npm test
+```
+
+Adapt the commands to the repository. Prefer focused package tests first, then broader tests when the blast radius justifies it. If a known unrelated test fails, document the exact failure and why it is unrelated instead of hiding it.
+
+### 4. Write the PR
+
+Use the repository's template when present. A good PR body answers:
+
+```markdown
+## Summary
+
+- What changed and why
+
+## Testing
+
+- `command`: result
+
+## Risk
+
+- Known risks, compatibility notes, or "None identified"
+
+Fixes #123
+```
+
+The title should describe the user-visible or maintainer-visible value:
+
+```
+fix(parser): preserve escaped delimiters in quoted fields
+test(api): cover nil response handling
+docs(skill): add pull request readiness workflow
+```
+
+### 5. Follow Through After Opening
+
+The work is not done when the URL exists:
+
+- Watch initial CI and bot checks long enough to catch formatting, DCO, CLA, or template failures.
+- If a bot fails, fix the branch rather than opening a replacement PR.
+- Address maintainer feedback with small follow-up commits that preserve review context.
+- Avoid force-pushing after review starts unless rebasing or history repair is clearly needed.
+- Do not leave "waiting for review" comments unless you have meaningful new evidence or a maintainer asked for a ping.
 
 ## Pre-Commit Hygiene
 
@@ -269,7 +352,7 @@ git log --grep="validation" --oneline
 
 ## Release & Versioning
 
-Commits are how *you* track change; a **version** is how your *consumers* track it. The moment anything else depends on your code — another team, a published package, a deployed client — "latest on main" stops being a sufficient answer to "what am I running, and is it safe to upgrade?" A version number and a changelog are the contract that answers it.
+Commits are how _you_ track change; a **version** is how your _consumers_ track it. The moment anything else depends on your code — another team, a published package, a deployed client — "latest on main" stops being a sufficient answer to "what am I running, and is it safe to upgrade?" A version number and a changelog are the contract that answers it.
 
 ### Semantic Versioning
 
@@ -300,11 +383,17 @@ A changelog is not `git log`. It's the curated, consumer-facing answer to "what 
 
 ```markdown
 ## [1.4.0] - 2025-06-12
+
 ### Added
+
 - Bulk task import via CSV
+
 ### Fixed
+
 - Timezone drift in recurring task due dates
+
 ### Deprecated
+
 - `GET /v1/tasks/all` — use the paginated `GET /v1/tasks` (removal in 2.0)
 ```
 
@@ -312,17 +401,17 @@ Write the entry in the same change that makes the change, while the impact is fr
 
 ## Common Rationalizations
 
-| Rationalization | Reality |
-|---|---|
-| "I'll commit when the feature is done" | One giant commit is impossible to review, debug, or revert. Commit each slice. |
-| "The message doesn't matter" | Messages are documentation. Future you (and future agents) will need to understand what changed and why. |
-| "I'll squash it all later" | Squashing destroys the development narrative. Prefer clean incremental commits from the start. |
-| "Branches add overhead" | Short-lived branches are free and prevent conflicting work from colliding. Long-lived branches are the problem — merge within 1-3 days. |
-| "I'll split this change later" | Large changes are harder to review, riskier to deploy, and harder to revert. Split before submitting, not after. |
-| "I don't need a .gitignore" | Until `.env` with production secrets gets committed. Set it up immediately. |
-| "It's just a small fix, bump the patch" | Check what consumers can observe. A behavior change they relied on is a major, whatever the diff size. |
-| "The changelog is just the commit log" | Commits are for you; the changelog is for consumers, curated by impact. Generating one from raw commits buries what matters. |
-| "We'll write the changelog at release time" | By then the impact is reconstructed from memory and half of it is missing. Write the entry with the change. |
+| Rationalization                             | Reality                                                                                                                                 |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| "I'll commit when the feature is done"      | One giant commit is impossible to review, debug, or revert. Commit each slice.                                                          |
+| "The message doesn't matter"                | Messages are documentation. Future you (and future agents) will need to understand what changed and why.                                |
+| "I'll squash it all later"                  | Squashing destroys the development narrative. Prefer clean incremental commits from the start.                                          |
+| "Branches add overhead"                     | Short-lived branches are free and prevent conflicting work from colliding. Long-lived branches are the problem — merge within 1-3 days. |
+| "I'll split this change later"              | Large changes are harder to review, riskier to deploy, and harder to revert. Split before submitting, not after.                        |
+| "I don't need a .gitignore"                 | Until `.env` with production secrets gets committed. Set it up immediately.                                                             |
+| "It's just a small fix, bump the patch"     | Check what consumers can observe. A behavior change they relied on is a major, whatever the diff size.                                  |
+| "The changelog is just the commit log"      | Commits are for you; the changelog is for consumers, curated by impact. Generating one from raw commits buries what matters.            |
+| "We'll write the changelog at release time" | By then the impact is reconstructed from memory and half of it is missing. Write the entry with the change.                             |
 
 ## Red Flags
 


### PR DESCRIPTION
## Summary
- add a /pr command for Claude Code and Gemini CLI that prepares reviewable pull requests with scope, verification, risk, and publishing checks
- extend git-workflow-and-versioning with a concrete pull request workflow covering contribution rules, duplicate checks, focused diffs, verification evidence, and CI follow-through
- update README and setup docs to include the new command

Fixes #178

## Testing
- node scripts/validate-skills.js
- git diff --check

## Risk
- Docs-only change; no runtime behavior changes.