### PR TITLE
feat: add longbridge financial markets skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,16 @@ Skills bake in best practices from Google's engineering culture — including co
 
 ---
 
+## Finance & Trading Skills
+
+Community skills for financial market data and trading workflows:
+
+| Skill | What It Does | Use When |
+|-------|-------------|----------|
+| [longbridge](https://github.com/longbridge/skills/tree/main/skills/longbridge) | Live financial market data, trading, and portfolio analysis for US, HK, A-share, and Singapore markets via Longbridge Securities CLI | Quotes, K-lines, fundamentals, news, options, portfolio, institutional data |
+
+---
+
 ## Contributing
 
 Skills should be **specific** (actionable steps, not vague advice), **verifiable** (clear exit criteria with evidence requirements), **battle-tested** (based on real workflows), and **minimal** (only what's needed to guide the agent).


### PR DESCRIPTION
## Summary

- Adds a new **Finance & Trading Skills** section to README.md
- Lists **[longbridge](https://github.com/longbridge/skills/tree/main/skills/longbridge)** — live financial market data, trading, and portfolio analysis for US, HK, A-share, and Singapore markets via Longbridge Securities CLI
- Covers quotes, K-lines, fundamentals, news, options, portfolio management, and institutional data

## Test plan

- [ ] Verify the new section and table render correctly in Markdown
- [ ] Confirm the link resolves to the correct GitHub URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)