### PR TITLE
fix(browser-testing): correct chrome-devtools-mcp install config

### DIFF
--- a/skills/browser-testing-with-devtools/SKILL.md
+++ b/skills/browser-testing-with-devtools/SKILL.md
@@ -25,18 +25,20 @@ Use Chrome DevTools MCP to give your agent eyes into the browser. This bridges t
 
 ### Installation
 
-```bash
-# Add Chrome DevTools MCP server to your Claude Code config
-# In your project's .mcp.json or Claude Code settings:
+Add the following to your project's `.mcp.json` or Claude Code settings:
+
+```json
 {
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",
-      "args": ["@anthropic/chrome-devtools-mcp@latest"]
+      "args": ["-y", "chrome-devtools-mcp@latest", "--autoConnect"]
     }
   }
 }
 ```
+
+`-y` skips the npx install confirmation. `--autoConnect` connects automatically to a running Chrome instance (or launches one) — recommended for most users.
 
 ### Available Tools
 


### PR DESCRIPTION
## Summary
- Fix package name: `@anthropic/chrome-devtools-mcp` does not exist; correct package is `chrome-devtools-mcp`
- Add `-y` to npx args to skip install confirmation prompt
- Add `--autoConnect` as recommended default, with a short explanation
- Restore the context line indicating where the config block should be placed (`.mcp.json` or Claude Code settings)

## Test plan
- [ ] Verify the config block matches a working `.mcp.json` / `claude_desktop_config.json` setup with `chrome-devtools-mcp`