### PR TITLE
docs: include webperf in setup command lists

### DIFF
--- a/docs/antigravity-setup.md
+++ b/docs/antigravity-setup.md
@@ -43,7 +43,7 @@ agy plugin list
 
 ## Slash Commands
 
-The plugin registers 7 custom slash commands that map to the development lifecycle:
+The plugin registers 8 custom slash commands: 7 lifecycle commands plus the `/webperf` specialist audit:
 
 | Command | What it does | Activated Skill |
 |---------|--------------|-----------------|
@@ -54,6 +54,7 @@ The plugin registers 7 custom slash commands that map to the development lifecyc
 | `/review` | Five-axis code review | `code-review-and-quality` |
 | `/code-simplify` | Reduce complexity without changing behavior | `code-simplification` |
 | `/ship` | Pre-launch checklist via parallel persona fan-out | `shipping-and-launch` |
+| `/webperf` | Audit browser-facing apps for Core Web Vitals and performance issues | `web-performance-auditor` |
 
 Each command automatically invokes the corresponding skill and guides the agent step-by-step.
 

--- a/docs/gemini-cli-setup.md
+++ b/docs/gemini-cli-setup.md
@@ -107,7 +107,7 @@ This is useful when you want to ensure a specific workflow is followed without w
 
 ## Slash Commands
 
-The repo ships 7 slash commands under `.gemini/commands/` that map to the development lifecycle. Gemini CLI auto-discovers them when you run from the project root.
+The repo ships 8 slash commands under `.gemini/commands/`: 7 lifecycle commands plus the `/webperf` specialist audit. Gemini CLI auto-discovers them when you run from the project root.
 
 | Command | What it does |
 |---------|--------------|
@@ -118,6 +118,7 @@ The repo ships 7 slash commands under `.gemini/commands/` that map to the develo
 | `/review` | Five-axis code review |
 | `/code-simplify` | Reduce complexity without changing behavior |
 | `/ship` | Pre-launch checklist via parallel persona fan-out |
+| `/webperf` | Audit browser-facing apps for Core Web Vitals and performance issues |
 
 Each command invokes the corresponding skill automatically — no manual skill loading required.
 


### PR DESCRIPTION
## Summary
- update Gemini CLI setup docs to list the existing /webperf command
- update Antigravity setup docs to list the existing /webperf command and activated persona
- clarify that the setup guides cover 7 lifecycle commands plus the specialist web performance audit

This complements #247, which updates the README command overview.

## Verification
- node scripts/validate-skills.js
- git diff --check
- checked command counts: .claude/commands, .gemini/commands, and commands each contain 8 files