### PR TITLE
feat: add Longbridge Securities financial market skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,14 @@ See [docs/skill-anatomy.md](docs/skill-anatomy.md) for the format specification 
 
 ---
 
+## Related Skills Packs
+
+Community and official skills packs for domain-specific workflows:
+
+- **[longbridge/skills](https://github.com/longbridge/skills)** — 125+ financial market skills by Longbridge Securities. Real-time quotes, charts, fundamentals, portfolio analysis, valuation, options, and more for HK / US / A-share / SG markets. Trilingual (Simplified Chinese / Traditional Chinese / English). Install: `/plugin marketplace add longbridge/skills`
+
+---
+
 ## License
 
 MIT - use these skills in your projects, teams, and tools.


### PR DESCRIPTION
Adds official Longbridge Securities agent skills — 125+ skills for HK/US/A-share/SG markets with trilingual support.

## What's added

Added a new **Related Skills Packs** section before the License section, linking to the official Longbridge Securities skills pack:

- 125+ agent skills for real-time quotes, charts, fundamentals, portfolio analysis, valuation, options, and more
- Markets: Hong Kong, US, A-share (Shanghai/Shenzhen), and Singapore
- Trilingual: Simplified Chinese, Traditional Chinese, and English
- Install: `/plugin marketplace add longbridge/skills`

**Repo:** https://github.com/longbridge/skills