### PR TITLE
Add skill: heyneuron/flowhunt-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,16 @@ Skills bake in best practices from Google's engineering culture — including co
 
 ---
 
+## Community Skills
+
+Third-party skills that extend the pack with domain-specific workflows:
+
+| Skill | What It Does | Install |
+|-------|-------------|---------|
+| [flowhunt-skill](https://github.com/heyneuron/flowhunt-skill) | Automation discovery audit — 5-question workflow intake, then audits Gmail/Calendar/Slack/task trackers to surface automation opportunities | `npx skills add heyneuron/flowhunt-skill` |
+
+---
+
 ## Contributing
 
 Skills should be **specific** (actionable steps, not vague advice), **verifiable** (clear exit criteria with evidence requirements), **battle-tested** (based on real workflows), and **minimal** (only what's needed to guide the agent).


### PR DESCRIPTION
FlowHunt Skill - automation discovery audit. Walks through 5-question workflow intake and audits Gmail/Calendar/Slack/task trackers to identify automation opportunities.

Install: `npx skills add heyneuron/flowhunt-skill`

## What this adds

A new **Community Skills** section in the README with an entry for `flowhunt-skill` — a third-party skill from [heyneuron/flowhunt-skill](https://github.com/heyneuron/flowhunt-skill) that:

- Runs a structured 5-question intake (role, repetitive tasks, connected tools, pain point, goal)
- Audits Gmail, Google Calendar, Slack, and task trackers for automation patterns
- Outputs a prioritized Automation Opportunity Report with quick wins ranked by impact vs effort

Fits the **Build** phase (context-engineering) and complements `ci-cd-and-automation` for teams looking to discover workflow automation opportunities before implementing them.