### PR TITLE
fix(gemini): point /ship personas at root agents dir

### DIFF
--- a/.gemini/commands/ship.toml
+++ b/.gemini/commands/ship.toml
@@ -7,7 +7,7 @@ Invoke the shipping-and-launch skill.
 
 ## Phase A — Parallel fan-out
 
-Spawn three subagents concurrently. Gemini CLI exposes each custom subagent in `.gemini/agents/` as a tool with the same name — so `code-reviewer.md` becomes a `code-reviewer` tool the main agent can call, and `@code-reviewer` works as an explicit invocation in the prompt. **Issue all three subagent tool calls in a single assistant turn so they execute in parallel** — sequential calls defeat the purpose of this command.
+Spawn three subagents concurrently. Gemini CLI exposes each custom subagent from this plugin's `agents/` directory as a tool with the same name — so `code-reviewer.md` becomes a `code-reviewer` tool the main agent can call, and `@code-reviewer` works as an explicit invocation in the prompt. **Issue all three subagent tool calls in a single assistant turn so they execute in parallel** — sequential calls defeat the purpose of this command.
 
 Dispatch each persona by tool name:
 
@@ -22,7 +22,7 @@ Constraints (from Gemini CLI's subagent model):
 - Do not let one persona delegate to another — keep the fan-out flat.
 - For richer multi-agent collaboration where teammates talk to each other instead of just reporting back, see `references/orchestration-patterns.md`.
 
-**Persona resolution.** If you've defined your own `code-reviewer`, `security-auditor`, or `test-engineer` in `.gemini/agents/` or `~/.gemini/agents/`, those take precedence over this plugin's versions — `/ship` picks up your customizations automatically. This is intentional: plugin subagents sit at the bottom of Gemini CLI's scope priority table, so user-level definitions win by design.
+**Persona resolution.** This plugin ships `code-reviewer`, `security-auditor`, and `test-engineer` under `agents/`. If you've defined your own versions in `.gemini/agents/` or `~/.gemini/agents/`, those take precedence over the plugin's versions — `/ship` picks up your customizations automatically. This is intentional: plugin subagents sit at the bottom of Gemini CLI's scope priority table, so user-level definitions win by design.
 
 ## Phase B — Merge in main context
 


### PR DESCRIPTION
## Summary
- point the Gemini `/ship` command at the repo's real `agents/` directory
- keep the valid `.gemini/agents/` and `~/.gemini/agents/` override paths in the persona-resolution note

## Verification
- confirmed issue `#259` is still live on fresh `upstream/main`
- `gh search prs --repo addyosmani/agent-skills --state open "ship.toml .gemini/agents" --json number,title,url`
- `git diff --check`

Closes #259
