### PR TITLE
Add loop engineering skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ Skills are plain Markdown - they work with any agent that accepts system prompts
 
 ---
 
-## All 24 Skills
+## All 25 Skills
 
-The commands above are entry points. The pack includes 24 skills total — 23 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
+The commands above are entry points. The pack includes 25 skills total — 24 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
 
 ### Meta - Discover which skill applies
 
@@ -172,6 +172,7 @@ The commands above are entry points. The pack includes 24 skills total — 23 li
 | Skill | What It Does | Use When |
 |-------|-------------|----------|
 | [planning-and-task-breakdown](skills/planning-and-task-breakdown/SKILL.md) | Decompose specs into small, verifiable tasks with acceptance criteria and dependency ordering | You have a spec and need implementable units |
+| [loop-engineering](skills/loop-engineering/SKILL.md) | Design bounded inspect-act-verify loops with durable state, budgets, stop rules, rollback criteria, and handoff artifacts | Ambiguous or recurring agent work needs repeated passes without drift |
 
 ### Build - Write the code
 
@@ -275,11 +276,12 @@ Every skill follows a consistent anatomy:
 
 ```
 agent-skills/
-├── skills/                            # 24 skills (23 lifecycle + 1 meta)
+├── skills/                            # 25 skills (24 lifecycle + 1 meta)
 │   ├── interview-me/                  #   Define
 │   ├── idea-refine/                   #   Define
 │   ├── spec-driven-development/       #   Define
 │   ├── planning-and-task-breakdown/   #   Plan
+│   ├── loop-engineering/              #   Plan
 │   ├── incremental-implementation/    #   Build
 │   ├── context-engineering/           #   Build
 │   ├── source-driven-development/     #   Build

--- a/skills/loop-engineering/SKILL.md
+++ b/skills/loop-engineering/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: loop-engineering
+description: Designs bounded agent loops for ambiguous or recurring engineering work. Use when a task needs repeated inspect-act-verify passes, durable state, stop rules, rollback criteria, human gates, or handoff artifacts instead of a one-shot prompt.
+---
+
+# Loop Engineering
+
+## Overview
+
+Loop engineering turns an open-ended agent task into a controlled system: inspect current state, take one bounded action, verify with evidence, then decide whether to continue, stop, roll back, or ask a human. Use it to prevent long-running agents from drifting, over-editing, or claiming success without proof.
+
+## When to Use
+
+- The user asks for broad work such as "improve this repo", "keep fixing until it works", "monitor this PR", or "make this production ready".
+- The task may require more than one pass, but each pass should remain small and reviewable.
+- The work needs durable state, a run log, explicit budgets, or handoff to another agent.
+- A recurring workflow should run on a schedule, webhook, issue, PR, or release event.
+- Verification matters more than speed.
+
+Do not use this skill for a narrow one-step edit with a clear test and no recurrence. In that case, use the relevant build, test, or review skill directly.
+
+## Process
+
+### 1. Write the Loop Contract First
+
+Before changing anything, write a compact contract:
+
+```yaml
+goal: user-visible outcome
+trigger: manual | schedule | webhook | issue | pr | release
+state:
+  source: files, issues, PRs, logs, database, or external system to inspect
+  memory: where progress and decisions will be recorded
+loop:
+  inspect: evidence to collect before each pass
+  act: smallest allowed action for one pass
+  verify: command, check, screenshot, metric, or review gate
+  decide: continue | stop | rollback | ask
+budgets:
+  max_passes: 1-5 unless the user approved more
+  max_changes: files, directories, APIs, or systems allowed to change
+  max_cost: tokens, runtime, money, or external calls
+human_gates:
+  - decisions that require approval
+stop_rules:
+  - success condition
+  - ambiguity condition
+  - failure condition
+rollback:
+  - how to undo the last pass
+handoff:
+  - artifact to leave behind: run log, PR, issue, report, or checklist
+```
+
+If the user did not specify a field, choose the safest bounded default and label it as an assumption.
+
+### 2. Inspect Real State
+
+Collect current evidence before acting:
+
+- Read relevant files, issues, PRs, logs, test output, or runtime state.
+- Check the current branch and dirty state before file edits.
+- For UI work, inspect the running page or a screenshot.
+- Record evidence paths or links in the run log.
+
+Never start from a generic plan when the repository or system state is available.
+
+### 3. Take One Bounded Action
+
+Act only inside the contract:
+
+- Make the smallest change that can move the loop toward the goal.
+- Keep unrelated cleanup, dependency upgrades, and formatting out of the pass.
+- If the needed change exceeds the budget, stop and ask before continuing.
+- If a specialized workflow applies, follow the `spec-driven-development`, `incremental-implementation`, `test-driven-development`, `debugging-and-error-recovery`, or `code-review-and-quality` skill for that pass.
+
+### 4. Verify With Evidence
+
+Verification must be observable:
+
+- Prefer tests, builds, linters, runtime checks, screenshots, or reviewed diffs.
+- Match the verification scope to the action scope.
+- If no strong verifier exists, say "inspection-only" and record the residual risk.
+- Do not treat a green narrow check as proof of a broad goal.
+
+### 5. Decide Explicitly
+
+End every pass with one decision:
+
+- `continue`: the pass succeeded and another planned pass remains inside budget.
+- `stop`: the goal is met, or further work would be speculative.
+- `rollback`: the pass made the system worse or violated the contract.
+- `ask`: the next step depends on product intent, credentials, access, or risk tolerance.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "I can just keep improving until it feels done." | Loops need explicit stop rules; otherwise the agent drifts into unrelated work. |
+| "This is obvious, so I can skip the contract." | The contract is what keeps broad tasks bounded and reviewable. |
+| "The build passed, so the whole goal is complete." | A build is only proof for buildability. It may not prove behavior, UX, safety, or handoff quality. |
+| "I found another issue, so I should fix it now." | Capture adjacent issues separately unless they block the current loop goal. |
+| "Rollback is unnecessary because the change is small." | Small changes can still make state worse. Name the undo path before acting. |
+
+## Red Flags
+
+- The loop has no max pass count or cost budget.
+- The agent changes files outside the declared blast radius.
+- The run log contains conclusions without evidence.
+- Verification is described as "looks good" or "should work".
+- The agent keeps discovering new scope after the original success condition is satisfied.
+- Human approval is missing for irreversible, external, financial, security, or data-destructive actions.
+
+## Verification
+
+Before finishing, confirm:
+
+- [ ] The loop contract exists and names goal, trigger, state, action, verifier, stop rules, and rollback.
+- [ ] Every pass has evidence from current state, not memory or assumptions alone.
+- [ ] The action stayed within the declared budget and blast radius.
+- [ ] Verification evidence is named explicitly.
+- [ ] The final decision is one of `continue`, `stop`, `rollback`, or `ask`.
+- [ ] A handoff artifact exists so another agent or human can continue without reconstructing context.
+
+## Optional Tooling
+
+This skill works manually. If a user wants a local-first workbench for generating loop contracts, agent packets, verifier gates, and handoff reports, one public implementation is [Ariadne Loop](https://github.com/zhangzeyu99-web/ariadne-loop).


### PR DESCRIPTION
## Summary

Add a `loop-engineering` skill for designing bounded inspect-act-verify loops for ambiguous or recurring agent work.

The skill covers:

- loop contracts with trigger, state, budgets, stop rules, rollback, and handoff artifacts
- current-state inspection before action
- one bounded action per pass
- evidence-based verification and explicit continue/stop/rollback/ask decisions
- anti-rationalization checks for common agent drift patterns

It is intended to complement the existing planning, incremental implementation, TDD, debugging, and review skills when work needs repeated passes rather than a one-shot prompt.

## Validation

- `node scripts/validate-skills.js` -> 25 skills checked, 0 errors, 0 warnings
- `git diff --check` -> passed