### PR TITLE
fix: add path fallback for manual installation in hooks.json

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,8 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "SCRIPT=\"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"; [ -f \"$SCRIPT\" ] || SCRIPT=\"${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.sh\"; [ -f \"$SCRIPT\" ]
-  && bash \"$SCRIPT\" || true"
+            "command": "SCRIPT=\"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"; [ -f \"$SCRIPT\" ] || SCRIPT=\"${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.sh\"; [ -f \"$SCRIPT\" ]&& bash \"$SCRIPT\" || true"
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+            "command": "SCRIPT=\"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"; [ -f \"$SCRIPT\" ] || SCRIPT=\"${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.sh\"; [ -f \"$SCRIPT\" ]
+  && bash \"$SCRIPT\" || true"
           }
         ]
       }


### PR DESCRIPTION
    When users manually copy hooks to `.claude/` instead of installing via plugin or `--plugin-dir`, `${CLAUDE_PLUGIN_ROOT}` is not set and the SessionStart hook silently fails.
     This adds a fallback to `${CLAUDE_PROJECT_DIR}/.claude/hooks/` so the hook resolves in both plugin and manual install modes. If neither path exists, it silently succeeds.

Before:
 "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
Now:
"command": "SCRIPT="${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"; [ -f "$SCRIPT" ] || SCRIPT="${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.sh"; [ -f "$SCRIPT" ] && bash  "$SCRIPT" || true"

Resolution order:
1. `${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh` — plugin installation
2. `${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.sh` — manual copy
3.  If neither exists, silently succeed (don't block session start)