### PR TITLE
fix(copilot-setup): add references folder and agents README to setup instructions

### DIFF
--- a/docs/copilot-setup.md
+++ b/docs/copilot-setup.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-### Copilot Instructions
+### Copilot Skills
 
 Copilot supports creating agent skills using a `.github/skills`, `.claude/skills`, or `.agents/skills` directory in your repository.
 
@@ -22,9 +22,13 @@ Copilot supports specialized agent personas. Use the agent-skills agents:
 
 ```bash
 # Copy agent definitions
+cp /path/to/agent-skills/agents/README.md .github/agents/README.md
 cp /path/to/agent-skills/agents/code-reviewer.md .github/agents/code-reviewer.md
 cp /path/to/agent-skills/agents/test-engineer.md .github/agents/test-engineer.md
 cp /path/to/agent-skills/agents/security-auditor.md .github/agents/security-auditor.md
+
+# Copy references (referenced in agents README)
+cp -r /path/to/agent-skills/references .github/references
 ```
 
 Invoke agents in Copilot Chat:


### PR DESCRIPTION
## Summary

- Added `cp` for `agents/README.md` in the agent definitions setup block
- Added `cp -r` for the `references/` directory with a comment explaining the dependency

## Motivation

The agent personas (`code-reviewer`, `test-engineer`, `security-auditor`) reference files under `references/` via the agents `README.md`. Anyone following the setup guide as written would end up with broken links inside their local agent definitions. This makes the manual setup self-contained without requiring the user to discover the missing files themselves.

## Test plan

- [ ] Follow the updated setup block from scratch and verify no broken references inside the agent files
- [ ] Confirm the `references/` `cp` command lands at `.github/references/` as expected by the agent README links
- [ ] Check that the added lines match the existing writing style and code block format of the file
- [ ] No other docs file references this setup flow, so no cross-doc updates needed