### PR TITLE
feat: add Agent Resilience and Fuzzing skill

### DIFF
--- a/skills/agent-resilience-and-fuzzing/SKILL.md
+++ b/skills/agent-resilience-and-fuzzing/SKILL.md
@@ -1,0 +1,61 @@
+```markdown
+---
+name: agent-resilience-and-fuzzing
+description: Guides agents through resilience and fuzzing testing for any skill. Use when you have finished implementing a skill and want to ensure it handles edge cases, invalid inputs, and adversarial interactions gracefully.
+---
+
+# Agent Resilience and Fuzzing
+
+## Overview
+This skill ensures that any skill is production-ready by systematically testing its resilience to unexpected or adversarial inputs. Instead of assuming “it works on the happy path”, the agent follows a concrete fuzzing workflow to discover failures, ambiguous behaviors, and security-relevant edge cases.
+
+## When to Use
+- Use when you have finished implementing a new skill or significantly changed an existing one.
+- Use when a skill interacts with external systems (APIs, CLIs, databases) or receives untrusted input.
+- Use when a skill’s failure could lead to data loss, security issues, or poor user experience.
+- Do NOT use for purely documentation-only skills that do not execute logic.
+
+## Core Process
+1. **Identify the skill under test**: Locate the target skill directory under `skills/` and read its `SKILL.md`.
+2. **Extract the input schema**: Identify the inputs the skill accepts (CLI args, paths, JSON payloads). Document expected types and constraints.
+3. **Define fuzzing dimensions**: For each input, define fuzzing categories: Type mismatches, Boundary values, Invalid formats, Adversarial payloads.
+4. **Generate concrete fuzz cases**: Write 2–5 examples per dimension in a `fuzz-cases.md` file inside the skill directory.
+5. **Run the skill with each fuzz case**: Execute the skill in a safe environment. Capture exit status, errors, and side effects. Use the helper script `scripts/fuzz-skill.sh`.
+6. **Classify outcomes**: Graceful failure, Ambiguous behavior, Unsafe failure, or Unexpected success.
+7. **Fix and document**: Update the skill’s logic for unsafe/ambiguous outcomes. Add an `Edge Cases` section to its `SKILL.md`.
+8. **Resilience summary**: Create a `RESILIENCE.md` in the skill directory summarizing tested dimensions and known limitations.
+9. **Update Verification section**: Add resilience checks to the target skill’s Verification checklist.
+
+## Fuzzing with `scripts/fuzz-skill.sh`
+This skill ships a helper script to run simple fuzz tests for skills that accept command-line arguments.
+
+Example usage:
+
+```bash
+./skills/agent-resilience-and-fuzzing/scripts/fuzz-skill.sh \
+  --skill skills/<skill-name>/SKILL.md \
+  --arg "limit" --type number \
+  --fuzz-type "boundary,mismatch,overflow"
+```
+
+## Common Rationalizations
+| Rationalization | Reality |
+| --- | --- |
+| “The happy path is enough; edge cases are rare.” | Production systems often fail under rare or adversarial inputs; resilience is a feature. |
+| “If the input is invalid, it’s the caller’s fault.” | Robust skills fail safely and clearly, regardless of who is at fault. |
+| “Adding resilience checks will bloat the skill.” | A few explicit checks are cheaper than debugging outages or security incidents. |
+
+## Red Flags
+- The skill crashes, hangs, or produces unclear errors on any fuzz case.
+- The skill silently accepts invalid input and proceeds as if it were valid.
+- The skill leaks internal details (stack traces, full file paths) in error messages.
+- The skill performs destructive actions on invalid inputs without confirmation.
+
+## Verification
+After completing this skill for a target skill, confirm:
+- [ ] A `fuzz-cases.md` file exists in the target skill directory.
+- [ ] All fuzz cases have been executed and their outcomes recorded.
+- [ ] No unsafe or ambiguous failures remain; each is handled gracefully or documented as a known limitation.
+- [ ] A `RESILIENCE.md` file exists and summarizes the tested dimensions and known limitations.
+- [ ] The target skill’s `SKILL.md` Verification section includes resilience exit criteria.
+```

--- a/skills/agent-resilience-and-fuzzing/scripts/fuzz-skill.sh
+++ b/skills/agent-resilience-and-fuzzing/scripts/fuzz-skill.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# skills/agent-resilience-and-fuzzing/scripts/fuzz-skill.sh
+# Simple fuzzing helper for agent-skills that accept command-line arguments.
+
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage:
+  $(basename "$0") --skill SKILL_MD --arg ARG_NAME --type TYPE [--fuzz-type TYPES]
+
+Options:
+  --skill      Path to the target skill's SKILL.md.
+  --arg        Name of the argument to fuzz.
+  --type       Type of the argument: number|string|path|url.
+  --fuzz-type  Comma-separated list of fuzzing types: boundary,mismatch,overflow,invalid-format,adversarial.
+               Default: boundary,mismatch,overflow.
+
+Example:
+  $(basename "$0") \\
+    --skill skills/example-skill/SKILL.md \\
+    --arg limit \\
+    --type number \\
+    --fuzz-type boundary,mismatch,overflow
+EOF
+}
+
+SKILL_MD=""
+ARG_NAME=""
+ARG_TYPE=""
+FUZZ_TYPES="boundary,mismatch,overflow"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skill) SKILL_MD="$2"; shift 2 ;;
+    --arg) ARG_NAME="$2"; shift 2 ;;
+    --type) ARG_TYPE="$2"; shift 2 ;;
+    --fuzz-type) FUZZ_TYPES="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$SKILL_MD" || -z "$ARG_NAME" || -z "$ARG_TYPE" ]]; then
+  echo "Error: --skill, --arg, and --type are required."
+  usage
+  exit 1
+fi
+
+if [[ ! -f "$SKILL_MD" ]]; then
+  echo "Error: Skill file not found: $SKILL_MD"
+  exit 1
+fi
+
+SKILL_DIR="$(dirname "$SKILL_MD")"
+SKILL_NAME="$(basename "$SKILL_DIR")"
+
+echo "=== Fuzzing skill: $SKILL_NAME ==="
+echo "Skill file: $SKILL_MD"
+echo "Argument: $ARG_NAME ($ARG_TYPE)"
+echo "Fuzz types: $FUZZ_TYPES"
+echo
+
+generate_fuzz_values() {
+  local arg_type="$1"
+  local fuzz_types="$2"
+  IFS=',' read -ra types <<< "$fuzz_types"
+
+  case "$arg_type" in
+    number)
+      for ft in "${types[@]}"; do
+        case "$ft" in
+          boundary) echo -e "-10\n0\n999999999" ;;
+          mismatch) echo -e "\"abc\"\nnull\nundefined" ;;
+          overflow) echo -e "1e309\n-1e309" ;;
+        esac
+      done
+      ;;
+    string)
+      for ft in "${types[@]}"; do
+        case "$ft" in
+          boundary) echo -e "\na\n$(printf 'a%.0s' {1..256})" ;;
+          mismatch) echo -e "123\nnull\n{}" ;;
+          adversarial) echo -e "<script>alert(1)</script>\n' OR '1'='1" ;;
+        esac
+      done
+      ;;
+    path)
+      for ft in "${types[@]}"; do
+        case "$ft" in
+          boundary) echo -e "/nonexistent/path\n/dev/null" ;;
+          invalid-format) echo -e "http://not-a-path\n|invalid" ;;
+        esac
+      done
+      ;;
+    url)
+      for ft in "${types[@]}"; do
+        case "$ft" in
+          boundary) echo -e "http://0.0.0.0:0" ;;
+          invalid-format) echo -e "htt://bad-url\n\"" ;;
+          adversarial) echo -e "http://evil.com/<script>alert(1)</script>" ;;
+        esac
+      done
+      ;;
+    *) echo "Unsupported type: $arg_type" >&2; exit 1 ;;
+  esac
+}
+
+FUZZ_VALUES=()
+while IFS= read -r value; do
+  [[ -n "$value" ]] && FUZZ_VALUES+=("$value")
+done < <(generate_fuzz_values "$ARG_TYPE" "$FUZZ_TYPES")
+
+if [[ ${#FUZZ_VALUES[@]} -eq 0 ]]; then
+  echo "No fuzz values generated."; exit 0
+fi
+
+SKILL_SCRIPT=""
+if [[ -d "$SKILL_DIR/scripts" ]]; then
+  SKILL_SCRIPT="$(find "$SKILL_DIR/scripts" -maxdepth 1 -type f -name '*.sh' | head -n 1)"
+fi
+
+run_skill() {
+  local arg_value="$1"
+  echo "---- Running with $ARG_NAME=$arg_value ----"
+  if [[ -n "$SKILL_SCRIPT" ]]; then
+    if "$SKILL_SCRIPT" "--$ARG_NAME=$arg_value" 2>&1; then
+      echo "Status: OK"
+    else
+      echo "Status: FAILED"
+    fi
+  else
+    echo "(No executable script found; stub execution.)"
+    echo "Skill: $SKILL_NAME | Arg: $ARG_NAME=$arg_value | Status: STUB"
+  fi
+  echo
+}
+
+for value in "${FUZZ_VALUES[@]}"; do
+  run_skill "$value"
+done
+
+echo "=== Fuzzing complete for skill $SKILL_NAME ==="


### PR DESCRIPTION
🚀 Summary
This PR adds a new skill agent-resilience-and-fuzzing that guides agents through resilience and fuzzing testing for any skill, plus a helper script (fuzz-skill.sh) to automate simple fuzz tests. 🛡️

💡 Motivation
While agent-skills already covers many quality dimensions (TDD, code review, security, etc.), there is no explicit workflow for ensuring that skills themselves are resilient to unexpected or adversarial inputs. 📉

As agents get more autonomous, a malformed input or an unexpected API response can cascade into a broken state. This skill:

🛡️ Defines a concrete process for identifying and testing edge cases in any skill.
🤖 Ships a generic fuzzing helper script that can be reused across the repo.
🧩 Integrates with the existing skill anatomy by adding fuzz-cases.md, RESILIENCE.md, and resilience-related verification steps.

🧪 How to test

Run the included script against an existing skill:
./skills/agent-resilience-and-fuzzing/scripts/fuzz-skill.sh \  --skill skills/incremental-implementation/SKILL.md \  --arg "limit" \  --type number \  --fuzz-type boundary,mismatch,overflow

Verify that the script generates and runs fuzz cases, clearly showing which cases are OK vs FAILED. ✅

✅ Checklist

New skill under skills/ with kebab-case name
 SKILL.md follows docs/skill-anatomy.md
 YAML frontmatter with valid name and description
 Description starts with what the skill does, then Use when triggers
 Skill is specific, verifiable, and minimal
 No duplicate content; other skills are referenced by name
 No empty scripts/ directory; this skill ships a concrete, usable script
