### PR TITLE
fix: update marketplace.json to use explicit GitHub source format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,16 +1,22 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "addy-agent-skills",
+  "description": "Production-grade engineering skills for AI coding agents — covering the full software development lifecycle from spec to ship.",
   "owner": {
-    "name": "Addy Osmani"
-  },
-  "metadata": {
-    "description": "Production-grade engineering skills for AI coding agents — covering the full software development lifecycle from spec to ship."
+    "name": "Addy Osmani",
+    "url": "https://github.com/addyosmani"
   },
   "plugins": [
     {
       "name": "agent-skills",
-      "source": "./",
-      "description": "Production-grade engineering skills covering every phase of software development: spec, plan, build, verify, review, and ship."
+      "source": {
+        "source": "github",
+        "repo": "addyosmani/agent-skills"
+      },
+      "description": "Production-grade engineering skills covering every phase of software development: spec, plan, build, verify, review, and ship.",
+      "homepage": "https://github.com/addyosmani/agent-skills",
+      "license": "MIT",
+      "keywords": ["skills", "agents", "engineering", "spec", "tdd", "review", "ship"]
     }
   ]
 }


### PR DESCRIPTION
## Problem

Fixes #212. Claude CLI v2.1.156+ reported `plugins.X.source: Invalid input` errors when loading marketplace files that used relative path sources (e.g. `"./"`).

## Root Cause

The `.claude-plugin/marketplace.json` used `"source": "./"` — a relative path format. While technically valid per the JSON schema (it matches `^\./.*`), some Claude CLI versions reject it under stricter validation. The explicit GitHub source object format is the canonical, unambiguous way to specify a GitHub-hosted plugin.

## Changes

- Changed `source` from `"./"` to `{ "source": "github", "repo": "addyosmani/agent-skills" }`
- Added `$schema` reference for editor autocomplete/validation
- Moved `description` from `metadata.description` to the top-level field
- Added `owner.url`, `homepage`, `license`, and `keywords` to the plugin entry

## Validation

The updated file validates cleanly against the official JSON schema at `https://json.schemastore.org/claude-code-marketplace.json`.