### PR TITLE
feat: add workflow-tracker skill with 7-phase lifecycle tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,16 @@ Skills are plain Markdown - they work with any agent that accepts system prompts
 
 ---
 
-## All 23 Skills
+## All 24 Skills
 
-The commands above are entry points. The pack includes 23 skills total — 22 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
+The commands above are entry points. The pack includes 24 skills total — 22 lifecycle skills, the `workflow-tracker` companion skill, and the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
 
 ### Meta - Discover which skill applies
 
 | Skill | What It Does | Use When |
 |-------|-------------|----------|
 | [using-agent-skills](skills/using-agent-skills/SKILL.md) | Maps incoming work to the right skill workflow and defines shared operating rules | Starting a session or deciding which skill applies |
+| [workflow-tracker](skills/workflow-tracker/SKILL.md) | Maintains a live TodoWrite phase list (SPEC→PLAN→BUILD→TEST→REVIEW→SIMPLIFY→SHIP) alongside lifecycle skills | Start of any development task to track progress across phases |
 
 ### Define - Clarify what to build
 
@@ -242,10 +243,10 @@ Every skill follows a consistent anatomy:
 
 ```
 agent-skills/
-├── skills/                            # 23 skills (22 lifecycle + 1 meta)
-│   ├── interview-me/                  #   Define
-│   ├── idea-refine/                   #   Define
-│   ├── spec-driven-development/       #   Define
+├── skills/                            # 24 skills (22 lifecycle + 2 meta)
+│   ├── interview-me/                  #   Spec
+│   ├── idea-refine/                   #   Spec
+│   ├── spec-driven-development/       #   Spec
 │   ├── planning-and-task-breakdown/   #   Plan
 │   ├── incremental-implementation/    #   Build
 │   ├── context-engineering/           #   Build
@@ -254,20 +255,21 @@ agent-skills/
 │   ├── frontend-ui-engineering/       #   Build
 │   ├── test-driven-development/       #   Build
 │   ├── api-and-interface-design/      #   Build
-│   ├── browser-testing-with-devtools/ #   Verify
-│   ├── debugging-and-error-recovery/  #   Verify
+│   ├── browser-testing-with-devtools/ #   Test
+│   ├── debugging-and-error-recovery/  #   Test
 │   ├── code-review-and-quality/       #   Review
-│   ├── code-simplification/          #   Review
 │   ├── security-and-hardening/        #   Review
 │   ├── performance-optimization/      #   Review
+│   ├── code-simplification/           #   Simplify
 │   ├── git-workflow-and-versioning/   #   Ship
 │   ├── ci-cd-and-automation/          #   Ship
 │   ├── deprecation-and-migration/     #   Ship
 │   ├── documentation-and-adrs/        #   Ship
 │   ├── shipping-and-launch/           #   Ship
+│   ├── workflow-tracker/              #   Meta: live phase tracker
 │   └── using-agent-skills/            #   Meta: how to use this pack
 ├── agents/                            # 3 specialist personas
-├── references/                        # 4 supplementary checklists
+├── references/                        # 5 supplementary references (incl. lifecycle.md)
 ├── hooks/                             # Session lifecycle hooks
 ├── .claude/commands/                  # 7 slash commands (Claude Code)
 ├── .gemini/commands/                  # 7 slash commands (Gemini CLI)

--- a/references/lifecycle.md
+++ b/references/lifecycle.md
@@ -1,0 +1,49 @@
+# Development Lifecycle
+
+This file is the single source of truth for phase names, order, and per-command phase sets. All skills and documentation that enumerate phases must reference this file rather than defining their own lists.
+
+## Canonical Phases
+
+The 7 phases map 1:1 to the slash commands in `.claude/commands/`:
+
+| # | Phase | Slash Command | What it covers |
+|---|-------|---------------|----------------|
+| 1 | SPEC | `/spec` | Define what to build — requirements, acceptance criteria, boundaries |
+| 2 | PLAN | `/plan` | Break the spec into small, verifiable, ordered tasks |
+| 3 | BUILD | `/build` | Implement the tasks incrementally |
+| 4 | TEST | `/test` | Prove the implementation works — TDD, browser testing, debugging |
+| 5 | REVIEW | `/review` | Quality gates before merge — code review, security, performance |
+| 6 | SIMPLIFY | `/code-simplify` | Reduce complexity without changing behavior |
+| 7 | SHIP | `/ship` | Deploy safely — pre-launch checklist, monitoring, rollback |
+
+## Per-Command Phase Sets
+
+When a slash command is invoked, only the phases from that point forward are relevant. Show only these phases in the workflow tracker.
+
+| Command invoked | Phases to show |
+|-----------------|----------------|
+| `/spec` | SPEC → PLAN → BUILD → TEST → REVIEW → SIMPLIFY → SHIP |
+| `/plan` | PLAN → BUILD → TEST → REVIEW → SIMPLIFY → SHIP |
+| `/build` | BUILD → TEST → REVIEW → SIMPLIFY → SHIP |
+| `/test` | TEST → REVIEW → SIMPLIFY → SHIP |
+| `/review` | REVIEW → SIMPLIFY → SHIP |
+| `/code-simplify` | SIMPLIFY → SHIP |
+| `/ship` | SHIP |
+
+## Phase Regression
+
+Phases are not always linear. When a phase must be revisited (e.g., TEST fails and work returns to BUILD), reopen the completed phase by setting it back to `in_progress`. Do not add a duplicate item — update the existing one.
+
+## Skill Mapping
+
+Each phase is primarily served by one or more skills:
+
+| Phase | Primary skills |
+|-------|---------------|
+| SPEC | `interview-me`, `idea-refine`, `spec-driven-development` |
+| PLAN | `planning-and-task-breakdown` |
+| BUILD | `incremental-implementation`, `test-driven-development`, `frontend-ui-engineering`, `api-and-interface-design`, `source-driven-development`, `context-engineering`, `doubt-driven-development` |
+| TEST | `test-driven-development`, `browser-testing-with-devtools`, `debugging-and-error-recovery` |
+| REVIEW | `code-review-and-quality`, `security-and-hardening`, `performance-optimization` |
+| SIMPLIFY | `code-simplification` |
+| SHIP | `git-workflow-and-versioning`, `ci-cd-and-automation`, `documentation-and-adrs`, `shipping-and-launch` |

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -160,27 +160,28 @@ Not every task needs every skill. A bug fix might only need: `debugging-and-erro
 
 ## Quick Reference
 
-| Phase | Skill | One-Line Summary |
-|-------|-------|-----------------|
-| Define | interview-me | Surface what the user actually wants before any plan, spec, or code exists |
-| Define | idea-refine | Refine ideas through structured divergent and convergent thinking |
-| Define | spec-driven-development | Requirements and acceptance criteria before code |
-| Plan | planning-and-task-breakdown | Decompose into small, verifiable tasks |
-| Build | incremental-implementation | Thin vertical slices, test each before expanding |
-| Build | source-driven-development | Verify against official docs before implementing |
-| Build | doubt-driven-development | Adversarial fresh-context review of every non-trivial decision |
-| Build | context-engineering | Right context at the right time |
-| Build | frontend-ui-engineering | Production-quality UI with accessibility |
-| Build | api-and-interface-design | Stable interfaces with clear contracts |
-| Verify | test-driven-development | Failing test first, then make it pass |
-| Verify | browser-testing-with-devtools | Chrome DevTools MCP for runtime verification |
-| Verify | debugging-and-error-recovery | Reproduce → localize → fix → guard |
-| Review | code-review-and-quality | Five-axis review with quality gates |
-| Review | code-simplification | Preserve behavior while reducing unnecessary complexity |
-| Review | security-and-hardening | OWASP prevention, input validation, least privilege |
-| Review | performance-optimization | Measure first, optimize only what matters |
-| Ship | git-workflow-and-versioning | Atomic commits, clean history |
-| Ship | ci-cd-and-automation | Automated quality gates on every change |
-| Ship | deprecation-and-migration | Remove old systems and migrate users safely |
-| Ship | documentation-and-adrs | Document the why, not just the what |
-| Ship | shipping-and-launch | Pre-launch checklist, monitoring, rollback plan |
+Phases map 1:1 to the slash commands. See `references/lifecycle.md` for the canonical order and per-command phase sets.
+
+| Phase | Slash Command | Skill | One-Line Summary |
+|-------|--------------|-------|-----------------|
+| Spec | `/spec` | interview-me | Surface what the user actually wants before any plan, spec, or code exists |
+| Spec | `/spec` | idea-refine | Refine ideas through structured divergent and convergent thinking |
+| Spec | `/spec` | spec-driven-development | Requirements and acceptance criteria before code |
+| Plan | `/plan` | planning-and-task-breakdown | Decompose into small, verifiable tasks |
+| Build | `/build` | incremental-implementation | Thin vertical slices, test each before expanding |
+| Build | `/build` | source-driven-development | Verify against official docs before implementing |
+| Build | `/build` | doubt-driven-development | Adversarial fresh-context review of every non-trivial decision |
+| Build | `/build` | context-engineering | Right context at the right time |
+| Build | `/build` | frontend-ui-engineering | Production-quality UI with accessibility |
+| Build | `/build` | api-and-interface-design | Stable interfaces with clear contracts |
+| Test | `/test` | test-driven-development | Failing test first, then make it pass |
+| Test | `/test` | browser-testing-with-devtools | Chrome DevTools MCP for runtime verification |
+| Test | `/test` | debugging-and-error-recovery | Reproduce → localize → fix → guard |
+| Review | `/review` | code-review-and-quality | Five-axis review with quality gates |
+| Review | `/review` | security-and-hardening | OWASP prevention, input validation, least privilege |
+| Review | `/review` | performance-optimization | Measure first, optimize only what matters |
+| Simplify | `/code-simplify` | code-simplification | Reduce complexity without changing behavior |
+| Ship | `/ship` | git-workflow-and-versioning | Atomic commits, clean history |
+| Ship | `/ship` | ci-cd-and-automation | Automated quality gates on every change |
+| Ship | `/ship` | documentation-and-adrs | Document the why, not just the what |
+| Ship | `/ship` | shipping-and-launch | Pre-launch checklist, monitoring, rollback plan |

--- a/skills/workflow-tracker/SKILL.md
+++ b/skills/workflow-tracker/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: workflow-tracker
+description: Use at the start of any development task alongside lifecycle skills to track progress across SPEC→PLAN→BUILD→TEST→REVIEW→SIMPLIFY→SHIP phases via a TodoWrite list. Phases derive from the slash commands in `.claude/commands/` — see `references/lifecycle.md` for the canonical order and per-command phase sets.
+---
+
+# Workflow Tracker
+
+Companion skill — activates alongside lifecycle skills to maintain a live `TodoWrite` list mapped to the active workflow phases so the user always sees where they are and what comes next.
+
+Requires the `TodoWrite` tool.
+
+## Activation
+
+Invoke alongside any lifecycle skill or slash command:
+
+| Slash command | Phases to initialize |
+|--------------|----------------------|
+| `/spec` | SPEC → PLAN → BUILD → TEST → REVIEW → SIMPLIFY → SHIP |
+| `/plan` | PLAN → BUILD → TEST → REVIEW → SIMPLIFY → SHIP |
+| `/build` | BUILD → TEST → REVIEW → SIMPLIFY → SHIP |
+| `/test` | TEST → REVIEW → SIMPLIFY → SHIP |
+| `/review` | REVIEW → SIMPLIFY → SHIP |
+| `/code-simplify` | SIMPLIFY → SHIP |
+| `/ship` | SHIP |
+
+The canonical phase list and order is defined in `references/lifecycle.md`. If new slash commands are added, update that file — this skill derives its phase sets from it.
+
+## Initialization
+
+When a task begins, immediately create a `TodoWrite` list containing only the phases relevant to the invoked command (see table above). Use these statuses:
+
+- `in_progress` — the current phase
+- `pending` — future phases
+- `completed` — phases already done
+
+**Example: `/review` invoked**
+
+```
+[in_progress] REVIEW — code review passed
+[pending]     SIMPLIFY — complexity reduced
+[pending]     SHIP — branch merged / PR created
+```
+
+**Example: `/spec` invoked**
+
+```
+[in_progress] SPEC — spec written and approved
+[pending]     PLAN — plan written and approved
+[pending]     BUILD — all tasks complete
+[pending]     TEST — verification output shown
+[pending]     REVIEW — code review passed
+[pending]     SIMPLIFY — complexity reduced
+[pending]     SHIP — branch merged / PR created
+```
+
+If a formal plan from `planning-and-task-breakdown` exists with multiple tasks, expand BUILD into one `TodoWrite` item per task:
+
+```
+[pending] BUILD — task 1: <task name from plan>
+[pending] BUILD — task 2: <task name from plan>
+...
+```
+
+## Phase Gates
+
+| Phase | Entry gate | Exit gate |
+|-------|-----------|-----------|
+| SPEC | Task described | Spec approved by user |
+| PLAN | Spec approved | Plan approved by user |
+| BUILD | Plan approved | All tasks verified complete |
+| TEST | Tasks complete | Verification output shown and passing |
+| REVIEW | Verification passing | Code review GO |
+| SIMPLIFY | Review GO | Simplification complete or explicitly skipped |
+| SHIP | Simplify complete | Merged / PR created |
+
+## Real-time Updates
+
+Update `TodoWrite` items in real time as gates are passed — do not batch updates.
+
+Mark a phase `completed` the moment its exit gate is reached. Mark the next phase `in_progress` immediately after.
+
+## Phase Regression
+
+Phases are not always linear. When a phase must be revisited (e.g., TEST fails and work returns to BUILD):
+
+1. Set the previously-completed phase back to `in_progress`
+2. Do **not** add a duplicate item — update the existing one
+3. When it passes again, mark it `completed` and re-advance
+
+## Completion
+
+The tracker is complete when SHIP is marked `completed`.


### PR DESCRIPTION
## Summary

- Adds `workflow-tracker` skill that maintains a live TodoWrite phase list (SPEC→PLAN→BUILD→TEST→REVIEW→SIMPLIFY→SHIP) alongside lifecycle skills
- Adds `references/lifecycle.md` as a single source of truth for phase order, per-command phase sets, regression rules, and skill mappings
- Updates `using-agent-skills` Quick Reference table to include slash command column and align to 7 canonical phases
- Updates README skill count (24 total) and directory structure to reflect new companion skill

## What it does

The `workflow-tracker` skill ensures agents maintain visible phase progress across a full development session. It hooks into the existing lifecycle skills and uses `TodoWrite` to surface where a task is in the SPEC→PLAN→BUILD→TEST→REVIEW→SIMPLIFY→SHIP pipeline — preventing phase skipping and giving the user a consistent view of progress.

## Changes

| File | Change |
|------|--------|
| `skills/workflow-tracker/SKILL.md` | New skill — 7-phase TodoWrite tracker |
| `references/lifecycle.md` | New — canonical phase order and slash command mapping |
| `skills/using-agent-skills/SKILL.md` | Quick Reference updated with slash command column |
| `README.md` | Skill count, Meta section, directory structure updated |

## Not included

Spec and plan documents have been intentionally excluded — they are working artifacts, not part of the distributable skill.