### PR TITLE
feat: add local Copilot assets sync script with auto-sync git hooks

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${HOOK_DIR}/.." && pwd)"
+
+"${REPO_DIR}/scripts/sync-copilot-assets.sh"

--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -e
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${HOOK_DIR}/.." && pwd)"
+
+"${REPO_DIR}/scripts/sync-copilot-assets.sh"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules/
 *.log
 .claude/.simplify-ignore-cache/
 .claude/sdd-cache/
+sync-copilot-assets.local.config
+.idea/

--- a/docs/copilot-setup.md
+++ b/docs/copilot-setup.md
@@ -74,6 +74,56 @@ GitHub Copilot supports project-level instructions via `.github/copilot-instruct
 
 Use the agents for targeted review workflows in Copilot Chat.
 
+## Local Sync
+
+Automatically copy skills and agents into every Git project under your local projects directory after each `git pull`.
+
+### One-time setup
+
+```bash
+cd /path/to/agent-skills
+
+cp sync-copilot-assets.config.example sync-copilot-assets.local.config
+# Edit sync-copilot-assets.local.config to set TARGET_ROOT, EXCLUDED_PATHS, etc.
+
+./scripts/install-git-hooks.sh
+```
+
+Verify the hook is installed:
+
+```bash
+git config --local --get core.hooksPath
+# .githooks
+```
+
+### Run manually
+
+```bash
+cd /path/to/agent-skills
+git pull
+./scripts/sync-copilot-assets.sh
+```
+
+### How it works
+
+- Discovers target projects by finding `.git` directories under `TARGET_ROOT`.
+- By default `TARGET_ROOT` is the parent directory of this repo, so cloning `agent-skills` next to your other projects requires no extra configuration.
+- Copies `skills/**/SKILL.md` to `<project>/.github/skills/<skill-name>/SKILL.md`.
+- Copies `agents/*.md` to `<project>/.github/agents/<agent-name>.md`.
+- Skips files that are identical to the source.
+- Updates files that match a previous Git-tracked version of the source (safe upgrade).
+- Reports conflicts when a destination file differs from both the current and all historical source versions.
+- Set `OVERWRITE_EXISTING="true"` in your local config to always overwrite.
+
+### Config options (`sync-copilot-assets.local.config`)
+
+| Variable | Default | Description |
+|---|---|---|
+| `TARGET_ROOT` | parent directory of this repo | Root directory to scan for Git projects |
+| `SYNC_CONTENT` | `both` | What to sync: `skills`, `agents`, or `both` |
+| `OVERWRITE_EXISTING` | `false` | Overwrite files not matching source history |
+| `EXCLUDED_PATHS` | this repo | Paths to exclude from scanning |
+
 ## Usage Tips
 
 1. **Keep instructions concise** — Copilot instructions work best when focused. Summarize the key rules rather than including full skill files.

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HOOKS_DIR="${REPO_DIR}/.githooks"
+
+if [ ! -d "${HOOKS_DIR}" ]; then
+  echo "Error: hooks directory not found: ${HOOKS_DIR}" >&2
+  exit 1
+fi
+
+chmod +x "${HOOKS_DIR}/post-merge"
+chmod +x "${HOOKS_DIR}/post-rewrite"
+
+git -C "${REPO_DIR}" config core.hooksPath .githooks
+
+echo "Git hooks installed with core.hooksPath=.githooks"

--- a/scripts/sync-copilot-assets.sh
+++ b/scripts/sync-copilot-assets.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SOURCE_PARENT_DIR="$(cd "${SOURCE_DIR}/.." && pwd)"
+
+TARGET_ROOT="${SOURCE_PARENT_DIR}"
+SYNC_CONTENT="both"
+OVERWRITE_EXISTING="false"
+EXCLUDED_PATHS=("${SOURCE_DIR}")
+
+TMP_DIR="$(mktemp -d)"
+
+projects_scanned=0
+projects_updated=0
+projects_skipped=0
+conflicts_skipped=0
+skills_copied_or_updated=0
+agents_copied_or_updated=0
+errors_count=0
+updated_project_paths=()
+
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+
+die() {
+  echo "Error: $1" >&2
+  exit 1
+}
+
+load_config_file() {
+  local config_file="$1"
+
+  if [ -f "${config_file}" ]; then
+    source "${config_file}"
+  fi
+}
+
+load_config() {
+  load_config_file "${SOURCE_DIR}/sync-copilot-assets.config"
+  load_config_file "${SOURCE_DIR}/sync-copilot-assets.local.config"
+}
+
+validate_path_exists() {
+  local path="$1"
+
+  if [ ! -e "${path}" ]; then
+    die "Required path does not exist: ${path}"
+  fi
+}
+
+should_sync_skills() {
+  [ "${SYNC_CONTENT}" = "skills" ] || [ "${SYNC_CONTENT}" = "both" ]
+}
+
+should_sync_agents() {
+  [ "${SYNC_CONTENT}" = "agents" ] || [ "${SYNC_CONTENT}" = "both" ]
+}
+
+validate_sync_content() {
+  case "${SYNC_CONTENT}" in
+    skills | agents | both)
+      return 0
+      ;;
+    *)
+      die "SYNC_CONTENT must be skills, agents, or both"
+      ;;
+  esac
+}
+
+validate_paths() {
+  validate_path_exists "${TARGET_ROOT}"
+  validate_path_exists "${SOURCE_DIR}"
+
+  if should_sync_skills; then
+    validate_path_exists "${SOURCE_DIR}/skills"
+  fi
+
+  if should_sync_agents; then
+    validate_path_exists "${SOURCE_DIR}/agents"
+  fi
+}
+
+collect_projects() {
+  local find_args=("${TARGET_ROOT}")
+  local excluded_path=""
+
+  for excluded_path in "${EXCLUDED_PATHS[@]}"; do
+    if [ -z "${excluded_path}" ]; then
+      continue
+    fi
+
+    find_args+=( \( -path "${excluded_path}" -o -path "${excluded_path}/*" \) -prune -o )
+  done
+
+  find "${find_args[@]}" \
+    \( -type d -name ".git" -print -prune \) \
+    -o \( -type f -name ".git" -print \) |
+    while IFS= read -r git_path; do
+      dirname "${git_path}"
+    done |
+    sort -u
+}
+
+collect_skill_sources() {
+  if ! should_sync_skills; then
+    return 0
+  fi
+
+  find "${SOURCE_DIR}/skills" -type f -name "SKILL.md" -print | sort
+}
+
+collect_agent_sources() {
+  local agent_source=""
+
+  if ! should_sync_agents; then
+    return 0
+  fi
+
+  for agent_source in "${SOURCE_DIR}/agents"/*.md; do
+    if [ -f "${agent_source}" ]; then
+      printf "%s\n" "${agent_source}"
+    fi
+  done | sort
+}
+
+is_previous_source_content() {
+  local source_relative_path="$1"
+  local destination_file="$2"
+  local commits_file=""
+  local commit=""
+  local history_file=""
+
+  if ! git -C "${SOURCE_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    return 1
+  fi
+
+  commits_file="$(mktemp "${TMP_DIR}/commits.XXXXXX")"
+
+  if ! git -C "${SOURCE_DIR}" log --format="%H" -- "${source_relative_path}" > "${commits_file}" 2>/dev/null; then
+    return 1
+  fi
+
+  while IFS= read -r commit; do
+    history_file="$(mktemp "${TMP_DIR}/history.XXXXXX")"
+
+    if ! git -C "${SOURCE_DIR}" show "${commit}:${source_relative_path}" > "${history_file}" 2>/dev/null; then
+      continue
+    fi
+
+    if cmp -s "${destination_file}" "${history_file}"; then
+      return 0
+    fi
+  done < "${commits_file}"
+
+  return 1
+}
+
+copy_sync_file() {
+  local source_file="$1"
+  local destination_file="$2"
+  local source_relative_path="$3"
+  local destination_dir=""
+
+  destination_dir="$(dirname "${destination_file}")"
+
+  if [ -d "${destination_file}" ]; then
+    echo "Error: destination is a directory: ${destination_file}" >&2
+    return 3
+  fi
+
+  if ! mkdir -p "${destination_dir}"; then
+    echo "Error: cannot create directory: ${destination_dir}" >&2
+    return 3
+  fi
+
+  if [ ! -e "${destination_file}" ]; then
+    if cp -p "${source_file}" "${destination_file}"; then
+      return 1
+    fi
+
+    echo "Error: cannot copy ${source_file} to ${destination_file}" >&2
+    return 3
+  fi
+
+  if cmp -s "${source_file}" "${destination_file}"; then
+    return 0
+  fi
+
+  if [ "${OVERWRITE_EXISTING}" = "true" ]; then
+    if cp -p "${source_file}" "${destination_file}"; then
+      return 1
+    fi
+
+    echo "Error: cannot overwrite ${destination_file}" >&2
+    return 3
+  fi
+
+  if is_previous_source_content "${source_relative_path}" "${destination_file}"; then
+    if cp -p "${source_file}" "${destination_file}"; then
+      return 1
+    fi
+
+    echo "Error: cannot update ${destination_file}" >&2
+    return 3
+  fi
+
+  echo "Conflict skipped: ${destination_file}"
+  return 2
+}
+
+process_source_file() {
+  local project_path="$1"
+  local source_file="$2"
+  local source_relative_path=""
+  local destination_file=""
+  local status=0
+
+  source_relative_path="${source_file#${SOURCE_DIR}/}"
+  destination_file="${project_path}/.github/${source_relative_path}"
+
+  copy_sync_file "${source_file}" "${destination_file}" "${source_relative_path}"
+  status=$?
+
+  if [ "${status}" -eq 1 ]; then
+    case "${source_relative_path}" in
+      skills/*)
+        skills_copied_or_updated=$((skills_copied_or_updated + 1))
+        ;;
+      agents/*)
+        agents_copied_or_updated=$((agents_copied_or_updated + 1))
+        ;;
+    esac
+  fi
+
+  if [ "${status}" -eq 2 ]; then
+    conflicts_skipped=$((conflicts_skipped + 1))
+  fi
+
+  if [ "${status}" -eq 3 ]; then
+    errors_count=$((errors_count + 1))
+  fi
+
+  return "${status}"
+}
+
+process_project() {
+  local project_path="$1"
+  local source_file=""
+  local status=0
+  local project_changed=0
+  local project_had_error=0
+
+  while IFS= read -r source_file; do
+    process_source_file "${project_path}" "${source_file}"
+    status=$?
+
+    if [ "${status}" -eq 1 ]; then
+      project_changed=1
+    fi
+
+    if [ "${status}" -eq 3 ]; then
+      project_had_error=1
+    fi
+  done < "${TMP_DIR}/source-files"
+
+  if [ "${project_changed}" -eq 1 ]; then
+    projects_updated=$((projects_updated + 1))
+    updated_project_paths+=("${project_path}")
+    return 0
+  fi
+
+  if [ "${project_had_error}" -eq 1 ]; then
+    return 0
+  fi
+
+  projects_skipped=$((projects_skipped + 1))
+}
+
+print_summary() {
+  local path=""
+
+  echo
+  echo "Summary"
+  echo "target root:              ${TARGET_ROOT}"
+  echo "sync content:             ${SYNC_CONTENT}"
+  echo "overwrite existing:       ${OVERWRITE_EXISTING}"
+  echo "projects scanned:         ${projects_scanned}"
+  echo "projects updated:         ${projects_updated}"
+  echo "projects skipped:         ${projects_skipped}"
+  echo "conflicts skipped:        ${conflicts_skipped}"
+  echo "skills copied or updated: ${skills_copied_or_updated}"
+  echo "agents copied or updated: ${agents_copied_or_updated}"
+  echo "errors:                   ${errors_count}"
+
+  if [ "${#updated_project_paths[@]}" -gt 0 ]; then
+    echo
+    echo "updated projects:"
+    for path in "${updated_project_paths[@]}"; do
+      echo "  ${path}"
+    done
+  fi
+}
+
+main() {
+  local project_path=""
+
+  if [ "$#" -ne 0 ]; then
+    die "Usage: $0"
+  fi
+
+  load_config
+  validate_sync_content
+  validate_paths
+
+  : > "${TMP_DIR}/source-files"
+
+  collect_skill_sources >> "${TMP_DIR}/source-files"
+  collect_agent_sources >> "${TMP_DIR}/source-files"
+
+  if [ ! -s "${TMP_DIR}/source-files" ]; then
+    die "No source files found for SYNC_CONTENT=${SYNC_CONTENT}"
+  fi
+
+  collect_projects > "${TMP_DIR}/projects"
+
+  while IFS= read -r project_path; do
+    projects_scanned=$((projects_scanned + 1))
+    process_project "${project_path}"
+  done < "${TMP_DIR}/projects"
+
+  print_summary
+
+  if [ "${errors_count}" -gt 0 ]; then
+    exit 1
+  fi
+}
+
+trap cleanup EXIT
+
+main "$@"

--- a/sync-copilot-assets.config.example
+++ b/sync-copilot-assets.config.example
@@ -1,0 +1,8 @@
+TARGET_ROOT="${SOURCE_PARENT_DIR}"
+SYNC_CONTENT="both"
+OVERWRITE_EXISTING="false"
+
+EXCLUDED_PATHS=(
+  "${SOURCE_DIR}"
+  # "${TARGET_ROOT}/SomeDirectoryToExclude"
+)


### PR DESCRIPTION
Adds a contribution-friendly local sync system that copies `skills/` and `agents/` from this repo into every Git project discovered under the parent directory, with no hardcoded personal paths.

### What's included

- `scripts/sync-copilot-assets.sh` — discovers Git projects via `.git`, copies skills and agents into `.github/skills/` and `.github/agents/`, detects conflicts using source Git history, prints a summary with the list of updated projects
- `scripts/install-git-hooks.sh` — one-time setup: sets `core.hooksPath=.githooks` via `git config`
- `.githooks/post-merge` / `.githooks/post-rewrite` — auto-run the sync after `git pull` (merge or rebase)
- `sync-copilot-assets.config.example` — configurable template for `TARGET_ROOT`, `SYNC_CONTENT`, `OVERWRITE_EXISTING`, and `EXCLUDED_PATHS`
- `docs/copilot-setup.md` — new **Local Sync** section with setup instructions and config reference

### Overwrite safety

| Destination state | Behaviour |
|---|---|
| Does not exist | Copy |
| Identical to source | Skip |
| Differs, matches a previous Git-tracked version | Update |
| Differs, not in source history | Conflict — skip and report |
| `OVERWRITE_EXISTING=true` | Always overwrite |

### Setup (after clone)

```bash
cp sync-copilot-assets.config.example sync-copilot-assets.local.config
./scripts/install-git-hooks.sh
```

`sync-copilot-assets.local.config` is gitignored and never committed.