### PR TITLE
fix(#145): drop pinning version field from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "agent-skills",
   "description": "Production-grade engineering skills for AI coding agents — covering the full software development lifecycle from spec to ship.",
-  "version": "1.0.0",
   "author": {
     "name": "Addy Osmani"
   },


### PR DESCRIPTION
## Summary

Removes the hard-coded `"version": "1.0.0"` from `.claude-plugin/plugin.json` so Claude Code uses commit-SHA versioning to decide whether an installed plugin is stale. Fixes a real update-delivery bug, not just a cosmetic mismatch with the `0.5.0` / `0.6.0` git tags.

## The bug

Per the [Claude Code marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces#version-resolution-and-release-channels):

> Setting `version` pins the plugin. If `plugin.json` declares `"version": "1.0.0"`, pushing new commits without changing that string does nothing for existing users, because Claude Code sees the same version and keeps the cached copy. Bump the field on every release, or omit it to use the commit SHA.

Two consequences observed in practice:

1. **Users are pinned to old snapshots.** Anyone who ran `/plugin install agent-skills@addy-agent-skills` before today is still on the commit that was HEAD when `version` was first set to `1.0.0`. They are not receiving the 37 commits that landed on `main` after the `0.6.0` release — including the new `doubt-driven-development` and `interview-me` skills, frontmatter cleanups across several existing skills, and cross-reference fixes. `claude plugin update` reports no change because the cached and remote `version` strings are identical.
2. **The current release cadence does not feed the update mechanism.** Tags `0.5.0` and `0.6.0` have already shipped without a corresponding bump in `plugin.json`. So option 2 (manually bumping `version` on every release) has empirically already been forgotten, and it would also require coordinating the bump with release tagging — extra discipline for the same outcome as commit-SHA mode.

I confirmed this end-to-end on a real install today: marketplace `git pull` advanced to `f17c6e8` cleanly, but `claude plugin update agent-skills@addy-agent-skills` did not refresh the cache — only a manual `rsync` of the marketplace clone into `~/.claude/plugins/cache/.../1.0.0/` plus a hand edit of `installed_plugins.json` picked up the new skills.

## Why option 1 over option 2

Same [docs](https://code.claude.com/docs/en/plugin-marketplaces#version-resolution-and-release-channels):

> If you omit `version` and host this marketplace in git, every commit automatically counts as a new version. This is the simplest setup for internal or actively-developed plugins.

Agent-skills fits that profile:

- **Active development**: 37 commits in ~3 weeks between `0.6.0` and `HEAD`.
- **Low per-commit breakage risk**: content is almost entirely markdown `SKILL.md` files. No executable code paths, no schema migrations, no public APIs that downstream consumers integrate against. A bad commit is trivial to revert and only affects which instructions a model reads.
- **Maintainer time**: option 2 requires remembering to bump the field on every release, which has already not happened for `0.5.0` or `0.6.0`. Option 1 needs zero ongoing maintenance.

Git tags and GitHub Releases remain available as editorial milestones — useful for changelog and announcements — but they no longer need to drive the update mechanism. This is the same pattern Homebrew formulas, VS Code extensions, and most actively-developed plugin ecosystems use: a continuous-delivery channel plus optional named releases for communication.

## What this does NOT do

- Does not change any skill content, agent definition, hook, or command.
- Does not touch the marketplace.json or any user-facing documentation.
- Does not introduce a release process change — existing tags and releases continue to work as before.

## Alternative considered

**PR #155** takes option 2 (changes `"1.0.0"` → `"0.6.0"`). That fixes the cosmetic mismatch but (a) is numerically a regression that may or may not be detected as an update depending on how Claude Code compares semver against the already-installed `1.0.0`, and (b) leaves the underlying maintenance burden in place for future releases. Happy to defer if the maintainers prefer that path, but wanted option 1 on the table since @federicobartoli flagged it in the issue thread and no one had sent it.

Closes #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)