### PR TITLE
feat: add vertical-slicing skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ skills/
     SKILL.md              # Required: skill definition
     scripts/              # Required: executable scripts
       {script-name}.sh    # Bash scripts (preferred)
-  {skill-name}.zip        # Required: packaged for distribution
+  {skill-name}.zip        # Distribution artifact — not committed to git; create after merge
 ```
 
 ### Naming Conventions
@@ -173,6 +173,8 @@ After creating or updating a skill:
 cd skills
 zip -r {skill-name}.zip {skill-name}/
 ```
+
+> **Note:** Zip files are distribution artifacts — they are not committed to git and are not required in a PR. Create the zip after the skill directory is merged.
 
 ### End-User Installation
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ Skills are plain Markdown - they work with any agent that accepts system prompts
 
 ---
 
-## All 23 Skills
+## All 24 Skills
 
-The commands above are entry points. The pack includes 23 skills total — 22 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
+The commands above are entry points. The pack includes 24 skills total — 23 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
 
 ### Meta - Discover which skill applies
 
@@ -140,6 +140,7 @@ The commands above are entry points. The pack includes 23 skills total — 22 li
 
 | Skill | What It Does | Use When |
 |-------|-------------|----------|
+| [vertical-slicing](skills/vertical-slicing/SKILL.md) | Thin end-to-end slices that each deliver verifiable, demoable functionality through every layer | Breaking down a spec into tasks, when implementation order is unclear, or when horizontal layering is tempting |
 | [planning-and-task-breakdown](skills/planning-and-task-breakdown/SKILL.md) | Decompose specs into small, verifiable tasks with acceptance criteria and dependency ordering | You have a spec and need implementable units |
 
 ### Build - Write the code
@@ -242,10 +243,11 @@ Every skill follows a consistent anatomy:
 
 ```
 agent-skills/
-├── skills/                            # 23 skills (22 lifecycle + 1 meta)
+├── skills/                            # 24 skills (23 lifecycle + 1 meta)
 │   ├── interview-me/                  #   Define
 │   ├── idea-refine/                   #   Define
 │   ├── spec-driven-development/       #   Define
+│   ├── vertical-slicing/              #   Plan
 │   ├── planning-and-task-breakdown/   #   Plan
 │   ├── incremental-implementation/    #   Build
 │   ├── context-engineering/           #   Build

--- a/skills/planning-and-task-breakdown/SKILL.md
+++ b/skills/planning-and-task-breakdown/SKILL.md
@@ -221,3 +221,7 @@ Before starting implementation, confirm:
 - [ ] No task touches more than ~5 files
 - [ ] Checkpoints exist between major phases
 - [ ] The human has reviewed and approved the plan
+
+## See Also
+
+- `vertical-slicing` — Use before this skill when the right task boundaries are unclear. Vertical slicing determines *what* the tasks are (one behavior per slice); this skill determines *how* to order and specify them.

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -19,6 +19,7 @@ Task arrives
     ├── Don't know what you want yet? ──────→ interview-me
     ├── Have a rough concept, need variants? → idea-refine
     ├── New project/feature/change? ──→ spec-driven-development
+    ├── Breaking spec into slices? ────→ vertical-slicing
     ├── Have a spec, need tasks? ──────→ planning-and-task-breakdown
     ├── Implementing code? ────────────→ incremental-implementation
     │   ├── UI work? ─────────────────→ frontend-ui-engineering
@@ -140,16 +141,17 @@ For a complete feature, the typical skill sequence is:
 1.  interview-me                → Extract what the user actually wants
 2.  idea-refine                 → Refine vague ideas
 3.  spec-driven-development     → Define what we're building
-4.  planning-and-task-breakdown → Break into verifiable chunks
-5.  context-engineering         → Load the right context
-6.  source-driven-development   → Verify against official docs
-7.  incremental-implementation  → Build slice by slice
-8.  doubt-driven-development    → Cross-examine non-trivial decisions in-flight
-9.  test-driven-development     → Prove each slice works
-10. code-review-and-quality     → Review before merge
-11. git-workflow-and-versioning → Clean commit history
-12. documentation-and-adrs      → Document decisions
-13. shipping-and-launch         → Deploy safely
+4.  vertical-slicing            → Determine slice boundaries before task breakdown
+5.  planning-and-task-breakdown → Break into verifiable chunks
+6.  context-engineering         → Load the right context
+7.  source-driven-development   → Verify against official docs
+8.  incremental-implementation  → Build slice by slice
+9.  doubt-driven-development    → Cross-examine non-trivial decisions in-flight
+10. test-driven-development     → Prove each slice works
+11. code-review-and-quality     → Review before merge
+12. git-workflow-and-versioning → Clean commit history
+13. documentation-and-adrs      → Document decisions
+14. shipping-and-launch         → Deploy safely
 ```
 
 Not every task needs every skill. A bug fix might only need: `debugging-and-error-recovery` → `test-driven-development` → `code-review-and-quality`.
@@ -161,6 +163,7 @@ Not every task needs every skill. A bug fix might only need: `debugging-and-erro
 | Define | interview-me | Surface what the user actually wants before any plan, spec, or code exists |
 | Define | idea-refine | Refine ideas through structured divergent and convergent thinking |
 | Define | spec-driven-development | Requirements and acceptance criteria before code |
+| Plan | vertical-slicing | Thin end-to-end slices, each independently demoable |
 | Plan | planning-and-task-breakdown | Decompose into small, verifiable tasks |
 | Build | incremental-implementation | Thin vertical slices, test each before expanding |
 | Build | source-driven-development | Verify against official docs before implementing |

--- a/skills/vertical-slicing/SKILL.md
+++ b/skills/vertical-slicing/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: vertical-slicing
+description: Decomposes work into thin end-to-end slices that each deliver verifiable, demoable functionality through every layer. Use when breaking down a spec or plan into tasks, when a task feels like it builds an entire layer before any user-facing behavior is visible, or when the implementation order is unclear.
+---
+
+# Vertical Slicing
+
+## Overview
+
+A vertical slice cuts through all layers of the stack — schema, API, logic, UI, tests — for one narrow piece of behavior, and delivers something demoable at the end. The alternative, horizontal slicing, builds one entire layer before moving to the next. Horizontal slicing feels organized but routinely produces integration failures at the end, tests that test imagined behavior, and work that cannot be reviewed or demoed mid-stream.
+
+This skill is the decomposition companion to `incremental-implementation` (which governs how to execute a slice) and `planning-and-task-breakdown` (which governs how to order slices). Use this skill when the right boundaries between slices are unclear.
+
+## When to Use
+
+Use this skill when:
+- A spec or requirement exists and you need to determine how to break the work into tasks
+- A task title describes a layer ("Add database schema", "Build API endpoints") rather than a behavior
+- The implementation order is unclear or risky
+- You're about to hand tasks to an agent and want to prevent integration failures
+
+**When NOT to use:**
+- Single-function changes that don't span multiple layers
+- A task already decomposed into well-specified behaviors by the caller
+- Pure infrastructure work with no user-facing or system-observable behavior
+
+## The Core Distinction
+
+```
+HORIZONTAL (avoid):
+  Task 1: All database schemas
+  Task 2: All API endpoints
+  Task 3: All UI components
+  Task 4: Connect everything and hope
+
+VERTICAL (use this):
+  Slice 1: User can create a task        ← schema + API + UI + tests
+  Slice 2: User can view their tasks     ← query + API + UI + tests
+  Slice 3: User can delete a task        ← delete + API + UI + tests
+```
+
+Each vertical slice is independently demoable. If the project stops after Slice 1, something real was shipped.
+
+## Slice Types
+
+Not all slices are the same. Three types matter:
+
+### Tracer Bullet
+
+The first slice in any feature. Its job is not to be complete — it is to prove the path exists end-to-end. A tracer bullet slice is intentionally thin: the minimum surface area that touches every layer and confirms they connect.
+
+```
+Tracer bullet for a task management feature:
+  - Schema: one table, two columns (id, title)
+  - API: one endpoint, POST /tasks
+  - UI: a text input and a submit button
+  - Test: user enters a title and submits; task appears in response
+```
+
+If the tracer bullet fails, you discover the integration problem before investing in any real functionality. Ship the tracer bullet first, always.
+
+### HITL Slice (Human-in-the-Loop)
+
+A slice that requires a human decision or action before it can be completed. Examples: an architectural decision, a design review, an external approval, a manual verification step that cannot be automated.
+
+Mark these explicitly so they are not handed to an AFK agent that will block.
+
+### AFK Slice (Away From Keyboard)
+
+A slice that an agent can implement, test, and merge without human interaction. The majority of slices should be AFK. If a slice requires human judgment mid-implementation, it is either a HITL slice or it is not well-enough specified.
+
+**How to decide:**
+
+| Use HITL when... | Use AFK when... |
+| ---------------- | --------------- |
+| Acceptance criteria reference taste or judgment ("looks correct", "makes sense") | Acceptance criteria are fully mechanical (test passes, API returns X) |
+| An external approval or design review is required | No external approvals needed |
+| The decision depends on information the agent does not have at slice start | The agent has all information required at slice start |
+
+If uncertain, mark as HITL. A false HITL blocks briefly; a false AFK blocks indefinitely.
+
+## How to Slice
+
+### Step 1: Identify the behaviors
+
+From the spec or task, list every piece of user-visible or system-observable behavior. Not layers — behaviors.
+
+```
+Spec: "Users can manage their tasks"
+
+Behaviors:
+- Create a task with a title
+- View a list of tasks
+- Mark a task as complete
+- Delete a task
+- Filter tasks by status
+```
+
+### Step 2: Order by dependency and risk
+
+- **Dependency order:** If Slice B cannot exist without Slice A (e.g. "mark complete" requires a task to exist), A comes first.
+- **Risk order:** Put the riskiest slice first. A risky slice is one where the approach is uncertain, the integration is novel, or failure would invalidate subsequent slices. Discovering a risk early is cheap. Discovering it after five slices is expensive.
+- **Tracer bullet first:** The first slice is always the tracer bullet — the thinnest possible path that proves end-to-end connectivity.
+
+### Step 3: Write each slice
+
+Each slice needs:
+
+| Field | Content |
+| ----- | ------- |
+| **Title** | One short verb phrase describing the behavior: "User can create a task" |
+| **Type** | AFK or HITL |
+| **Layers touched** | Which layers this slice passes through (schema, API, logic, UI, tests) |
+| **Acceptance criteria** | Specific, testable conditions — not implementation steps |
+| **Blocked by** | Which prior slices must complete first, or "None" |
+| **Demoable as** | What you can show or verify when this slice is complete |
+
+### Step 4: Validate the slices
+
+Before handing to an agent or starting implementation, check each slice against:
+
+- [ ] Does completing this slice produce something demoable or verifiable on its own?
+- [ ] Does it pass through every layer it needs to (not just one layer)?
+- [ ] Could an AFK agent complete it without a human decision mid-way?
+- [ ] Is the acceptance criteria testable without knowing implementation internals?
+- [ ] Is the title a behavior, not a layer? ("User can create a task" not "Add task schema")
+
+## Slice Sizing
+
+The right size for a slice is the smallest surface that produces demoable behavior.
+
+**Too large:** A slice that takes more than one focused session to implement, or whose acceptance criteria cannot be stated in three or fewer bullet points, or that touches two or more independent subsystems.
+
+**Too small:** A slice that does not produce anything demoable. If completing the slice leaves the system in an untestable intermediate state, it is not a slice — it is a horizontal layer pretending to be a slice.
+
+When a slice feels too large, ask: "What is the minimum behavior that would be worth showing to a human?" That is the boundary of the slice.
+
+## Relationship to Other Skills
+
+| Skill | Relationship |
+| ----- | ------------ |
+| `planning-and-task-breakdown` | Slices are the output format for a plan. Use vertical slicing to determine what the tasks in the plan are. |
+| `incremental-implementation` | Governs how to execute a single slice: implement → test → verify → commit. |
+| `test-driven-development` | Each slice follows red-green-refactor. The tracer bullet is the first red-green cycle. |
+| `spec-driven-development` | Slices are derived from the spec. The spec defines behaviors; slicing determines how to deliver them incrementally. |
+| `ubiquitous-language` | Slice titles and acceptance criteria use the canonical vocabulary from `CONTEXT.md`. |
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+| --------------- | ------- |
+| "It's faster to build the whole database first" | Faster to type, slower to discover that the API you designed does not fit the UI you need. |
+| "We can't demo anything until the UI is done" | The tracer bullet proves the path. A form that submits and shows a response is demoable. |
+| "These layers are too coupled to slice vertically" | That coupling is the problem. Vertical slicing forces you to confront it early instead of at integration time. |
+| "The slices are too thin to be useful tasks" | A thin slice that delivers demoable behavior is exactly the right size. Thin is not small — it is precise. |
+| "I'll add the tests after all slices are done" | Tests written after the fact test imagined behavior. Tests written per slice test actual behavior. |
+
+## Red Flags
+
+- A task title names a layer, not a behavior ("Add database schema", "Build API endpoints")
+- The first task in a plan does not produce anything demoable
+- No task is marked as a tracer bullet
+- All tasks depend on all previous tasks (no parallel work is possible)
+- Acceptance criteria describe implementation steps, not observable outcomes
+- A slice cannot be completed without a human decision mid-way but is marked AFK
+
+## Verification
+
+Before handing slices to an agent:
+
+- [ ] First slice is a tracer bullet that proves end-to-end connectivity
+- [ ] Every slice title describes a behavior, not a layer
+- [ ] Every slice has acceptance criteria stated as observable outcomes
+- [ ] Every slice is independently demoable or verifiable when complete
+- [ ] HITL and AFK types are correctly assigned
+- [ ] Dependency order is correct (blockers listed explicitly)
+- [ ] No slice is large enough to require more than one focused implementation session

--- a/skills/vertical-slicing/SKILL.md
+++ b/skills/vertical-slicing/SKILL.md
@@ -9,7 +9,7 @@ description: Decomposes work into thin end-to-end slices that each deliver verif
 
 A vertical slice cuts through all layers of the stack — schema, API, logic, UI, tests — for one narrow piece of behavior, and delivers something demoable at the end. The alternative, horizontal slicing, builds one entire layer before moving to the next. Horizontal slicing feels organized but routinely produces integration failures at the end, tests that test imagined behavior, and work that cannot be reviewed or demoed mid-stream.
 
-This skill is the decomposition companion to `incremental-implementation` (which governs how to execute a slice) and `planning-and-task-breakdown` (which governs how to order slices). Use this skill when the right boundaries between slices are unclear.
+This skill is the decomposition companion to `incremental-implementation` (which governs how to execute a slice) and `planning-and-task-breakdown` (which governs how to order slices). Use this skill when breaking down a spec or requirement into tasks.
 
 ## When to Use
 
@@ -98,9 +98,9 @@ Behaviors:
 
 ### Step 2: Order by dependency and risk
 
-- **Dependency order:** If Slice B cannot exist without Slice A (e.g. "mark complete" requires a task to exist), A comes first.
 - **Risk order:** Put the riskiest slice first. A risky slice is one where the approach is uncertain, the integration is novel, or failure would invalidate subsequent slices. Discovering a risk early is cheap. Discovering it after five slices is expensive.
-- **Tracer bullet first:** The first slice is always the tracer bullet — the thinnest possible path that proves end-to-end connectivity.
+- **Tracer bullet first:** For any new feature, the tracer bullet IS the riskiest slice — it is the one that proves the end-to-end path even exists. So "tracer bullet first" is a special case of risk-first, not a competing rule. Start with the tracer bullet, then order remaining slices by dependency and residual risk.
+- **Dependency order:** If Slice B cannot exist without Slice A (e.g. "mark complete" requires a task to exist), A comes first.
 
 ### Step 3: Write each slice
 
@@ -110,7 +110,7 @@ Each slice needs:
 | ----- | ------- |
 | **Title** | One short verb phrase describing the behavior: "User can create a task" |
 | **Type** | AFK or HITL |
-| **Layers touched** | Which layers this slice passes through (schema, API, logic, UI, tests) |
+| **Layers touched** *(optional)* | Which layers this slice passes through (schema, API, logic, UI, tests). Useful when the team is unfamiliar with the stack; omit if it pushes focus toward implementation over behavior. |
 | **Acceptance criteria** | Specific, testable conditions — not implementation steps |
 | **Blocked by** | Which prior slices must complete first, or "None" |
 | **Demoable as** | What you can show or verify when this slice is complete |
@@ -129,7 +129,7 @@ Before handing to an agent or starting implementation, check each slice against:
 
 The right size for a slice is the smallest surface that produces demoable behavior.
 
-**Too large:** A slice that takes more than one focused session to implement, or whose acceptance criteria cannot be stated in three or fewer bullet points, or that touches two or more independent subsystems.
+**Too large:** A slice that takes more than one focused session to implement, or that touches two or more independent subsystems.
 
 **Too small:** A slice that does not produce anything demoable. If completing the slice leaves the system in an untestable intermediate state, it is not a slice — it is a horizontal layer pretending to be a slice.
 


### PR DESCRIPTION
## Summary

Adds the `vertical-slicing` skill — a decomposition workflow that ensures work is broken into thin, independently demoable end-to-end slices rather than horizontal layers.

## Inspiration

The vertical slicing approach and slice taxonomy (tracer bullet, HITL/AFK classification) is informed by Matt Pocock's [skills-to-issues workflow](https://www.aihero.dev/skills-to-issues). This PR packages those ideas as a standalone agent-skills skill following the standard anatomy of this repo.

## What this skill does

- Defines three slice types: Tracer Bullet (proves end-to-end connectivity), HITL (requires human decision), and AFK (agent-executable)
- Provides a decision table for HITL vs AFK classification
- Guides agents through a 4-step process: identify behaviors → order by dependency and risk → write each slice → validate
- Includes a slice sizing guide (too large / too small) and relationship table to sibling skills

## Why it belongs in the lifecycle

The most common planning failure is horizontal slicing — building entire layers before any behavior is demonstrable. This skill is the decomposition step between spec approval and task breakdown, placed between `spec-driven-development` and `planning-and-task-breakdown` in the lifecycle.

## Changes

- `skills/vertical-slicing/SKILL.md` — new skill (177 lines)
- `skills/using-agent-skills/SKILL.md` — added to discovery tree, lifecycle sequence, and Quick Reference table
- `README.md` — added to Plan section, project structure; skill count 23 → 24

## Verification

- `wc -l skills/vertical-slicing/SKILL.md` → 177 (under 500)
- `bash hooks/session-start-test.sh` → `session-start JSON payload OK`