### PR TITLE
docs: add optional references, examples, and resources directories to skill anatomy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ docs/         → Setup guides for different tools
 - YAML frontmatter with `name` and `description` fields
 - Description starts with what the skill does (third person), followed by trigger conditions ("Use when...")
 - Every skill has: Overview, When to Use, Process, Common Rationalizations, Red Flags, Verification
-- References are in `references/`, not inside skill directories
+- Shared references are in the root `references/` directory; the emerging convention for self-contained, distributable skills keeps a skill's own references inside `skills/<name>/references/`
 - Supporting files only created when content exceeds 100 lines
 
 ## Contributing

--- a/docs/skill-anatomy.md
+++ b/docs/skill-anatomy.md
@@ -154,7 +154,7 @@ When a skill ships runnable helpers under `scripts/`, each script follows these 
 - Skill files: `SKILL.md` (always uppercase)
 - Supporting files: `lowercase-hyphen-separated.md`
 - Shared references: stored in the root `references/` directory, not inside skill directories (see [Shared References](#shared-references) for why).
-- Skill-specific references: the emerging convention for self-contained, distributable skills is a `references/` directory inside the skill directory, so the skill carries its own supporting docs.
+- Skill-specific references: a single supporting doc can stay as a loose file in the skill directory (the `Supporting files` entry above); when several related docs travel with the skill, the emerging convention for self-contained, distributable skills is to group them in a `references/` directory inside the skill directory, so the skill carries its own supporting docs.
 
 ## Cross-Skill References
 

--- a/docs/skill-anatomy.md
+++ b/docs/skill-anatomy.md
@@ -11,10 +11,11 @@ skills/
   skill-name/
     SKILL.md           # Required: The skill definition
     scripts/           # Optional: Runnable helpers used by the skill workflow
+    references/        # Optional: Skill-specific reference documentation
     supporting-file.md # Optional: Reference material loaded on demand
 ```
 
-`SKILL.md` is the only required file. Add `scripts/` only when the skill actually ships runnable helpers, and omit the directory entirely for markdown-only skills.
+`SKILL.md` is the only required file. Add `scripts/` or `references/` only when the skill actually needs them, and omit them entirely for simpler skills.
 
 ## SKILL.md Format
 
@@ -152,7 +153,8 @@ When a skill ships runnable helpers under `scripts/`, each script follows these 
 - Skill directories: `lowercase-hyphen-separated`
 - Skill files: `SKILL.md` (always uppercase)
 - Supporting files: `lowercase-hyphen-separated.md`
-- References: stored in `references/` at the project root, not inside skill directories (see [Shared References](#shared-references) for why)
+- Shared references: stored in the root `references/` directory, not inside skill directories (see [Shared References](#shared-references) for why).
+- Skill-specific references: the emerging convention for self-contained, distributable skills is a `references/` directory inside the skill directory, so the skill carries its own supporting docs.
 
 ## Cross-Skill References
 


### PR DESCRIPTION
This PR proposes updating the skill documentation to explicitly specify `references/`, `examples/`, and `resources/` as optional subdirectories inside a skill directory under `skills/`.

### Changes:
- **[docs/skill-anatomy.md](file:///Users/joanleon/projects/nucliweb/GitHub/addy-agent-skills/docs/skill-anatomy.md)**: Updated the directory layout structure and naming conventions section to include local skill-specific references/examples/resources directories.
- **[AGENTS.md](file:///Users/joanleon/projects/nucliweb/GitHub/addy-agent-skills/AGENTS.md)**: Standardized the new skill creation structure with optional reference directories.
- **[CLAUDE.md](file:///Users/joanleon/projects/nucliweb/GitHub/addy-agent-skills/CLAUDE.md)**: Clarified that shared references live in the root `/references` folder while skill-specific ones live in `skills/<name>/references/`.