### PR TITLE
Add legacy-code-and-refactoring skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ docs/         → Setup guides for different tools
 
 **Define:** interview-me, idea-refine, spec-driven-development
 **Plan:** planning-and-task-breakdown
-**Build:** incremental-implementation, test-driven-development, context-engineering, source-driven-development, doubt-driven-development, frontend-ui-engineering, api-and-interface-design
+**Build:** incremental-implementation, test-driven-development, context-engineering, source-driven-development, doubt-driven-development, frontend-ui-engineering, api-and-interface-design, legacy-code-and-refactoring
 **Verify:** browser-testing-with-devtools, debugging-and-error-recovery
 **Review:** code-review-and-quality, code-simplification, security-and-hardening, performance-optimization
 **Ship:** git-workflow-and-versioning, ci-cd-and-automation, deprecation-and-migration, documentation-and-adrs, observability-and-instrumentation, shipping-and-launch

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ The commands above are entry points. The pack includes 24 skills total — 23 li
 | [doubt-driven-development](skills/doubt-driven-development/SKILL.md) | Adversarial fresh-context review of every non-trivial decision in-flight - CLAIM → EXTRACT → DOUBT → RECONCILE → STOP, with optional user-authorized cross-model escalation | Stakes are high (production, security, irreversible), working in unfamiliar code, or a confident output is cheaper to verify now than to debug later |
 | [frontend-ui-engineering](skills/frontend-ui-engineering/SKILL.md) | Component architecture, design systems, state management, responsive design, WCAG 2.1 AA accessibility | Building or modifying user-facing interfaces |
 | [api-and-interface-design](skills/api-and-interface-design/SKILL.md) | Contract-first design, Hyrum's Law, One-Version Rule, error semantics, boundary validation | Designing APIs, module boundaries, or public interfaces |
+| [legacy-code-and-refactoring](skills/legacy-code-and-refactoring/SKILL.md) | Characterization tests, seams, sprout method, strangler fig - never refactor and change behavior in the same commit | Modifying untested or unfamiliar code, or tempted to rewrite from scratch |
 
 ### Verify - Prove it works
 
@@ -287,6 +288,7 @@ agent-skills/
 │   ├── frontend-ui-engineering/       #   Build
 │   ├── test-driven-development/       #   Build
 │   ├── api-and-interface-design/      #   Build
+│   ├── legacy-code-and-refactoring/   #   Build
 │   ├── browser-testing-with-devtools/ #   Verify
 │   ├── debugging-and-error-recovery/  #   Verify
 │   ├── code-review-and-quality/       #   Review

--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ Skills are plain Markdown - they work with any agent that accepts system prompts
 
 ---
 
-## All 24 Skills
+## All 25 Skills
 
-The commands above are entry points. The pack includes 24 skills total — 23 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
+The commands above are entry points. The pack includes 25 skills total — 24 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
 
 ### Meta - Discover which skill applies
 
@@ -276,7 +276,7 @@ Every skill follows a consistent anatomy:
 
 ```
 agent-skills/
-├── skills/                            # 24 skills (23 lifecycle + 1 meta)
+├── skills/                            # 25 skills (24 lifecycle + 1 meta)
 │   ├── interview-me/                  #   Define
 │   ├── idea-refine/                   #   Define
 │   ├── spec-driven-development/       #   Define

--- a/skills/legacy-code-and-refactoring/SKILL.md
+++ b/skills/legacy-code-and-refactoring/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: legacy-code-and-refactoring
+description: Guides safe changes to legacy code — code without tests, documentation, or anyone who remembers why it works. Use when modifying code that has no test coverage. Use when a change requires refactoring first but there's no safety net. Use when inheriting an unfamiliar codebase and the first instinct is "rewrite it".
+---
+
+# Legacy Code and Refactoring
+
+## Overview
+
+Legacy code is code without tests — regardless of its age. Without tests, you cannot know whether a change preserves behavior, so every edit is a gamble. This skill turns that gamble into a process: pin down current behavior first, create the seams that make the code testable, then change it in small, separately-verified steps. The cardinal rule: **never refactor and change behavior in the same step.**
+
+## When to Use
+
+- Modifying code that has no test coverage
+- Fixing a bug in code you don't fully understand
+- The task is "add feature X" but the surrounding code resists change
+- Inheriting a codebase and deciding between refactor and rewrite
+- Any time you catch yourself thinking "I'll just carefully edit it and hope"
+
+**NOT for:**
+- Code that is already tested and readable but over-complex — use the `code-simplification` skill
+- Removing or sunsetting an entire system — use the `deprecation-and-migration` skill
+- Diagnosing an active failure — use the `debugging-and-error-recovery` skill first; come back here for the fix
+
+## Core Process
+
+### 1. Understand before touching
+
+Read the code and its history before editing a line:
+
+```bash
+git log --follow -20 -- path/to/file.js        # why did it change before?
+git log -S "functionName" --oneline            # who calls/changed this logic?
+grep -rn "functionName" --include="*.js" .     # blast radius: every caller
+```
+
+Apply Chesterton's Fence (see `code-simplification`): if you can't explain why a weird branch exists, you're not ready to delete it. Write down what you believe the code does — that belief becomes the first characterization test. For non-trivial uncertainty, run the `doubt-driven-development` skill on your reading of the code.
+
+### 2. Pin current behavior with characterization tests
+
+A characterization test asserts what the code **does**, not what it should do. Bugs included — today's callers may depend on them (Hyrum's Law, see `api-and-interface-design`).
+
+```typescript
+// You don't know what calculateDiscount returns for edge cases? Ask it.
+test.each([
+  [0, 0],
+  [100, 5],
+  [-50, -2.5],     // negative input "works" — pin it, flag it, don't fix it yet
+  [NaN, NaN],      // surprising? Capture reality, note the question for later
+])('calculateDiscount(%p) currently returns %p', (input, current) => {
+  expect(calculateDiscount(input)).toBe(current);
+});
+```
+
+Workflow: write the assertion with a deliberately wrong expected value → run it → copy the actual value into the test. The test suite is done when it fails if you break anything you care about. For functions with large or messy output (reports, HTML, generated files), snapshot the entire output once — a golden master — and diff against it on every change.
+
+If you find a real bug while characterizing: pin the buggy behavior, file it, and fix it **after** the refactor, in its own commit with its own failing-test-first (`test-driven-development`).
+
+### 3. Create a seam if the code won't go into a harness
+
+Most legacy code can't be tested because it constructs its own dependencies — database, clock, network — deep inside. A seam is a place where you can substitute behavior without editing the logic you're trying to test. The smallest safe ones:
+
+```typescript
+// BEFORE: untestable — hidden dependencies
+function generateInvoice(orderId: string) {
+  const order = db.orders.find(orderId);          // real DB
+  const issuedAt = new Date();                    // real clock
+  /* 200 lines of pricing logic */
+}
+
+// AFTER: parameterize the dependencies, default to the old behavior.
+// Existing callers unchanged; tests inject fakes.
+function generateInvoice(
+  orderId: string,
+  deps = { findOrder: (id: string) => db.orders.find(id), now: () => new Date() },
+) {
+  const order = deps.findOrder(orderId);
+  const issuedAt = deps.now();
+  /* the 200 lines stay byte-identical */
+}
+```
+
+For new logic that must live inside an untestable monster function, use **sprout**: write the new logic as a fresh, fully tested function, and add a single call to it from the legacy code. The untested surface doesn't grow.
+
+### 4. Refactor and change behavior in separate commits
+
+This is the rule everything else serves:
+
+```
+Commit 1: refactor   — extract function, rename, introduce seam.
+                       Characterization tests pass UNCHANGED.
+Commit 2: behavior   — the bug fix or feature.
+                       One test changes/appears, and it changed first (red → green).
+```
+
+If a "refactor" commit requires editing a test expectation, it wasn't a refactor — stop and split it. Mixed commits are unreviewable (`code-review-and-quality` can't tell intended change from accident) and unbisectable. Keep each commit independently green (`git-workflow-and-versioning`).
+
+### 5. Choose strangler fig over rewrite
+
+For replacing a whole module or system, don't big-bang rewrite. Route through an interface and replace incrementally:
+
+```
+1. Put a facade in front of the legacy module (callers now hit the facade)
+2. Implement one slice of behavior in the new code
+3. Route that slice to the new path — feature-flagged, with a kill switch
+4. Compare outputs in production (run both, log diffs) until confidence is earned
+5. Repeat per slice; delete legacy code as each slice proves out (deprecation-and-migration)
+```
+
+Each step ships (`incremental-implementation`), each step is reversible, and the system never stops working. A rewrite that takes six months delivers nothing for six months and re-discovers every edge case the old code already handled.
+
+### 6. Leave it better — within scope
+
+Apply the boy-scout rule at the scale of the task: the code you touched ends up tested and slightly clearer. Do **not** expand into adjacent cleanup — scope discipline (see `using-agent-skills` core behaviors) applies doubly in legacy code, where every extra touched line is extra risk. Note follow-ups; don't do them now.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It's a one-line change, I don't need tests first" | One line in untested code is where regressions live. The characterization test for that path costs ten minutes; the production incident costs days. |
+| "Writing tests for bad code legitimizes it" | Characterization tests legitimize nothing — they're scaffolding that makes the bad code safe to change. Delete or rewrite them when the refactor is done. |
+| "This code is impossible to test" | It's untestable *as is*. That's what seams are for — parameterize one dependency and the harness fits. "Impossible" usually means "I haven't found the seam yet". |
+| "Faster to rewrite it from scratch" | The mess encodes years of edge cases you can't see. A rewrite rediscovers them one production incident at a time. Strangler fig gets you the new code without the amnesia. |
+| "I'll fix this bug while I'm refactoring anyway" | Now your diff has two kinds of change and the reviewer can't tell which differences are intended. Two commits: refactor green, then fix red→green. |
+| "Nobody depends on this weird behavior" | Hyrum's Law: with enough users, someone depends on every observable behavior — including the bug. Pin it first, change it deliberately, with a migration note. |
+| "While I'm here, I'll clean up the whole file" | Every touched line is risk and review burden. Surgical precision: the task's scope, tested, nothing more. |
+
+## Red Flags
+
+- Editing untested code with no characterization test written first
+- A "refactor" commit where test expectations changed
+- A diff that mixes renames/extractions with logic changes
+- "Improved" behavior shipped silently because the old behavior "was obviously wrong"
+- A rewrite branch alive for weeks while the legacy system keeps evolving
+- Tests written *after* the change, asserting whatever the new code happens to do
+- Growing an already-untestable function instead of sprouting tested code beside it
+- Cleanup commits touching files the task never required
+
+## Verification
+
+After changing legacy code, confirm:
+
+- [ ] Characterization tests existed and passed **before** the first behavioral change
+- [ ] Refactoring commits and behavior-change commits are separate, each independently green
+- [ ] Any behavior change has a test that failed first (red → green evidence)
+- [ ] Bugs discovered during characterization were pinned and filed, not silently fixed
+- [ ] Every touched code path is covered by a test that fails if it breaks
+- [ ] No changes outside the task's scope (diff reviewed for accidental cleanup)
+- [ ] For strangler-fig work: old and new paths compared on real traffic, kill switch tested

--- a/skills/legacy-code-and-refactoring/SKILL.md
+++ b/skills/legacy-code-and-refactoring/SKILL.md
@@ -22,7 +22,7 @@ Legacy code is code without tests — regardless of its age. Without tests, you 
 - Removing or sunsetting an entire system — use the `deprecation-and-migration` skill
 - Diagnosing an active failure — use the `debugging-and-error-recovery` skill first; come back here for the fix
 
-## Core Process
+## Process
 
 ### 1. Understand before touching
 

--- a/skills/legacy-code-and-refactoring/SKILL.md
+++ b/skills/legacy-code-and-refactoring/SKILL.md
@@ -103,11 +103,11 @@ For replacing a whole module or system, don't big-bang rewrite. Route through an
 1. Put a facade in front of the legacy module (callers now hit the facade)
 2. Implement one slice of behavior in the new code
 3. Route that slice to the new path — feature-flagged, with a kill switch
-4. Compare outputs in production (run both, log diffs) until confidence is earned
+4. Compare outputs in production (run both, log diffs — reads only, see warning below) until confidence is earned
 5. Repeat per slice; delete legacy code as each slice proves out
 ```
 
-**Shadow reads only.** Running both paths doubles any side effect: a shadowed write path means two database writes, two charged cards, two sent emails. For write paths, suppress the new path's side effects (dry-run mode, a recording adapter) and compare the writes it *would* have made against the real ones.
+**Shadow reads only.** Running both paths doubles any side effect: a shadowed write path means two database writes, two charged cards, two sent emails. For write paths, suppress the new path's side effects — run it in dry-run mode, or swap its DB/payment/mail client for one that records each call instead of executing it — and compare the recorded writes against the real ones. Normalize nondeterministic fields (timestamps, generated IDs) before diffing, or every comparison is noise. And even pure reads double backend load: sample the shadow traffic if the dependency is already hot.
 
 Each step ships, each step is reversible, and the system never stops working. A rewrite that takes six months delivers nothing for six months and re-discovers every edge case the old code already handled.
 

--- a/skills/legacy-code-and-refactoring/SKILL.md
+++ b/skills/legacy-code-and-refactoring/SKILL.md
@@ -34,11 +34,11 @@ git log -S "functionName" --oneline            # who calls/changed this logic?
 grep -rn "functionName" --include="*.js" .     # blast radius: every caller
 ```
 
-Apply Chesterton's Fence (see `code-simplification`): if you can't explain why a weird branch exists, you're not ready to delete it. Write down what you believe the code does — that belief becomes the first characterization test. For non-trivial uncertainty, run the `doubt-driven-development` skill on your reading of the code.
+Apply Chesterton's Fence: if you can't explain why a weird branch exists, you're not ready to delete it. Write down what you believe the code does — that belief becomes the first characterization test.
 
 ### 2. Pin current behavior with characterization tests
 
-A characterization test asserts what the code **does**, not what it should do. Bugs included — today's callers may depend on them (Hyrum's Law, see `api-and-interface-design`).
+A characterization test asserts what the code **does**, not what it should do. Bugs included — today's callers may depend on them (Hyrum's Law).
 
 ```typescript
 // You don't know what calculateDiscount returns for edge cases? Ask it.
@@ -93,7 +93,7 @@ Commit 2: behavior   — the bug fix or feature.
                        One test changes/appears, and it changed first (red → green).
 ```
 
-If a "refactor" commit requires editing a test expectation, it wasn't a refactor — stop and split it. Mixed commits are unreviewable (`code-review-and-quality` can't tell intended change from accident) and unbisectable. Keep each commit independently green (`git-workflow-and-versioning`).
+If a "refactor" commit requires editing a test expectation, it wasn't a refactor — stop and split it. Mixed commits are unreviewable (the reviewer can't tell intended change from accident) and unbisectable. Keep each commit independently green (`git-workflow-and-versioning`).
 
 ### 5. Choose strangler fig over rewrite
 
@@ -104,14 +104,16 @@ For replacing a whole module or system, don't big-bang rewrite. Route through an
 2. Implement one slice of behavior in the new code
 3. Route that slice to the new path — feature-flagged, with a kill switch
 4. Compare outputs in production (run both, log diffs) until confidence is earned
-5. Repeat per slice; delete legacy code as each slice proves out (deprecation-and-migration)
+5. Repeat per slice; delete legacy code as each slice proves out
 ```
 
-Each step ships (`incremental-implementation`), each step is reversible, and the system never stops working. A rewrite that takes six months delivers nothing for six months and re-discovers every edge case the old code already handled.
+**Shadow reads only.** Running both paths doubles any side effect: a shadowed write path means two database writes, two charged cards, two sent emails. For write paths, suppress the new path's side effects (dry-run mode, a recording adapter) and compare the writes it *would* have made against the real ones.
+
+Each step ships, each step is reversible, and the system never stops working. A rewrite that takes six months delivers nothing for six months and re-discovers every edge case the old code already handled.
 
 ### 6. Leave it better — within scope
 
-Apply the boy-scout rule at the scale of the task: the code you touched ends up tested and slightly clearer. Do **not** expand into adjacent cleanup — scope discipline (see `using-agent-skills` core behaviors) applies doubly in legacy code, where every extra touched line is extra risk. Note follow-ups; don't do them now.
+Apply the boy-scout rule at the scale of the task: the code you touched ends up tested and slightly clearer. Do **not** expand into adjacent cleanup — scope discipline applies doubly in legacy code, where every extra touched line is extra risk. Note follow-ups; don't do them now.
 
 ## Common Rationalizations
 
@@ -146,4 +148,13 @@ After changing legacy code, confirm:
 - [ ] Bugs discovered during characterization were pinned and filed, not silently fixed
 - [ ] Every touched code path is covered by a test that fails if it breaks
 - [ ] No changes outside the task's scope (diff reviewed for accidental cleanup)
-- [ ] For strangler-fig work: old and new paths compared on real traffic, kill switch tested
+- [ ] For strangler-fig work: old and new paths compared on real traffic (reads shadowed, writes dry-run — no doubled side effects), kill switch tested
+
+## Related Skills
+
+- `code-simplification` — Chesterton's Fence; the follow-up pass once the code is tested and readable
+- `doubt-driven-development` — cross-examine your reading of unfamiliar code before acting on it
+- `api-and-interface-design` — Hyrum's Law: observable behavior is a de facto contract
+- `code-review-and-quality` — why mixed refactor/behavior diffs are unreviewable
+- `incremental-implementation` — shipping strangler-fig slices one at a time
+- `deprecation-and-migration` — retiring the legacy path once the new one proves out

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -25,6 +25,7 @@ Task arrives
     │   ├── API work? ────────────────→ api-and-interface-design
     │   ├── Need better context? ─────→ context-engineering
     │   ├── Need doc-verified code? ───→ source-driven-development
+    │   ├── Legacy/untested code? ─────→ legacy-code-and-refactoring
     │   └── Stakes high / unfamiliar code? ──→ doubt-driven-development
     ├── Writing/running tests? ────────→ test-driven-development
     │   └── Browser-based? ───────────→ browser-testing-with-devtools
@@ -174,6 +175,7 @@ Not every task needs every skill. A bug fix might only need: `debugging-and-erro
 | Build | context-engineering | Right context at the right time |
 | Build | frontend-ui-engineering | Production-quality UI with accessibility |
 | Build | api-and-interface-design | Stable interfaces with clear contracts |
+| Build | legacy-code-and-refactoring | Characterization tests first; refactor and behavior change in separate commits |
 | Verify | test-driven-development | Failing test first, then make it pass |
 | Verify | browser-testing-with-devtools | Chrome DevTools MCP for runtime verification |
 | Verify | debugging-and-error-recovery | Reproduce → localize → fix → guard |


### PR DESCRIPTION
All the current skills assume new or at least tested code, but the most common thing I actually point an agent at is old untested code that nobody remembers why it works. code-simplification doesn't cover it — it explicitly wants code that's already readable and tested.

So this adds the classic Feathers playbook as a skill: characterization tests before touching anything, seams and sprout to make untestable code testable, refactor and behavior change always in separate commits, strangler fig instead of rewrites.

Wired into README, CLAUDE.md and the using-agent-skills tree. session-start-test.sh passes since I touched the meta-skill.