### PR TITLE
Add handoff skill for session continuity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ The agent should automatically map user intent to skills:
 - Refactoring / simplification → `code-simplification`
 - API or interface design → `api-and-interface-design`
 - UI work → `frontend-ui-engineering`
+- Running low on context / ending a session / passing work to another agent → `handoff`
 
 ### Lifecycle Mapping (Implicit Commands)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ docs/         → Setup guides for different tools
 **Verify:** browser-testing-with-devtools, debugging-and-error-recovery
 **Review:** code-review-and-quality, code-simplification, security-and-hardening, performance-optimization
 **Ship:** git-workflow-and-versioning, ci-cd-and-automation, deprecation-and-migration, documentation-and-adrs, observability-and-instrumentation, shipping-and-launch
+**Cross-cutting:** handoff (compact a session into a resume-ready doc for the next agent)
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ Skills are plain Markdown - they work with any agent that accepts system prompts
 
 ---
 
-## All 24 Skills
+## All 25 Skills
 
-The commands above are entry points. The pack includes 24 skills total — 23 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
+The commands above are entry points. The pack includes 25 skills total — 24 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
 
 ### Meta - Discover which skill applies
 
@@ -151,6 +151,7 @@ The commands above are entry points. The pack includes 24 skills total — 23 li
 | [incremental-implementation](skills/incremental-implementation/SKILL.md) | Thin vertical slices - implement, test, verify, commit. Feature flags, safe defaults, rollback-friendly changes | Any change touching more than one file |
 | [test-driven-development](skills/test-driven-development/SKILL.md) | Red-Green-Refactor, test pyramid (80/15/5), test sizes, DAMP over DRY, Beyonce Rule, browser testing | Implementing logic, fixing bugs, or changing behavior |
 | [context-engineering](skills/context-engineering/SKILL.md) | Feed agents the right information at the right time - rules files, context packing, MCP integrations | Starting a session, switching tasks, or when output quality drops |
+| [handoff](skills/handoff/SKILL.md) | Compact the session into a resume-ready handoff doc - current state, decisions, rejected approaches, next steps, suggested skills | Running low on context, ending a session, or passing work to another agent |
 | [source-driven-development](skills/source-driven-development/SKILL.md) | Ground every framework decision in official documentation - verify, cite sources, flag what's unverified | You want authoritative, source-cited code for any framework or library |
 | [doubt-driven-development](skills/doubt-driven-development/SKILL.md) | Adversarial fresh-context review of every non-trivial decision in-flight - CLAIM → EXTRACT → DOUBT → RECONCILE → STOP, with optional user-authorized cross-model escalation | Stakes are high (production, security, irreversible), working in unfamiliar code, or a confident output is cheaper to verify now than to debug later |
 | [frontend-ui-engineering](skills/frontend-ui-engineering/SKILL.md) | Component architecture, design systems, state management, responsive design, WCAG 2.1 AA accessibility | Building or modifying user-facing interfaces |
@@ -245,13 +246,14 @@ Every skill follows a consistent anatomy:
 
 ```
 agent-skills/
-├── skills/                            # 24 skills (23 lifecycle + 1 meta)
+├── skills/                            # 25 skills (24 lifecycle + 1 meta)
 │   ├── interview-me/                  #   Define
 │   ├── idea-refine/                   #   Define
 │   ├── spec-driven-development/       #   Define
 │   ├── planning-and-task-breakdown/   #   Plan
 │   ├── incremental-implementation/    #   Build
 │   ├── context-engineering/           #   Build
+│   ├── handoff/                       #   Any (session continuity)
 │   ├── source-driven-development/     #   Build
 │   ├── doubt-driven-development/      #   Build
 │   ├── frontend-ui-engineering/       #   Build

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: handoff
+description: Compacts the current conversation into a handoff document so another agent (or a future session) can resume the work without re-deriving context. Use when the session is running low on context, you are about to /clear or /compact, the task spans multiple sessions, or you are passing work to a different agent or person.
+---
+
+# Handoff
+
+> Inspired by Matt Pocock's [`handoff` skill](https://github.com/mattpocock/.agents). Adapted here as a model-agnostic, process-driven skill aligned with the agent-skills anatomy.
+
+## Overview
+
+A handoff document captures the *state of the work*, not a transcript of the conversation. The next agent starts cold — it has no memory of what was tried, what was decided, or what is half-finished. A good handoff lets it resume in one read instead of re-deriving context from scratch (or worse, repeating work and undoing decisions).
+
+The discipline is selective compaction: write down what only lives in this conversation, and reference everything that already lives in a durable artifact. A handoff that restates the PRD, the plan, and the diff is noise; a handoff that says "here's where we are, here's what's left, here's the landmine" is signal.
+
+## When to Use
+
+- Context is running low and you are about to `/compact` or `/clear`
+- The task won't finish in this session and needs to continue later
+- You are passing work to a different agent, model, or teammate
+- A long debugging or exploration session uncovered state worth preserving (dead ends, working hypotheses, environment quirks)
+- Before a risky operation, so a fresh session can pick up if this one is interrupted
+
+**When NOT to use:**
+
+- The task is complete and verified — write a commit message or PR description instead, not a handoff
+- Everything needed is already in durable artifacts (spec, plan, ADR, issue, commits) — point to them; don't duplicate
+- The next step is trivial and self-evident from the code — a handoff doc adds overhead without value
+
+## The Handoff Process
+
+### Step 1: Choose the Destination
+
+Write the document to the operating system's temporary directory, **not** the current workspace — a handoff is scratch state, not a tracked artifact, and committing it pollutes the repo.
+
+```
+- macOS / Linux:  $TMPDIR or /tmp/handoff-<short-task-name>.md
+- Windows:        %TEMP%\handoff-<short-task-name>.md
+```
+
+Tell the user the exact path so they can pass it to the next session.
+
+### Step 2: Capture Only What Lives in This Conversation
+
+Reference durable artifacts by path or URL — do not restate their contents:
+
+| Already captured in… | Reference it, don't copy it |
+|---|---|
+| PRD / spec | Link the file or issue |
+| Plan / task breakdown | Link the plan; note which task is in progress |
+| ADRs | Link the decision record |
+| Commits / diffs | Give the SHA or branch name |
+| Open issues / PRs | Give the URL |
+
+What belongs in the handoff is the context that exists *only* in the conversation: the current intent, what's in flight, what was ruled out and why, and the next concrete action.
+
+### Step 3: Write the Document
+
+Use this structure. Keep it tight — every line must earn its place.
+
+```markdown
+# Handoff: <task name>
+
+## Goal
+One or two sentences: what we are ultimately trying to achieve.
+
+## Current State
+Where things stand right now. What works, what's half-done, what's untouched.
+
+## What's Been Done
+- Decisions made (and the reasoning, if non-obvious)
+- Approaches tried and rejected — with WHY, so the next agent doesn't retry them
+
+## Next Steps
+1. The immediate next concrete action
+2. Then the following one
+Ordered, specific, actionable.
+
+## Landmines & Context
+- Environment quirks, flaky steps, non-obvious constraints
+- "Don't touch X — it breaks Y"
+- Anything that would cost the next agent an hour to rediscover
+
+## References
+- spec: path/or/url
+- plan: path/or/url
+- branch / commit: <name or SHA>
+- related issues/PRs: url
+
+## Suggested Skills
+Which agent-skills the next session should invoke and when,
+e.g. "resume with `incremental-implementation`; run `test-driven-development` before the auth slice."
+```
+
+### Step 4: Redact Sensitive Information
+
+Before saving, scrub anything that should not be written to disk in plaintext:
+
+- API keys, tokens, passwords, connection strings
+- Personally identifiable information (PII)
+- Internal hostnames or secrets surfaced during debugging
+
+Replace with a placeholder and a note on where to obtain the real value (`<DB_PASSWORD — see 1Password "staging-db">`).
+
+### Step 5: Tailor to the Next Session's Focus
+
+If the user said what the next session is for, bias the document toward it. A handoff aimed at "finish the migration" leads with migration state and next steps; one aimed at "review what we built" leads with decisions and rationale. Don't write a generic dump when you know the destination.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I'll just paste the whole conversation" | A transcript forces the next agent to re-derive state. Compact to decisions, current state, and next steps — that's the entire point. |
+| "Let me restate the plan and spec to be safe" | Duplicated content goes stale the moment the source changes. Reference artifacts by path; only capture what isn't already written down. |
+| "I'll save it in the repo so it's easy to find" | Handoffs are scratch state. Committing them pollutes history and risks leaking secrets. Use the OS temp dir. |
+| "The next agent can figure out what I tried" | It can't — rejected approaches live only in this conversation. Omitting them means the next session repeats your dead ends. |
+| "Redaction is overkill for a temp file" | Temp files get shared, pasted, and synced. Scrub secrets and PII regardless of destination. |
+| "It's obvious what to do next" | It's obvious to *you*, holding full context. Write the next concrete action explicitly — the cold-start reader has none of it. |
+
+## Red Flags
+
+- The handoff is as long as the conversation — you transcribed instead of compacting
+- It restates the spec, plan, or diff that already exists elsewhere
+- It was written into the workspace/repo instead of the temp directory
+- Secrets, tokens, or PII appear in plaintext
+- "Next steps" are vague ("continue the work") instead of a specific next action
+- Rejected approaches are missing, so the next agent will retry them
+- No references section — the next agent can't find the spec, branch, or issues
+
+## Verification
+
+Before handing off, confirm:
+
+- [ ] Document saved to the OS temp directory, not the workspace
+- [ ] Exact file path reported to the user
+- [ ] Durable artifacts (spec, plan, ADR, commits, issues) are referenced, not duplicated
+- [ ] Decisions and rejected approaches are captured with their reasoning
+- [ ] Next steps are ordered, specific, and actionable
+- [ ] Landmines and non-obvious constraints are documented
+- [ ] A "Suggested Skills" section tells the next session which skills to invoke
+- [ ] All secrets and PII are redacted with pointers to the real source
+- [ ] The document is tailored to the next session's stated focus (if one was given)

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -38,7 +38,8 @@ Task arrives
     ├── Deprecating/migrating? ────────→ deprecation-and-migration
     ├── Writing docs/ADRs? ───────────→ documentation-and-adrs
     ├── Adding logs/metrics/alerts? ───→ observability-and-instrumentation
-    └── Deploying/launching? ─────────→ shipping-and-launch
+    ├── Deploying/launching? ─────────→ shipping-and-launch
+    └── Low on context / ending session / passing work on? → handoff
 ```
 
 ## Core Operating Behaviors
@@ -160,6 +161,8 @@ For a complete feature, the typical skill sequence is:
 
 Not every task needs every skill. A bug fix might only need: `debugging-and-error-recovery` → `test-driven-development` → `code-review-and-quality`.
 
+When a session runs out of context before the work is done, use `handoff` at any point to compact the current state into a document the next session can resume from.
+
 ## Quick Reference
 
 | Phase | Skill | One-Line Summary |
@@ -187,3 +190,4 @@ Not every task needs every skill. A bug fix might only need: `debugging-and-erro
 | Ship | documentation-and-adrs | Document the why, not just the what |
 | Ship | observability-and-instrumentation | Structured logs, RED metrics, traces, symptom-based alerts |
 | Ship | shipping-and-launch | Pre-launch checklist, monitoring, rollback plan |
+| Any | handoff | Compact the session into a resume-ready doc for the next agent |


### PR DESCRIPTION
## What

Adds a new cross-cutting **`handoff`** skill that compacts the current conversation into a resume-ready document, so another agent or a future session can continue the work without re-deriving context.

This fills a genuine gap in the pack: there is currently no skill for preserving work state across sessions / `compact` / agent handoffs. It complements `context-engineering` (which loads context *in*) by handling the *out* direction.

## Why a skill, not prose

It follows the standard anatomy from `docs/skill-anatomy.md`:

- **Overview / When to Use** — including explicit "When NOT to use" (task complete → write a commit/PR instead; everything already in durable artifacts → reference them)
- **Process** — choose an OS temp-dir destination (not the workspace), capture only conversation-local state, reference durable artifacts instead of duplicating them, redact secrets/PII, tailor to the next session's focus
- **Common Rationalizations / Red Flags** — anti-patterns like transcribing instead of compacting, committing the doc into the repo, omitting rejected approaches
- **Verification** — evidence checklist

Adapted from Matt Pocock's `handoff` skill, reworked into a model-agnostic, process-driven form (attribution noted in the skill).

## Integration

- `skills/handoff/SKILL.md` (new)
- `using-agent-skills`: discovery flowchart branch, lifecycle note, quick-reference row
- `README.md`: skill count 24 → 25, skill table row, project tree
- `CLAUDE.md`: cross-cutting phase entry
- `AGENTS.md`: intent → skill mapping

## Verification

Per `CONTRIBUTING.md`, this PR touches `skills/using-agent-skills/SKILL.md` (embedded by the session-start hook), so the hook regression test was run:

```
$ bash hooks/session-start-test.sh
session-start JSON payload OK
```

Frontmatter validated: `name` matches the directory, `description` is what-then-"Use when" and is 320 chars (< 1024).

🤖 Generated with [Claude Code](https://claude.com/claude-code)