### PR TITLE
docs: add superpowers + agent-skills workflow reference and ship output example

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,6 +125,10 @@ The `references/` directory contains supplementary checklists:
 
 Load a reference when you need detailed patterns beyond what the skill covers.
 
+## Using superpowers + agent-skills together
+
+If you are running the `superpowers` process backbone alongside `agent-skills`, see [superpowers-workflow.md](superpowers-workflow.md) for a full phase-by-phase reference: which skills fire at each phase, what the hard gates are, and common mistakes to watch for.
+
 ## Spec and task artifacts
 
 The `/spec` and `/plan` commands create working artifacts (`SPEC.md`, `tasks/plan.md`, `tasks/todo.md`). Treat them as **living documents** while the work is in progress:

--- a/docs/opencode-setup.md
+++ b/docs/opencode-setup.md
@@ -176,3 +176,11 @@ OpenCode integration works by combining:
 - Automatic skill invocation via reasoning
 
 This results in a **fully agent-driven, production-grade engineering workflow** without requiring plugins or manual commands.
+
+---
+
+## Using superpowers with agent-skills
+
+If you are running both the `superpowers` OpenCode plugin and `agent-skills`, see the combined workflow reference:
+
+[docs/superpowers-workflow.md](superpowers-workflow.md)

--- a/docs/ship-output-example.md
+++ b/docs/ship-output-example.md
@@ -1,0 +1,191 @@
+# `/ship` Output Example
+
+This document shows what the `/ship` command produces for a realistic change. It covers:
+
+1. The three parallel specialist reports (Phase A)
+2. The merged GO decision (Phase B + C)
+3. A NO-GO example showing how a blocker changes the verdict
+
+---
+
+## Context: the change being reviewed
+
+**Change:** Add a tagging feature to a task manager. Three commits, ~180 lines across `src/models/tag.ts`, `src/api/tags.ts`, `src/components/TagInput.tsx`, and `src/components/TagInput.test.tsx`.
+
+---
+
+## Phase A — Specialist reports (returned in parallel)
+
+### code-reviewer report
+
+```
+## Code Review — tagging feature
+
+### Correctness
+- src/api/tags.ts:34 — tag name is not trimmed before insert; "  work  " and "work" will 
+  create two distinct tags. Severity: Important.
+- src/models/tag.ts:12 — unique index on (userId, name) exists but the error thrown on 
+  duplicate insert is a raw DB error, not a domain error. Severity: Important.
+
+### Readability
+- src/components/TagInput.tsx:67 — local `handleKeyDown` closure captures `tags` from 
+  outer scope; easy to stale-close. Consider useCallback or move outside component.
+- Variable name `t` used as both a tag object and a loop iterator in two adjacent 
+  functions (lines 41, 89). Rename for clarity.
+
+### Architecture
+- Tag creation is inlined in the API route handler. If reuse is needed across routes 
+  (e.g. bulk import), there is no service layer to call. Not a blocker today, but worth 
+  noting in an ADR.
+
+### Security
+- No issues found beyond what security-auditor will cover.
+
+### Performance
+- Tag list endpoint returns all tags for the user on every keystroke via useEffect. 
+  Debounce or cache client-side. Severity: Important (no blocker, but will cause 
+  noticeable lag at >50 tags).
+```
+
+---
+
+### security-auditor report
+
+```
+## Security Audit — tagging feature
+
+### Input validation
+- src/api/tags.ts:19 — tag name max length is validated client-side only (TagInput.tsx:23). 
+  The API route has no length check. A crafted request can insert a 10 000-character tag 
+  name. Severity: Critical — server-side validation is mandatory.
+
+### Authentication / Authorization
+- src/api/tags.ts:8 — userId is read from req.session.userId. Session middleware is in 
+  place; no bypass path found. Clean.
+
+### Secrets handling
+- No secrets introduced in this diff.
+
+### Dependencies
+- No new dependencies introduced.
+
+### OWASP Top 10
+- A03 Injection: tag name passes through parameterized query. Clean.
+- A01 Broken Access Control: tag routes are behind authMiddleware. Clean.
+```
+
+---
+
+### test-engineer report
+
+```
+## Test Coverage Analysis — tagging feature
+
+### Happy path
+- Create tag: covered (TagInput.test.tsx:14)
+- Assign tag to task: NOT covered — no test for the TaskCard + tag relationship.
+- Filter by tag: NOT covered — no test for the tag filter query or UI.
+
+### Edge cases
+- Duplicate tag name: covered (TagInput.test.tsx:31)
+- Empty tag name: NOT covered.
+- Tag name with only whitespace: NOT covered (also a server-side validation gap per 
+  security-auditor).
+
+### Error paths
+- API error on tag create (network failure): NOT covered.
+
+### Concurrency
+- No concurrency scenarios identified for this feature.
+
+### Summary
+Happy path partially covered. Two of three user behaviors (assign, filter) have no tests. 
+Three edge cases uncovered. Recommend adding tests before ship; the assign and filter 
+paths carry enough risk to be a soft blocker.
+```
+
+---
+
+## Phase B + C — Merged decision: GO with required pre-ship fixes
+
+```markdown
+## Ship Decision: NO-GO
+
+### Blockers (must fix before ship)
+
+- **security-auditor:** Server-side tag name length validation missing — 
+  src/api/tags.ts:19. A crafted request can insert arbitrarily long strings. 
+  Add `maxLength` check in route handler before any DB call. (Critical)
+
+### Recommended fixes (should fix before ship)
+
+- **code-reviewer:** Trim tag name before insert to prevent whitespace duplicates — 
+  src/api/tags.ts:34. (Important)
+
+- **code-reviewer:** Throw a domain error on duplicate tag insert instead of 
+  surfacing a raw DB error — src/models/tag.ts:12. (Important)
+
+- **test-engineer:** Add tests for assign-tag-to-task and filter-by-tag behaviors. 
+  These are two of the three user-visible outcomes of this feature and have no 
+  coverage. (Important)
+
+- **code-reviewer:** Debounce the tag list fetch in TagInput — currently fires on 
+  every keystroke. (Important)
+
+### Acknowledged risks (shipping anyway)
+
+- Tag creation is inlined in the API handler with no service layer. Acceptable for 
+  now. Document in CONTEXT.md if reuse becomes a requirement.
+
+### Rollback plan
+
+- **Trigger conditions:** Error rate on /api/tags endpoints exceeds 1% over a 
+  5-minute window, or any report of data corruption in tag records.
+- **Rollback procedure:**
+  1. Revert the three commits: `git revert HEAD~3..HEAD`
+  2. Run `npm run migrate:down` to remove the tags table
+  3. Deploy the reverted build
+  4. Verify /api/tasks returns without tag data in response
+- **Recovery time objective:** < 15 minutes
+
+### Specialist reports (full)
+
+[code-reviewer, security-auditor, and test-engineer reports above]
+```
+
+---
+
+## What a GO looks like
+
+After fixing the blocker (server-side length validation) and the important findings:
+
+```markdown
+## Ship Decision: GO
+
+### Blockers
+None.
+
+### Recommended fixes
+None outstanding.
+
+### Acknowledged risks
+- Tag creation has no service layer. Acceptable for the current scope.
+
+### Rollback plan
+- **Trigger conditions:** Error rate on /api/tags > 1% over 5 minutes, or data 
+  corruption reports.
+- **Rollback procedure:**
+  1. `git revert HEAD~3..HEAD`
+  2. `npm run migrate:down`
+  3. Deploy reverted build
+- **Recovery time objective:** < 15 minutes
+```
+
+---
+
+## Rules that shaped this example
+
+- Any **Critical** finding from any persona → automatic NO-GO until fixed or explicitly accepted by the user.
+- The rollback plan is **mandatory** before a GO. A GO without a rollback plan is not valid output.
+- The three personas run **in parallel** — their reports are independent inputs to the main agent's merge step.
+- Personas do not read each other's reports. Deduplication happens in Phase B (note: both `security-auditor` and `test-engineer` independently flagged the whitespace/length gap from different angles; both entries are kept).

--- a/docs/superpowers-workflow.md
+++ b/docs/superpowers-workflow.md
@@ -1,0 +1,204 @@
+# Using superpowers + agent-skills Together
+
+**A workflow reference for daily use.**
+
+---
+
+## What each repo does
+
+| Repo | Job | Installed as |
+| ---- | --- | ------------ |
+| `superpowers` | Process backbone — enforces *how* to work | OpenCode plugin (auto-loads on session start) |
+| `agent-skills` | Lifecycle skills — covers *what* to do across the full SDLC | `AGENTS.md` + `.opencode/` package |
+
+They do not conflict. Both repos solve related problems independently: `superpowers` enforces process gates and `agent-skills` provides domain-specific lifecycle skills. When both are active, `superpowers` handles the core workflow enforcement and `agent-skills` handles skill selection and execution across the SDLC.
+
+---
+
+## What loads automatically
+
+Every time you open OpenCode, before you type anything:
+
+1. `superpowers` session hook fires → injects `using-superpowers` into context
+2. `agent-skills` `AGENTS.md` → injects the intent-to-skill mapping
+
+The agent knows all skills exist. It will select the right one based on what you say.
+
+**You do not need to name skills.** Just describe your task.
+
+---
+
+## The mental model
+
+Every task moves through phases. Each phase has a skill. The agent applies the skill automatically — your job is to answer its questions and approve its outputs before it moves forward.
+
+```
+DEFINE ──→ PLAN ──→ BUILD ──→ VERIFY ──→ REVIEW ──→ SHIP
+```
+
+You are the gate between each phase. The agent cannot proceed to PLAN until you approve the spec. Cannot proceed to BUILD until you approve the plan. This is intentional.
+
+---
+
+## Phase by phase
+
+### DEFINE — what are we building?
+
+**Trigger:** You describe a feature, paste a task description, or say "I need to..."
+
+**What fires:**
+
+| Skill | Source | Purpose |
+| ----- | ------ | ------- |
+| `brainstorming` | superpowers | One-question-at-a-time interview; proposes 2–3 approaches; writes spec to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`; you must approve before anything else happens |
+| `interview-me` | agent-skills | Alternative entry point — surfaces what you actually want vs what you said |
+| `ubiquitous-language` | agent-skills | Fires when an unfamiliar domain term appears; updates `CONTEXT.md` immediately; sparingly offers ADRs |
+
+**Your job:** Answer questions one at a time. Approve or revise the spec. Do not let the agent skip to planning.
+
+**Output:** A spec file at `docs/superpowers/specs/`.
+
+---
+
+### PLAN — how are we building it?
+
+**Trigger:** Approved spec exists.
+
+**What fires:**
+
+| Skill | Source | Purpose |
+| ----- | ------ | ------- |
+| `writing-plans` | superpowers | Produces a task-by-task plan with exact file paths, complete code, exact commands. No TBD placeholders allowed. Saves to `docs/superpowers/plans/YYYY-MM-DD-<feature>.md` |
+| `vertical-slicing` | agent-skills | Determines slice boundaries before `planning-and-task-breakdown` — each slice is a thin end-to-end cut, independently demoable |
+| `planning-and-task-breakdown` | agent-skills | Decomposes into verifiable tasks with acceptance criteria, dependency ordering, and checkpoints |
+
+**Your job:** Review the plan. Check that tasks are small (S or M — no XL), slices are vertical not horizontal, and there are no TBD placeholders.
+
+**Output:** A plan file at `docs/superpowers/plans/`.
+
+---
+
+### BUILD — implementing
+
+**Trigger:** Approved plan exists.
+
+**What fires:**
+
+| Skill | Source | Purpose |
+| ----- | ------ | ------- |
+| `subagent-driven-development` | superpowers | Dispatches a fresh subagent per task; spec-compliance review before code-quality review; four status codes: DONE / DONE_WITH_CONCERNS / NEEDS_CONTEXT / BLOCKED |
+| `incremental-implementation` | agent-skills | Implement → test → verify → commit cycle per slice; scope discipline enforced |
+| `test-driven-development` | agent-skills | Failing test first, then minimal code to pass; Beyoncé Rule — no untested behavior |
+| `source-driven-development` | agent-skills | Verifies implementation against official docs before writing code |
+| `context-engineering` | agent-skills | Manages what context the agent loads; prevents stale or irrelevant context |
+
+**Your job:** Review task completion reports. A task is not done until `verification-before-completion` has run commands and shown you the output.
+
+**Key rule:** `verification-before-completion` (superpowers) blocks any "it's done" claim until the agent runs the relevant command and reads the full output in the same message. If the agent says "tests should pass" without showing you the test run output, that is a violation.
+
+---
+
+### VERIFY — does it actually work?
+
+**Trigger:** Implementation claims completion, or something is broken.
+
+**What fires:**
+
+| Skill | Source | Purpose |
+| ----- | ------ | ------- |
+| `verification-before-completion` | superpowers | Hard gate — no completion claim without evidence. Runs: identify command → run it → read full output → check exit code |
+| `systematic-debugging` | superpowers | Four-phase: Root Cause → Pattern Analysis → Hypothesis and Testing → Implementation. "3+ fixes tried = architectural problem" rule |
+| `debugging-and-error-recovery` | agent-skills | Reproduce → localize → fix → guard (adds regression test) |
+
+**Your job:** If the agent says "done", look for the verification output in the same message. If it is not there, ask for it.
+
+---
+
+### REVIEW — is it good enough to merge?
+
+**Trigger:** All tasks complete, verification passing.
+
+**What fires:**
+
+| Skill | Source | Purpose |
+| ----- | ------ | ------- |
+| `requesting-code-review` | superpowers | Structures what to review and how to present it |
+| `code-review-and-quality` | agent-skills | Five-axis review: correctness, readability, architecture, security, performance |
+| `security-and-hardening` | agent-skills | OWASP-style audit; input validation; least privilege |
+| `code-simplification` | agent-skills | Removes unnecessary complexity without changing behavior |
+
+**`/ship` parallel fan-out (agent-skills):** Spawns three subagents simultaneously — `code-reviewer`, `security-auditor`, `test-engineer` — and merges their reports into a single GO/NO-GO with a rollback plan.
+
+**Your job:** Read the merged report. A NO-GO is not a failure — it is the system working. Address the blocking issues before merging.
+
+---
+
+### SHIP — deploying safely
+
+**Trigger:** GO from review gate.
+
+**What fires:**
+
+| Skill | Source | Purpose |
+| ----- | ------ | ------- |
+| `finishing-a-development-branch` | superpowers | Structured options: merge, PR, or cleanup. Only fires when tests pass and you need to decide how to integrate |
+| `git-workflow-and-versioning` | agent-skills | Atomic commits, clean history, branch strategy |
+| `shipping-and-launch` | agent-skills | Pre-launch checklist, monitoring, rollback plan |
+| `ci-cd-and-automation` | agent-skills | Automated quality gates on every change |
+
+---
+
+## Skill selection cheat sheet
+
+| You say / situation | Skill that fires | Source |
+| ------------------- | ---------------- | ------ |
+| "I need to build X" | `brainstorming` | superpowers |
+| "What does [term] mean in this codebase?" | `ubiquitous-language` | agent-skills |
+| "Break this into tasks" | `vertical-slicing` → `planning-and-task-breakdown` | agent-skills |
+| "Implement task N from the plan" | `subagent-driven-development` | superpowers |
+| "Something is broken" | `systematic-debugging` | superpowers |
+| "Is this done?" | `verification-before-completion` | superpowers |
+| "Review this before I merge" | `code-review-and-quality` | agent-skills |
+| "Ship it" | `finishing-a-development-branch` → `shipping-and-launch` | superpowers / agent-skills |
+
+---
+
+## The hard gates — what the agent cannot skip
+
+These are non-negotiable blocks enforced by skill design:
+
+| Gate | Skill | What it blocks |
+| ---- | ----- | -------------- |
+| No code before spec approved | `brainstorming` | Any implementation action |
+| No plan before spec approved | `writing-plans` | Task generation |
+| No completion claim without evidence | `verification-before-completion` | Saying "done" without running commands |
+| No merging on NO-GO | `/ship` review | Git merge / PR creation |
+| No TBD in plan | `writing-plans` | Plan is rejected by reviewer subagent |
+
+If the agent tries to skip a gate, it is a red flag. Name it and ask the agent to go back.
+
+---
+
+## Files produced per session
+
+| File | Written by | Location |
+| ---- | ---------- | -------- |
+| Spec | `brainstorming` / `spec-driven-development` | `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` |
+| Plan | `writing-plans` | `docs/superpowers/plans/YYYY-MM-DD-<feature>.md` |
+| Domain glossary | `ubiquitous-language` | `CONTEXT.md` (repo root) |
+| ADRs | `ubiquitous-language` | `docs/adr/NNNN-slug.md` |
+
+These files persist across sessions. The agent reads them at the start of the next session to restore context.
+
+---
+
+## Common mistakes to watch for
+
+| Mistake | What it looks like | Correct response |
+| ------- | ------------------ | ---------------- |
+| Agent skips spec | Starts planning immediately after you describe a task | "Stop. Use `brainstorming` first." |
+| Horizontal slicing | Tasks named by layer: "build database schema", "build all API endpoints" | "Reslice vertically — each task should deliver a demoable behavior end-to-end." |
+| Phantom verification | "Tests should pass" without showing output | "Run the tests and show me the output before claiming done." |
+| Vocabulary drift | Agent uses a different word for a concept already in `CONTEXT.md` | "That term conflicts with CONTEXT.md — use `[canonical term]`." |
+| Scope creep | Agent modifies files outside the current task | "That file is not in this task's scope. Revert and note it for a separate task." |
+| ADR inflation | Agent wants to write an ADR for a reversible decision | "Does this meet all three conditions — hard to reverse, surprising, real trade-off? If not, skip it." |


### PR DESCRIPTION
## Summary

Adds two documentation files and cross-links them from the existing setup guides.

## New files

**`docs/superpowers-workflow.md`** — A phase-by-phase workflow reference for users running both the `superpowers` OpenCode plugin and `agent-skills`. Covers:
- What each repo does and how they complement each other
- What loads automatically on session start
- DEFINE → PLAN → BUILD → VERIFY → REVIEW → SHIP phases with the skill that fires at each
- Skill selection cheat sheet
- Hard gates the agent cannot skip
- Common mistakes with corrective responses

**`docs/ship-output-example.md`** — A realistic example of what `/ship` produces: the three parallel specialist reports (code-reviewer, security-auditor, test-engineer), the merged NO-GO decision with rollback plan, and what a GO looks like after fixes are applied.

## Modified files

- `docs/getting-started.md` — added a short cross-reference to `superpowers-workflow.md`
- `docs/opencode-setup.md` — added a "Using superpowers with agent-skills" section linking to `superpowers-workflow.md`