### PR TITLE
feat: add CI linter to enforce skill anatomy standards

### DIFF
--- a/.github/workflows/lint-skills.yml
+++ b/.github/workflows/lint-skills.yml
@@ -1,0 +1,21 @@
+name: Lint Agent Skills
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+
+jobs:
+  lint-skills:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate Skill Anatomy
+        run: node scripts/validate-skill-structure.js

--- a/scripts/validate-skill-structure.js
+++ b/scripts/validate-skill-structure.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+
+const SKILLS_DIR = path.join(__dirname, '..', 'skills');
+const REQUIRED_SECTIONS = ['## Overview', '## When to Use', '## Verification'];
+let hasErrors = false;
+
+function validateSkill(skillPath, skillName) {
+    const mdPath = path.join(skillPath, 'SKILL.md');
+    if (!fs.existsSync(mdPath)) return; // Skip if no SKILL.md
+
+    const content = fs.readFileSync(mdPath, 'utf8');
+    const errors = [];
+
+    // 1. Check YAML frontmatter
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!frontmatterMatch) {
+        errors.push("Missing YAML frontmatter.");
+    } else {
+        const yaml = frontmatterMatch[1];
+        if (!yaml.match(/^name:\s*.+/m)) errors.push("Missing 'name' in frontmatter.");
+        if (!yaml.match(/^description:\s*.+/m)) errors.push("Missing 'description' in frontmatter.");
+        
+        const nameMatch = yaml.match(/^name:\s*(.+)/m);
+        if (nameMatch && nameMatch[1].trim() !== skillName) {
+            errors.push(`Frontmatter name '${nameMatch[1].trim()}' does not match directory name '${skillName}'.`);
+        }
+    }
+
+    // 2. Check required sections
+    REQUIRED_SECTIONS.forEach(section => {
+        if (!content.includes(section)) {
+            errors.push(`Missing required section: '${section}'.`);
+        }
+    });
+
+    if (errors.length > 0) {
+        console.error(`❌ Error(s) in skills/${skillName}/SKILL.md:`);
+        errors.forEach(err => console.error(`   - ${err}`));
+        hasErrors = true;
+    } else {
+        console.log(`✅ Valid: skills/${skillName}/SKILL.md`);
+    }
+}
+
+fs.readdirSync(SKILLS_DIR).forEach(skillName => {
+    const skillPath = path.join(SKILLS_DIR, skillName);
+    if (fs.statSync(skillPath).isDirectory()) {
+        validateSkill(skillPath, skillName);
+    }
+});
+
+if (hasErrors) {
+    process.exit(1);
+}


### PR DESCRIPTION
Adds a lightweight Node.js validation script and a GitHub Action to automatically check SKILL.md files on every Pull Request.

Motivation
As the repo scales, manually verifying that every skill follows docs/skill-anatomy.md is tedious and easy to miss during code review. This automates the structural checks.

What it checks
Valid YAML frontmatter exists.
name and description fields are present.
The name field matches the skill's directory name.
Required sections (## Overview, ## When to Use, ## Verification) are present.
How to test
Run node scripts/validate-skill-structure.js locally. It will exit with code 1 if any skill violates the rules, and code 0 if all pass.