### PR TITLE
docs: add Antigravity CLI setup and integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,25 @@ Copy any `SKILL.md` into `.cursor/rules/`, or reference the full `skills/` direc
 </details>
 
 <details>
+<summary><b>Antigravity CLI</b></summary>
+
+Install as a native plugin for automatic skill and subagent discovery. See [docs/antigravity-setup.md](docs/antigravity-setup.md).
+
+**Install from the repo:**
+
+```bash
+agy plugin install https://github.com/addyosmani/agent-skills.git
+```
+
+**Install from a local clone:**
+
+```bash
+agy plugin install ./agent-skills
+```
+
+</details>
+
+<details>
 <summary><b>Gemini CLI</b></summary>
 
 Install as native skills for auto-discovery, or add to `GEMINI.md` for persistent context. See [docs/gemini-cli-setup.md](docs/gemini-cli-setup.md).

--- a/docs/antigravity-setup.md
+++ b/docs/antigravity-setup.md
@@ -1,0 +1,83 @@
+# Using agent-skills with Antigravity CLI
+
+Antigravity CLI (`agy`) has native support for plugins, skills, and subagents. It can auto-discover and run skills on-demand, or import them globally or per-workspace.
+
+## Setup
+
+### Option 1: Install as a Plugin (Recommended)
+
+Antigravity CLI natively supports the plugin format defined in this repository.
+
+**Install from the remote repository:**
+
+```bash
+agy plugin install https://github.com/addyosmani/agent-skills.git
+```
+
+**Install from a local clone:**
+
+```bash
+git clone https://github.com/addyosmani/agent-skills.git
+agy plugin install ./agent-skills
+```
+
+Once installed, you can list the active plugins to verify:
+
+```bash
+agy plugin list
+```
+
+### Option 2: Import from Gemini CLI
+
+If you are migrating from Gemini CLI and already had `agent-skills` installed there, you can import it directly:
+
+```bash
+agy plugin import gemini
+```
+
+This will automatically migrate configuration, skills, and extensions from your old `~/.gemini/` path to your new `~/.gemini/antigravity-cli/` environment.
+
+---
+
+## How It Works
+
+### 1. On-Demand Skill Activation
+Antigravity CLI automatically discovers the `SKILL.md` files located in the `skills/` directory of the installed plugin. Using the trigger descriptions in each skill's frontmatter, the agent will dynamically activate the appropriate workflow when it detects matching developer intent.
+
+For example, when you ask the agent to:
+- **Design a new system** &rarr; It will suggest/activate `spec-driven-development`.
+- **Implement a feature** &rarr; It will activate `incremental-implementation` and `test-driven-development`.
+- **Fix a bug** &rarr; It will activate `debugging-and-error-recovery`.
+
+### 2. Specialized Agent Personas
+The plugin registers reusable subagent definitions from the `agents/` directory:
+- `code-reviewer.md`
+- `security-auditor.md`
+- `test-engineer.md`
+
+You can invoke these personas directly within your session or when delegating tasks using subagents.
+
+---
+
+## Configuration & Customization
+
+### Project-Specific Enforcements (`AGENTS.md`)
+To enforce strict skill compliance (e.g. requiring a spec or plan before writing code), copy or link `AGENTS.md` into the root of your workspace. Antigravity CLI reads this file to align the agent's behavior and planning phase with your team's conventions.
+
+### Sandbox Mode
+If you want to run skills or scripts with limited terminal permissions (for safety when running third-party validation tests), launch the CLI with:
+
+```bash
+agy --sandbox
+```
+
+---
+
+## Usage Tips
+
+1. **Keep plugins up-to-date:** You can update the CLI or check for newer plugin versions using:
+   ```bash
+   agy update
+   ```
+2. **Review before execution:** When agents execute complex refactoring tasks using these skills, use `Ctrl+r` to enter the **Artifact Review** screen to review, edit, or approve code before it is committed.
+3. **Control permissions:** You can use the `--dangerously-skip-permissions` flag only in trusted local projects where you want to bypass manual tool approval prompts.


### PR DESCRIPTION
Introduces a detailed guide on using agent-skills with the Antigravity CLI (agy), highlighting native plugin installation, migrations from Gemini CLI, on-demand skill activation, personas, and configuration settings. Also updates README.md to link to the new setup documentation.
