### PR TITLE
docs: clarify skill formatting conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,17 @@ New skills should generally follow the standard anatomy:
 
 The frontmatter fields above are required. The section anatomy is a recommended pattern: equivalent headings such as `How It Works`, `Workflow`, or `Core Process` are fine when they preserve the same intent and keep the skill easy to follow.
 
+### Formatting Conventions
+
+Keep formatting predictable so both humans and agents can scan skills consistently:
+
+- Put YAML frontmatter at the top of `SKILL.md` with `name` before `description`
+- Use ATX headings (`## Heading`) for sections
+- Use `-` for unordered lists
+- Prefer fenced code blocks with a language tag, such as `bash`, `json`, or `markdown`
+- Keep tables compact and only use them when side-by-side comparison is clearer than bullets
+- Omit empty sections rather than adding placeholders
+
 ### What Not to Do
 
 - Don't duplicate content between skills — reference other skills instead

--- a/docs/skill-anatomy.md
+++ b/docs/skill-anatomy.md
@@ -116,6 +116,15 @@ If a skill does not need runnable helpers, do not create an empty `scripts/` dir
 5. **Progressive disclosure.** Main SKILL.md is the entry point. Supporting files are loaded only when needed.
 6. **Token-conscious.** Every section must justify its inclusion. If removing it wouldn't change agent behavior, remove it.
 
+## Formatting Conventions
+
+- Put YAML frontmatter first, with `name` before `description`
+- Use ATX headings (`## Heading`) rather than underlined headings
+- Use `-` for unordered lists
+- Use fenced code blocks with a language tag when the language is known
+- Keep examples short enough to scan, and move long reference material into supporting files
+- Avoid placeholder sections; omit sections that do not add actionable guidance
+
 ## Naming Conventions
 
 - Skill directories: `lowercase-hyphen-separated`


### PR DESCRIPTION
## Summary

Adds concise formatting conventions for SKILL.md files in both the contributor guide and skill anatomy documentation.

## Why

This addresses part of #137 by documenting the expected formatting style before introducing any heavier linting or automated formatting. Keeping this first step documentation-only makes the convention explicit without changing existing skills or CI behavior.

## Changes

- Document frontmatter ordering expectations
- Clarify heading, list, and fenced-code-block conventions
- Encourage compact examples and avoiding placeholder sections

## Validation

- node scripts/validate-skills.js
- git diff --check

Refs #137
