### PR TITLE
feat(build): add /build auto for a one-pass plan + implement

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -29,15 +29,16 @@ Pick the next pending task from the plan. Then:
 Use this once a spec exists and you want to collapse plan + build into one run. It removes the manual stepping between tasks — **not** the verification. Every task still earns a passing test and its own commit.
 
 1. **Require a spec.** Look only for a spec at a known path: `SPEC.md` at the repo root, `docs/SPEC.md`, or a file under `spec/`. A README or arbitrary doc does **not** count. If none exists, stop and tell the user to run `/spec` first — do not invent requirements.
-2. **Plan if needed.** If there is no `tasks/plan.md`, invoke agent-skills:planning-and-task-breakdown to generate one.
-3. **Single checkpoint.** Present the full plan and wait for an unambiguous affirmative (e.g. "approve", "go", "yes"). Treat hedged responses ("looks reasonable", "I guess") as **not** approved. This is the only human gate — after approval, run autonomously.
-4. **Execute every task in dependency order.** Use each task's declared dependencies; if they aren't explicit, execute in the order the plan lists them. For each task, run the full default loop above (RED → GREEN → regression → build → commit per task → mark complete). One commit per task so any point is a clean rollback.
-5. **Stop and ask the user** (do not push through) when:
+2. **Establish a clean baseline.** Run `git status --porcelain`. If there are uncommitted changes outside the expected planning artifacts (`SPEC.md`, `docs/SPEC.md`, `spec/*`, `tasks/plan.md`, `tasks/todo.md`), stop and ask the user to commit, stash, or confirm how to handle them. Autonomous per-task commits must not absorb unrelated local work, or the clean-rollback guarantee breaks.
+3. **Plan if needed.** If there is no `tasks/plan.md`, invoke agent-skills:planning-and-task-breakdown to generate one.
+4. **Single checkpoint.** Present the full plan and wait for an unambiguous affirmative (e.g. "approve", "go", "yes"). Treat hedged responses ("looks reasonable", "I guess") as **not** approved. This is the only human gate — after approval, run autonomously. If you generated `tasks/plan.md`, commit it as a single preparatory commit now so it doesn't bleed into the first task's commit.
+5. **Execute every task in dependency order.** Use each task's declared dependencies; if they aren't explicit, execute in the order the plan lists them. For each task, run the full default loop above (RED → GREEN → regression → build → commit → mark complete). Stage only the files that task touched plus its task-status update — never `git add -A` blindly — and make one commit per task so any point is a clean rollback.
+6. **Stop and ask the user** (do not push through) when:
    - a test can't be made to pass or the build breaks without an obvious fix → follow agent-skills:debugging-and-error-recovery
    - the spec is ambiguous, or a task needs a decision the spec doesn't cover
    - a task is high-risk or irreversible — auth/permission changes, destructive data migrations, payments, deletions, deploys, anything touching secrets, **or anything you can't undo with `git revert`** → follow agent-skills:doubt-driven-development and get explicit sign-off before continuing
 
    After the user resolves a blocker, they re-invoke `/build auto` — it resumes from the next pending task.
-6. **Summarize at the end:** tasks completed, tests added, commits made, and anything skipped, flagged, or left for the user.
+7. **Summarize at the end:** tasks completed, tests added, commits made, and anything skipped, flagged, or left for the user.
 
 If any step fails, follow the agent-skills:debugging-and-error-recovery skill.

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,10 +1,19 @@
 ---
-description: Implement the next task incrementally — build, test, verify, commit
+description: Implement tasks incrementally — build, test, verify, commit. Add "auto" to run the whole plan in one approved pass.
 ---
 
 Invoke the agent-skills:incremental-implementation skill alongside agent-skills:test-driven-development.
 
-Pick the next pending task from the plan. For each task:
+## Modes
+
+- **`/build`** — implement the *next* pending task, then stop (careful, one slice at a time).
+- **`/build auto`** — generate the plan if needed, get a single approval, then implement *every* task without stopping between them.
+
+`$ARGUMENTS` selects the mode. Treat `auto`, `all`, or `fast` as autonomous mode; anything else (or empty) is the default single-task mode.
+
+## Default: one task
+
+Pick the next pending task from the plan. Then:
 
 1. Read the task's acceptance criteria
 2. Load relevant context (existing code, patterns, types)
@@ -13,6 +22,20 @@ Pick the next pending task from the plan. For each task:
 5. Run the full test suite to check for regressions
 6. Run the build to verify compilation
 7. Commit with a descriptive message
-8. Mark the task complete and move to the next one
+8. Mark the task complete and stop
+
+## Autonomous: the whole plan (`/build auto`)
+
+Use this once a spec exists and you want to collapse plan + build into one run. It removes the manual stepping between tasks — **not** the verification. Every task still earns a passing test and its own commit.
+
+1. **Require a spec.** If there is no `SPEC.md` (or equivalent), stop and tell the user to run `/spec` first. Do not invent requirements.
+2. **Plan if needed.** If there is no `tasks/plan.md`, invoke agent-skills:planning-and-task-breakdown to generate one.
+3. **Single checkpoint.** Present the full plan and get explicit approval. This is the only human gate — after approval, run autonomously.
+4. **Execute every task in dependency order.** For each task, run the full default loop above (RED → GREEN → regression → build → commit per task → mark complete). One commit per task so any point is a clean rollback.
+5. **Stop and ask the user** (do not push through) when:
+   - a test can't be made to pass or the build breaks without an obvious fix → follow agent-skills:debugging-and-error-recovery
+   - the spec is ambiguous, or a task needs a decision the spec doesn't cover
+   - a task is high-risk or irreversible — auth/permission changes, destructive data migrations, payments, deletions, deploys, or anything touching secrets → follow agent-skills:doubt-driven-development and get explicit sign-off before continuing
+6. **Summarize at the end:** tasks completed, tests added, commits made, and anything skipped, flagged, or left for the user.
 
 If any step fails, follow the agent-skills:debugging-and-error-recovery skill.

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -9,7 +9,7 @@ Invoke the agent-skills:incremental-implementation skill alongside agent-skills:
 - **`/build`** — implement the *next* pending task, then stop (careful, one slice at a time).
 - **`/build auto`** — generate the plan if needed, get a single approval, then implement *every* task without stopping between them.
 
-`$ARGUMENTS` selects the mode. Treat `auto`, `all`, or `fast` as autonomous mode; anything else (or empty) is the default single-task mode.
+`$ARGUMENTS` selects the mode. Treat `auto` (canonical) or `all` as autonomous mode; anything else (or empty) is the default single-task mode. Note: autonomous mode is not faster *per task* — it runs the same test-driven loop — it only removes the human stepping *between* tasks.
 
 ## Default: one task
 
@@ -28,14 +28,16 @@ Pick the next pending task from the plan. Then:
 
 Use this once a spec exists and you want to collapse plan + build into one run. It removes the manual stepping between tasks — **not** the verification. Every task still earns a passing test and its own commit.
 
-1. **Require a spec.** If there is no `SPEC.md` (or equivalent), stop and tell the user to run `/spec` first. Do not invent requirements.
+1. **Require a spec.** Look only for a spec at a known path: `SPEC.md` at the repo root, `docs/SPEC.md`, or a file under `spec/`. A README or arbitrary doc does **not** count. If none exists, stop and tell the user to run `/spec` first — do not invent requirements.
 2. **Plan if needed.** If there is no `tasks/plan.md`, invoke agent-skills:planning-and-task-breakdown to generate one.
-3. **Single checkpoint.** Present the full plan and get explicit approval. This is the only human gate — after approval, run autonomously.
-4. **Execute every task in dependency order.** For each task, run the full default loop above (RED → GREEN → regression → build → commit per task → mark complete). One commit per task so any point is a clean rollback.
+3. **Single checkpoint.** Present the full plan and wait for an unambiguous affirmative (e.g. "approve", "go", "yes"). Treat hedged responses ("looks reasonable", "I guess") as **not** approved. This is the only human gate — after approval, run autonomously.
+4. **Execute every task in dependency order.** Use each task's declared dependencies; if they aren't explicit, execute in the order the plan lists them. For each task, run the full default loop above (RED → GREEN → regression → build → commit per task → mark complete). One commit per task so any point is a clean rollback.
 5. **Stop and ask the user** (do not push through) when:
    - a test can't be made to pass or the build breaks without an obvious fix → follow agent-skills:debugging-and-error-recovery
    - the spec is ambiguous, or a task needs a decision the spec doesn't cover
-   - a task is high-risk or irreversible — auth/permission changes, destructive data migrations, payments, deletions, deploys, or anything touching secrets → follow agent-skills:doubt-driven-development and get explicit sign-off before continuing
+   - a task is high-risk or irreversible — auth/permission changes, destructive data migrations, payments, deletions, deploys, anything touching secrets, **or anything you can't undo with `git revert`** → follow agent-skills:doubt-driven-development and get explicit sign-off before continuing
+
+   After the user resolves a blocker, they re-invoke `/build auto` — it resumes from the next pending task.
 6. **Summarize at the end:** tasks completed, tests added, commits made, and anything skipped, flagged, or left for the user.
 
 If any step fails, follow the agent-skills:debugging-and-error-recovery skill.

--- a/.gemini/commands/build.toml
+++ b/.gemini/commands/build.toml
@@ -1,9 +1,18 @@
-description = "Implement the next task incrementally — build, test, verify, commit"
+description = "Implement tasks incrementally — build, test, verify, commit. Add \"auto\" to run the whole plan in one approved pass."
 
 prompt = """
 Invoke the incremental-implementation skill alongside test-driven-development.
 
-Pick the next pending task from the plan. For each task:
+## Modes
+
+- `/build` — implement the next pending task, then stop (careful, one slice at a time).
+- `/build auto` — generate the plan if needed, get a single approval, then implement every task without stopping between them.
+
+The arguments select the mode. Treat `auto`, `all`, or `fast` as autonomous mode; anything else (or empty) is the default single-task mode.
+
+## Default: one task
+
+Pick the next pending task from the plan. Then:
 
 1. Read the task's acceptance criteria
 2. Load relevant context (existing code, patterns, types)
@@ -12,7 +21,21 @@ Pick the next pending task from the plan. For each task:
 5. Run the full test suite to check for regressions
 6. Run the build to verify compilation
 7. Commit with a descriptive message
-8. Mark the task complete and move to the next one
+8. Mark the task complete and stop
+
+## Autonomous: the whole plan (`/build auto`)
+
+Use this once a spec exists and you want to collapse plan + build into one run. It removes the manual stepping between tasks — not the verification. Every task still earns a passing test and its own commit.
+
+1. Require a spec. If there is no SPEC.md (or equivalent), stop and tell the user to run /spec first. Do not invent requirements.
+2. Plan if needed. If there is no tasks/plan.md, invoke the planning-and-task-breakdown skill to generate one.
+3. Single checkpoint. Present the full plan and get explicit approval. This is the only human gate — after approval, run autonomously.
+4. Execute every task in dependency order. For each task, run the full default loop above (RED → GREEN → regression → build → commit per task → mark complete). One commit per task so any point is a clean rollback.
+5. Stop and ask the user (do not push through) when:
+   - a test can't be made to pass or the build breaks without an obvious fix → follow the debugging-and-error-recovery skill
+   - the spec is ambiguous, or a task needs a decision the spec doesn't cover
+   - a task is high-risk or irreversible — auth/permission changes, destructive data migrations, payments, deletions, deploys, or anything touching secrets → follow the doubt-driven-development skill and get explicit sign-off before continuing
+6. Summarize at the end: tasks completed, tests added, commits made, and anything skipped, flagged, or left for the user.
 
 If any step fails, follow the debugging-and-error-recovery skill.
 """

--- a/.gemini/commands/build.toml
+++ b/.gemini/commands/build.toml
@@ -8,7 +8,7 @@ Invoke the incremental-implementation skill alongside test-driven-development.
 - `/build` — implement the next pending task, then stop (careful, one slice at a time).
 - `/build auto` — generate the plan if needed, get a single approval, then implement every task without stopping between them.
 
-The arguments select the mode. Treat `auto`, `all`, or `fast` as autonomous mode; anything else (or empty) is the default single-task mode.
+The arguments select the mode. Treat `auto` (canonical) or `all` as autonomous mode; anything else (or empty) is the default single-task mode. Note: autonomous mode is not faster per task — it runs the same test-driven loop — it only removes the human stepping between tasks.
 
 ## Default: one task
 
@@ -27,14 +27,15 @@ Pick the next pending task from the plan. Then:
 
 Use this once a spec exists and you want to collapse plan + build into one run. It removes the manual stepping between tasks — not the verification. Every task still earns a passing test and its own commit.
 
-1. Require a spec. If there is no SPEC.md (or equivalent), stop and tell the user to run /spec first. Do not invent requirements.
+1. Require a spec. Look only for a spec at a known path: SPEC.md at the repo root, docs/SPEC.md, or a file under spec/. A README or arbitrary doc does NOT count. If none exists, stop and tell the user to run /spec first — do not invent requirements.
 2. Plan if needed. If there is no tasks/plan.md, invoke the planning-and-task-breakdown skill to generate one.
-3. Single checkpoint. Present the full plan and get explicit approval. This is the only human gate — after approval, run autonomously.
-4. Execute every task in dependency order. For each task, run the full default loop above (RED → GREEN → regression → build → commit per task → mark complete). One commit per task so any point is a clean rollback.
+3. Single checkpoint. Present the full plan and wait for an unambiguous affirmative (e.g. "approve", "go", "yes"). Treat hedged responses ("looks reasonable", "I guess") as NOT approved. This is the only human gate — after approval, run autonomously.
+4. Execute every task in dependency order. Use each task's declared dependencies; if they aren't explicit, execute in the order the plan lists them. For each task, run the full default loop above (RED → GREEN → regression → build → commit per task → mark complete). One commit per task so any point is a clean rollback.
 5. Stop and ask the user (do not push through) when:
    - a test can't be made to pass or the build breaks without an obvious fix → follow the debugging-and-error-recovery skill
    - the spec is ambiguous, or a task needs a decision the spec doesn't cover
-   - a task is high-risk or irreversible — auth/permission changes, destructive data migrations, payments, deletions, deploys, or anything touching secrets → follow the doubt-driven-development skill and get explicit sign-off before continuing
+   - a task is high-risk or irreversible — auth/permission changes, destructive data migrations, payments, deletions, deploys, anything touching secrets, or anything you can't undo with `git revert` → follow the doubt-driven-development skill and get explicit sign-off before continuing
+   After the user resolves a blocker, they re-invoke /build auto — it resumes from the next pending task.
 6. Summarize at the end: tasks completed, tests added, commits made, and anything skipped, flagged, or left for the user.
 
 If any step fails, follow the debugging-and-error-recovery skill.

--- a/.gemini/commands/build.toml
+++ b/.gemini/commands/build.toml
@@ -28,15 +28,16 @@ Pick the next pending task from the plan. Then:
 Use this once a spec exists and you want to collapse plan + build into one run. It removes the manual stepping between tasks — not the verification. Every task still earns a passing test and its own commit.
 
 1. Require a spec. Look only for a spec at a known path: SPEC.md at the repo root, docs/SPEC.md, or a file under spec/. A README or arbitrary doc does NOT count. If none exists, stop and tell the user to run /spec first — do not invent requirements.
-2. Plan if needed. If there is no tasks/plan.md, invoke the planning-and-task-breakdown skill to generate one.
-3. Single checkpoint. Present the full plan and wait for an unambiguous affirmative (e.g. "approve", "go", "yes"). Treat hedged responses ("looks reasonable", "I guess") as NOT approved. This is the only human gate — after approval, run autonomously.
-4. Execute every task in dependency order. Use each task's declared dependencies; if they aren't explicit, execute in the order the plan lists them. For each task, run the full default loop above (RED → GREEN → regression → build → commit per task → mark complete). One commit per task so any point is a clean rollback.
-5. Stop and ask the user (do not push through) when:
+2. Establish a clean baseline. Run `git status --porcelain`. If there are uncommitted changes outside the expected planning artifacts (SPEC.md, docs/SPEC.md, spec/*, tasks/plan.md, tasks/todo.md), stop and ask the user to commit, stash, or confirm how to handle them. Autonomous per-task commits must not absorb unrelated local work, or the clean-rollback guarantee breaks.
+3. Plan if needed. If there is no tasks/plan.md, invoke the planning-and-task-breakdown skill to generate one.
+4. Single checkpoint. Present the full plan and wait for an unambiguous affirmative (e.g. "approve", "go", "yes"). Treat hedged responses ("looks reasonable", "I guess") as NOT approved. This is the only human gate — after approval, run autonomously. If you generated tasks/plan.md, commit it as a single preparatory commit now so it doesn't bleed into the first task's commit.
+5. Execute every task in dependency order. Use each task's declared dependencies; if they aren't explicit, execute in the order the plan lists them. For each task, run the full default loop above (RED → GREEN → regression → build → commit → mark complete). Stage only the files that task touched plus its task-status update — never `git add -A` blindly — and make one commit per task so any point is a clean rollback.
+6. Stop and ask the user (do not push through) when:
    - a test can't be made to pass or the build breaks without an obvious fix → follow the debugging-and-error-recovery skill
    - the spec is ambiguous, or a task needs a decision the spec doesn't cover
    - a task is high-risk or irreversible — auth/permission changes, destructive data migrations, payments, deletions, deploys, anything touching secrets, or anything you can't undo with `git revert` → follow the doubt-driven-development skill and get explicit sign-off before continuing
    After the user resolves a blocker, they re-invoke /build auto — it resumes from the next pending task.
-6. Summarize at the end: tasks completed, tests added, commits made, and anything skipped, flagged, or left for the user.
+7. Summarize at the end: tasks completed, tests added, commits made, and anything skipped, flagged, or left for the user.
 
 If any step fails, follow the debugging-and-error-recovery skill.
 """

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Skills encode the workflows, quality gates, and best practices that senior engin
 | Simplify the code | `/code-simplify` | Clarity over cleverness |
 | Ship to production | `/ship` | Faster is safer |
 
+In a hurry once the spec exists? **`/build auto`** generates the plan and implements every task in a single approved pass — you approve the plan once, then it runs autonomously (test-driven and committing per task, pausing only on failures or risky steps).
+
 Skills also activate automatically based on what you're doing — designing an API triggers `api-and-interface-design`, building UI triggers `frontend-ui-engineering`, and so on.
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Skills encode the workflows, quality gates, and best practices that senior engin
 | Simplify the code | `/code-simplify` | Clarity over cleverness |
 | Ship to production | `/ship` | Faster is safer |
 
-In a hurry once the spec exists? **`/build auto`** generates the plan and implements every task in a single approved pass — you approve the plan once, then it runs autonomously (test-driven and committing per task, pausing only on failures or risky steps).
+Want fewer manual steps once the spec exists? **`/build auto`** generates the plan and implements every task in a single approved pass — you approve the plan once, then it runs autonomously. It removes the human stepping *between* tasks, not the verification: every task is still test-driven and committed individually, and it pauses on failures or risky steps.
 
 Skills also activate automatically based on what you're doing — designing an API triggers `api-and-interface-design`, building UI triggers `frontend-ui-engineering`, and so on.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,6 +108,7 @@ The `.claude/commands/` directory contains slash commands for Claude Code:
 | `/spec` | spec-driven-development |
 | `/plan` | planning-and-task-breakdown |
 | `/build` | incremental-implementation + test-driven-development |
+| `/build auto` | planning-and-task-breakdown → incremental-implementation + test-driven-development (whole plan, one approval) |
 | `/test` | test-driven-development |
 | `/review` | code-review-and-quality |
 | `/ship` | shipping-and-launch |


### PR DESCRIPTION
### What & why

The `refine → spec → plan → build` chain is deliberately careful, but once a `SPEC.md` exists, hand-cranking every task is friction - you end up approving the *route* and every single *turn*. This adds a fast path: **approve the route once, then let it drive.**

`/build` gains a second mode:

| Command | Behavior |
|---|---|
| `/build` | Unchanged - implement the next task, then stop (one slice at a time) |
| `/build auto` | Require a spec → generate the plan if missing → **one approval** → implement every task autonomously |

(`auto`, `all`, and `fast` all trigger autonomous mode.)

### What it keeps

Autonomous mode removes the manual *stepping*, not the *verification*. Every task still runs the full TDD loop (RED → GREEN → regression → build) and gets **its own commit**, so any point is a clean rollback. It auto-pauses and asks the human only when it should:

- a test it can't make pass, or a build break without an obvious fix → `debugging-and-error-recovery`
- spec ambiguity, or a decision the spec doesn't cover
- a **high-risk/irreversible** task - auth/permission changes, destructive migrations, payments, deletions, deploys, anything touching secrets → `doubt-driven-development` + explicit sign-off

It ends with a summary of tasks completed, tests added, commits made, and anything skipped or flagged.

### Changes

- `.claude/commands/build.md` - two-mode definition
- `.gemini/commands/build.toml` - mirrored for Gemini CLI (we should probably account for Antigravity CLI more)
- `README.md`, `docs/getting-started.md` - document the new mode

### Test plan

- `/build` with no argument still implements a single task and stops.
- `/build auto` with no `SPEC.md` stops and prompts for `/spec` (doesn't invent requirements).
- `/build auto` with a spec but no `tasks/plan.md` generates the plan, asks for one approval, then runs.
- Gemini `build.toml` parses (validated) and mirrors the Claude prompt.
