### PR TITLE
fix: remove stale SSH-to-HTTPS rewrite so CI tests real install path

### DIFF
--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -43,9 +43,6 @@ jobs:
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
-      - name: Configure git to use HTTPS
-        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
-
       - name: Add marketplace
         run: claude plugin marketplace add ./
 


### PR DESCRIPTION
Summary

Removes the `git config --global url."https://github.com/".insteadOf "git@github.com:"` step from the `test-install` CI job. The SSH-clone failure it worked around (#77) was fixed upstream in the Claude Code CLI, and keeping the rewrite means CI never exercises the install path users actually run — it would stay green even if the SSH regression described in #77 came back.

PR type
- [ ] Reproducible bug fix
- [x] Behavior bug / regression fix
- [ ] Small maintenance only, no UI or behavior change
- [ ] Docs accuracy fix

Why

Issue #77 reported that `claude plugin install agent-skills@addy-agent-skills` fails inside Docker/devcontainers because older CLI versions (v2.1.110 era) cloned the `{"source": "github"}` plugin source via `git@github.com:`, which requires SSH keys that containers don't have. The CI workflow (added 2026-04-04, before the upstream fix) needed the `insteadOf` rewrite for the same reason.

That root cause no longer exists: on the current CLI (v2.1.170, which CI installs fresh via `npm install -g @anthropic-ai/claude-code`), the plugin-source clone goes over anonymous HTTPS. I verified this empirically by running issue #77's exact reproduction steps (`claude plugin marketplace add addyosmani/agent-skills` followed by `claude plugin install agent-skills@addy-agent-skills`) in a container with **no ssh binary, no SSH keys, no git credential helper, and no URL rewrites** — both steps succeed.

With the workaround now dead code, its only remaining effect is harmful: it masks exactly the failure mode this workflow was created to catch. GitHub Actions runners have no GitHub SSH credentials configured, so after this change the `test-install` job faithfully reproduces #77's environment on every push and acts as a permanent regression guard for it.

Issue or approval

Fixes #77

UI / behavior impact
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch or bug
- [x] Behavior changed only to fix a documented bug or regression

Policy check
- [x] I have read CONTRIBUTING.md or applied general OSS norms.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] This PR does not bundle unrelated refactors, cleanups, or formatting changes.
- [x] This PR adds no new dependencies or architecture changes.
- [x] I have listed all testing performed below.

Scope boundaries

`.github/workflows/test-plugin-install.yml` — removed the single "Configure git to use HTTPS" step (3 lines deleted, nothing added). No other file touched; no lines reformatted; `marketplace.json`, hooks, skills, and the other two CI jobs are unchanged.

Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` on the modified workflow — parses cleanly.
- `node scripts/validate-skills.js` — 23 skills checked, 0 errors, 0 warnings, PASSED (unchanged baseline).
- `claude plugin validate .` — Validation passed.
- Empirical end-to-end run of the modified job's exact steps on Claude Code v2.1.170 in a Linux container with no ssh binary, no SSH keys, no credential helper, and no `insteadOf` rewrites:
  - `claude plugin marketplace add ./` → success
  - `claude plugin marketplace list` → marketplace listed
  - `claude plugin install agent-skills@addy-agent-skills --scope user` → **Successfully installed** (plugin source cloned from GitHub over anonymous HTTPS; installed commit `5e262b2` matches current `main` HEAD)
- Also ran issue #77's exact remote reproduction (`claude plugin marketplace add addyosmani/agent-skills` → install) in the same SSH-less container → success, confirming the original bug no longer reproduces.

STATIC ANALYSIS:
before fix: the `test-install` job rewrote every `git@github.com:` URL to HTTPS before `claude plugin install` ran, so the job could not detect a recurrence of #77 — an SSH-cloning regression in the CLI or a future SSH-only source in `marketplace.json` would pass CI while failing for every devcontainer/CI user.
after fix:  the job runs `claude plugin install` exactly as end users do, on a runner with no GitHub SSH credentials — any SSH-clone regression now fails CI immediately.
edge cases: `actions/checkout` credential persistence is written to the checked-out repo's local config (`http.extraheader`), not global config, and the plugin clone happens under `~/.claude/plugins/` — so checkout credentials neither help nor mask anything. The repo is public, so the anonymous HTTPS clone needs no auth.
regression risk: the change only deletes a git config line in an ephemeral CI runner; it cannot affect plugin contents, the published marketplace, or user installs. Worst case, if the CLI ever reverts to SSH cloning, the job fails — which is the intended signal, and re-adding the one-line workaround would be trivial.

Screenshots / Video (UI changes only)

Not a UI change.

Breaking changes

None.

Linked issues

Fixes #77