### PR TITLE
feat: add skill-router meta-skill for dynamic context loading

### DIFF
--- a/skills/skill-router/SKILL.md
+++ b/skills/skill-router/SKILL.md
@@ -1,0 +1,39 @@
+### name: skill-routerdescription: Dynamically selects and loads the right skill based on user intent to save context window space. Use when starting a task and unsure which skill to load.
+
+### Skill Router
+
+### Overview
+Routes user intent to the correct skill. Prevents context bloat and decision paralysis by loading only the required skill, rather than all skills at once.
+
+### When to Use
+At the start of a new task or conversation.
+When unsure which specific skill applies.
+Do NOT use if the required skill is already in context.
+
+### Core Process
+Analyze Intent: Determine the engineering phase (Planning, Building, Testing, Debugging, etc.).
+Match Skill: Identify the correct skill using the routing logic or scripts/skill-index.json.
+Dynamic Load: Read only the selected SKILL.md into context.
+Execute: Follow the loaded skill's process.
+Re-evaluate: If the task changes phase, return to step 1.
+
+### Routing Logic
+Defining what to build -> spec-driven-development
+Planning tasks -> planning-and-task-breakdown
+Writing code -> incremental-implementation
+Writing tests -> test-driven-development
+Fixing bugs/errors -> debugging-and-error-recovery
+Ensuring edge-case safety -> agent-resilience-and-fuzzing
+Reviewing code -> code-review-and-quality
+Common Rationalizations
+Rationalization	Reality
+“I'll load all skills to be safe.”	Bloats context, wastes tokens, and degrades accuracy.
+“I can guess the skill without checking.”	Guessing leads to applying the wrong workflow.
+
+### Red Flags
+Agent executes a task without loading a specific skill.
+Agent loads more than 2 skills simultaneously for a single task.
+Verification
+ User intent was categorized correctly.
+ Only the necessary skill was loaded.
+ The loaded skill is being actively followed.

--- a/skills/skill-router/scripts/generate-index.sh
+++ b/skills/skill-router/scripts/generate-index.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Generates a JSON index of skills for the skill-router.
+# Run from the repository root.
+
+SKILLS_DIR="skills"
+INDEX_FILE="skills/skill-router/scripts/skill-index.json"
+
+echo "{" > "$INDEX_FILE"
+echo "  \"skills\": [" >> "$INDEX_FILE"
+
+first=true
+for dir in "$SKILLS_DIR"/*/; do
+    if [ -f "$dir/SKILL.md" ]; then
+        skill_name=$(basename "$dir")
+        description=$(grep -A1 '^description:' "$dir/SKILL.md" | tail -n1 | sed 's/^description: //' | sed 's/"/\\"/g')
+        
+        if [ "$first" = true ]; then
+            first=false
+        else
+            echo "," >> "$INDEX_FILE"
+        fi
+        
+        echo -n "    {\"name\": \"$skill_name\", \"description\": \"$description\"}" >> "$INDEX_FILE"
+    fi
+done
+
+echo "" >> "$INDEX_FILE"
+echo "  ]" >> "$INDEX_FILE"
+echo "}" >> "$INDEX_FILE"
+
+echo "✅ Skill index generated at $INDEX_FILE"


### PR DESCRIPTION
### Summary
Adds a skill-router skill and an index generator script to enable dynamic, intent-based skill loading, saving context window tokens and reducing agent confusion.

Closes #248

### Motivation

Loading all skills at once wastes context. This formalizes the "Context-Aware Loading" guideline from docs/getting-started.md into an actionable meta-skill that agents can follow to route their own behavior dynamically.

### What it includes

skills/skill-router/SKILL.md: The meta-skill workflow for dynamic dispatch.
skills/skill-router/scripts/generate-index.sh: A script to index all skills into a lightweight JSON file for quick reference.

### How to test

Run bash skills/skill-router/scripts/generate-index.sh from the repo root.
Verify that skills/skill-router/scripts/skill-index.json is created with all current skills listed correctly.