### PR TITLE
Fix SessionStart hook to use documented stdout payload

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ The frontmatter fields above are required. The section anatomy is a recommended 
 
 ## Testing Hooks
 
-The session-start hook (`hooks/session-start.sh`) injects the `using-agent-skills` meta-skill into every new Claude Code session. A regression test at `hooks/session-start-test.sh` validates the hook's JSON payload — both when `jq` is available and when it isn't.
+The session-start hook (`hooks/session-start.sh`) injects the `using-agent-skills` meta-skill into every new Claude Code session. SessionStart hooks add their stdout to the agent's context, so the hook prints the meta-skill as plain text. A regression test at `hooks/session-start-test.sh` validates the hook's stdout payload.
 
 Run it before opening any PR that touches:
 
@@ -63,21 +63,7 @@ Run it before opening any PR that touches:
 bash hooks/session-start-test.sh
 ```
 
-Expected output: `session-start JSON payload OK`. The script exits non-zero on any assertion failure.
-
-### Reproducing the no-jq fallback
-
-The hook gracefully degrades to an `INFO`-priority payload when `jq` isn't on `PATH`. To exercise that branch locally, strip `jq`'s directory from `PATH` for the test invocation:
-
-```bash
-JQ_DIR=$(dirname "$(command -v jq)")
-PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "^${JQ_DIR}$" | tr '\n' ':' | sed 's/:$//') \
-  bash hooks/session-start-test.sh
-```
-
-This works cleanly when `jq` lives in its own directory (e.g. `/opt/homebrew/bin` from Homebrew, `/usr/local/bin` from a manual install). If your `jq` shares a system bin with other tools the test depends on (such as `mktemp` in `/usr/bin`), the simpler approach is to install `jq` via a separate package manager so it has its own bin directory, then re-run.
-
-The hook's `command -v jq` check fails under the stripped `PATH`, the `INFO`-priority fallback runs, and the test asserts the `jq is required` guidance message instead of the normal payload.
+Expected output: `session-start stdout payload OK`. The script exits non-zero on any assertion failure.
 
 ## Reporting Issues
 

--- a/hooks/session-start-test.sh
+++ b/hooks/session-start-test.sh
@@ -1,46 +1,25 @@
 #!/bin/bash
-# session-start-test.sh - Tests for the SessionStart hook JSON payload
+# session-start-test.sh - Tests for the SessionStart hook stdout payload
 
 set -euo pipefail
 
 tmp_payload="$(mktemp)"
 trap 'rm -f "$tmp_payload"' EXIT
 
-has_jq=0
-if command -v jq >/dev/null 2>&1; then
-  has_jq=1
-fi
+bash hooks/session-start.sh > "$tmp_payload"
 
-payload="$(bash hooks/session-start.sh)"
-printf '%s' "$payload" > "$tmp_payload"
-
-HAS_JQ="$has_jq" PAYLOAD_PATH="$tmp_payload" node <<'NODE'
+PAYLOAD_PATH="$tmp_payload" node <<'NODE'
 const fs = require('fs');
 
-const payload = JSON.parse(fs.readFileSync(process.env.PAYLOAD_PATH, 'utf8'));
-const hasJq = process.env.HAS_JQ === '1';
+const payload = fs.readFileSync(process.env.PAYLOAD_PATH, 'utf8');
 
-if (hasJq) {
-  if (payload.priority !== 'IMPORTANT') {
-    throw new Error(`expected IMPORTANT priority, got ${payload.priority}`);
-  }
-
-  if (!payload.message.includes('agent-skills loaded.')) {
-    throw new Error('message is missing startup preface');
-  }
-
-  if (!payload.message.includes('# Using Agent Skills')) {
-    throw new Error('message is missing using-agent-skills content');
-  }
-} else {
-  if (payload.priority !== 'INFO') {
-    throw new Error(`expected INFO priority when jq is missing, got ${payload.priority}`);
-  }
-
-  if (!payload.message.includes('jq is required')) {
-    throw new Error('message is missing jq fallback guidance');
-  }
+if (!payload.includes('agent-skills loaded.')) {
+  throw new Error('payload is missing startup preface');
 }
 
-console.log('session-start JSON payload OK');
+if (!payload.includes('# Using Agent Skills')) {
+  throw new Error('payload is missing using-agent-skills content');
+}
+
+console.log('session-start stdout payload OK');
 NODE

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -1,24 +1,21 @@
 #!/bin/bash
 # agent-skills session start hook
-# Injects the using-agent-skills meta-skill into every new session
+# Injects the using-agent-skills meta-skill into every new session.
+#
+# SessionStart hooks add their stdout to the agent's context, so we emit plain
+# text. The previous {priority, message} JSON shape is not part of Claude Code's
+# SessionStart hook schema and only worked where unrecognized JSON happened to
+# be treated as context; printing the content directly is the documented path
+# and removes the jq dependency.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$(dirname "$SCRIPT_DIR")/skills"
 META_SKILL="$SKILLS_DIR/using-agent-skills/SKILL.md"
 
-if ! command -v jq >/dev/null 2>&1; then
-  echo '{"priority": "INFO", "message": "agent-skills: jq is required for the session-start hook but was not found on PATH. Install jq (e.g. `brew install jq` or `apt-get install jq`) to enable meta-skill injection. Skills remain available individually."}'
-  exit 0
-fi
-
 if [ -f "$META_SKILL" ]; then
-  CONTENT=$(cat "$META_SKILL")
-  # Use jq to properly escape and construct valid JSON
-  jq -cn \
-    --arg message "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.
-
-$CONTENT" \
-    '{priority: "IMPORTANT", message: $message}'
+  echo "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task."
+  echo
+  cat "$META_SKILL"
 else
-  echo '{"priority": "INFO", "message": "agent-skills: using-agent-skills meta-skill not found. Skills may still be available individually."}'
+  echo "agent-skills: using-agent-skills meta-skill not found. Skills may still be available individually."
 fi


### PR DESCRIPTION
## Summary
The session-start hook emitted `{priority, message}` JSON, but those fields aren't in Claude Code's SessionStart hook schema. It only worked where unrecognized JSON got treated as context.

This prints the meta-skill as plain stdout (the documented SessionStart path) and drops the jq dependency. The regression test now checks stdout, and the obsolete jq-fallback steps are removed from CONTRIBUTING.

Fixes #110. Focused fix with no unrelated changes (unlike #117).

## Test
`bash hooks/session-start-test.sh` prints `session-start stdout payload OK`.