### PR TITLE
fix: quote SessionStart hook path

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\""
           }
         ]
       }

--- a/hooks/session-start-test.sh
+++ b/hooks/session-start-test.sh
@@ -11,6 +11,13 @@ if command -v jq >/dev/null 2>&1; then
   has_jq=1
 fi
 
+expected_command='bash "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"'
+actual_command="$(node -e "const fs=require('fs'); const hooks=JSON.parse(fs.readFileSync('hooks/hooks.json','utf8')); process.stdout.write(hooks.hooks.SessionStart[0].hooks[0].command);")"
+if [ "$actual_command" != "$expected_command" ]; then
+  echo "unexpected SessionStart command: $actual_command" >&2
+  exit 1
+fi
+
 payload="$(bash hooks/session-start.sh)"
 printf '%s' "$payload" > "$tmp_payload"
 


### PR DESCRIPTION
## Summary
- quote the `CLAUDE_PLUGIN_ROOT` expansion in the SessionStart hook command
- add a regression check that locks the hook command string in `hooks/hooks.json`

## Verification
- `hooks/session-start-test.sh` passed from an LF-normalized temp checkout on Windows
- executed the SessionStart hook command from a temp path containing spaces and confirmed it returned the expected JSON payload

Closes #214.