### PR TITLE
docs: route all lifecycle skills from meta-skill

### DIFF
--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -30,10 +30,12 @@ Task arrives
     │   └── Browser-based? ───────────→ browser-testing-with-devtools
     ├── Something broke? ──────────────→ debugging-and-error-recovery
     ├── Reviewing code? ───────────────→ code-review-and-quality
+    │   ├── Too complex? ─────────────→ code-simplification
     │   ├── Security concerns? ───────→ security-and-hardening
     │   └── Performance concerns? ────→ performance-optimization
     ├── Committing/branching? ─────────→ git-workflow-and-versioning
     ├── CI/CD pipeline work? ──────────→ ci-cd-and-automation
+    ├── Deprecating/migrating? ────────→ deprecation-and-migration
     ├── Writing docs/ADRs? ───────────→ documentation-and-adrs
     └── Deploying/launching? ─────────→ shipping-and-launch
 ```
@@ -128,7 +130,7 @@ These are the subtle errors that look like productivity but create problems:
 
 2. **Skills are workflows, not suggestions.** Follow the steps in order. Don't skip verification steps.
 
-3. **Multiple skills can apply.** A feature implementation might involve `idea-refine` → `spec-driven-development` → `planning-and-task-breakdown` → `incremental-implementation` → `test-driven-development` → `code-review-and-quality` → `shipping-and-launch` in sequence.
+3. **Multiple skills can apply.** A feature implementation might involve `idea-refine` → `spec-driven-development` → `planning-and-task-breakdown` → `incremental-implementation` → `test-driven-development` → `code-review-and-quality` → `code-simplification` → `shipping-and-launch` in sequence.
 
 4. **When in doubt, start with a spec.** If the task is non-trivial and there's no spec, begin with `spec-driven-development`.
 
@@ -147,9 +149,11 @@ For a complete feature, the typical skill sequence is:
 8.  doubt-driven-development    → Cross-examine non-trivial decisions in-flight
 9.  test-driven-development     → Prove each slice works
 10. code-review-and-quality     → Review before merge
-11. git-workflow-and-versioning → Clean commit history
-12. documentation-and-adrs      → Document decisions
-13. shipping-and-launch         → Deploy safely
+11. code-simplification         → Reduce unnecessary complexity while preserving behavior
+12. git-workflow-and-versioning → Clean commit history
+13. documentation-and-adrs      → Document decisions
+14. deprecation-and-migration   → Retire old systems and move users safely when needed
+15. shipping-and-launch         → Deploy safely
 ```
 
 Not every task needs every skill. A bug fix might only need: `debugging-and-error-recovery` → `test-driven-development` → `code-review-and-quality`.
@@ -172,9 +176,11 @@ Not every task needs every skill. A bug fix might only need: `debugging-and-erro
 | Verify | browser-testing-with-devtools | Chrome DevTools MCP for runtime verification |
 | Verify | debugging-and-error-recovery | Reproduce → localize → fix → guard |
 | Review | code-review-and-quality | Five-axis review with quality gates |
+| Review | code-simplification | Preserve behavior while reducing unnecessary complexity |
 | Review | security-and-hardening | OWASP prevention, input validation, least privilege |
 | Review | performance-optimization | Measure first, optimize only what matters |
 | Ship | git-workflow-and-versioning | Atomic commits, clean history |
 | Ship | ci-cd-and-automation | Automated quality gates on every change |
+| Ship | deprecation-and-migration | Remove old systems and migrate users safely |
 | Ship | documentation-and-adrs | Document the why, not just the what |
 | Ship | shipping-and-launch | Pre-launch checklist, monitoring, rollback plan |


### PR DESCRIPTION
## Summary
- add code-simplification to the using-agent-skills review routing path
- add deprecation-and-migration to the shipping/lifecycle routing path
- keep the lifecycle sequence and quick reference aligned with the full skill set

## Verification
- node scripts/validate-skills.js
- git diff --check

## Notes
The repository already documents both skills in README.md and CLAUDE.md, but the using-agent-skills meta-skill did not route users to them. This keeps the meta-skill in sync with the available lifecycle skills.