### PR TITLE
fix(scripts): report unexpected fs errors as structured validator output

### DIFF
--- a/scripts/validate-skills.js
+++ b/scripts/validate-skills.js
@@ -117,7 +117,13 @@ function validateSkill(dirName, knownSkills) {
     return { errors, warnings, exempt };
   }
 
-  const content = fs.readFileSync(skillPath, 'utf8');
+  let content;
+  try {
+    content = fs.readFileSync(skillPath, 'utf8');
+  } catch (err) {
+    errors.push(`Unreadable SKILL.md: ${err.message}`);
+    return { errors, warnings, exempt };
+  }
 
   // ── Frontmatter ──────────────────────────────────────────────────────────
   const fm = parseFrontmatter(content);
@@ -217,4 +223,11 @@ function main() {
   if (totalErrors > 0) process.exit(1);
 }
 
-main();
+// Surface unexpected failures (fs errors, bad symlinks, …) as a structured
+// one-line CI error instead of an uncaught stack trace.
+try {
+  main();
+} catch (err) {
+  console.error(`\nERROR: validate-skills failed unexpectedly: ${err.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Problem

`scripts/validate-skills.js` has no error boundary around `main()` (#252). Any unexpected filesystem error — an unreadable `SKILL.md`, a broken symlink, a permissions issue — aborts CI with a raw uncaught stack trace and no structured output, so the failure is not attributed to the offending skill.

## Fix

- `validateSkill()`: wrap the `SKILL.md` read; a read failure now reports as that skill's `ERROR: Unreadable SKILL.md: <reason>` line and validation continues for the remaining skills.
- Entry point: wrap `main()`; any other unexpected error prints a one-line `ERROR: validate-skills failed unexpectedly: <message>` and exits 1 instead of dumping an uncaught stack.

## Validation

- `node scripts/validate-skills.js` — 24 skills checked, 0 error(s), exit 0.
- Simulated unreadable skill (`skills/zz-crash-test/SKILL.md` created as a directory): run completes for all other skills, reports `✗ zz-crash-test → ERROR: Unreadable SKILL.md: EISDIR: illegal operation on a directory, read`, exits 1.

Fixes #252.