### PR TITLE
fix(claude-plugin): clear "commands/ ignored" lint without breaking Antigravity

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/addyosmani/agent-skills",
   "repository": "https://github.com/addyosmani/agent-skills",
   "license": "MIT",
-  "commands": "./.claude/commands",
+  "commands": ["./.claude/commands", "./commands"],
   "skills": "./skills",
   "agents": [
     "./agents/code-reviewer.md",


### PR DESCRIPTION
## Problem

On Claude Code v2.1.140+, this plugin surfaces a note in `/doctor`, `claude plugin list`, and the `/plugin` detail view (Errors tab):

> Default commands/ folder is ignored because the manifest sets "commands"

It's cosmetic — the plugin's `/spec`, `/plan`, `/build`, `/test`, `/review`, `/code-simplify`, `/ship`, and `/webperf` commands all load correctly — but it shows up under **Errors** and reads like something is broken.

## Cause

`.claude-plugin/plugin.json` sets `"commands": "./.claude/commands"` so Claude Code doesn't try to load the repo-root `commands/*.toml` files (Antigravity CLI's command set — a different TOML format and a different command list, e.g. `planning.toml`, `webperf.toml`).

Claude Code and Antigravity CLI **both** default to a repo-root `commands/` folder. Because the manifest points Claude *outside* that default while the folder still exists on disk, the v2.1.140 plugin linter flags it as "ignored."

## Fix

List both locations explicitly:

```diff
-  "commands": "./.claude/commands",
+  "commands": ["./.claude/commands", "./commands"],
```

Per the [plugins reference](https://docs.claude.com/en/docs/claude-code/plugins-reference), the array form keeps the default folder *and* the custom one, and the command loader only registers `.md` files — so Antigravity's `commands/*.toml` are silently ignored (zero extra Claude commands) and the lint clears.

## No behavior change

- **Claude Code** — loads the same `.md` commands from `.claude/commands/`; the note disappears.
- **Antigravity CLI** — unaffected; still reads root `commands/` + root `plugin.json` (it never reads `.claude-plugin/`).
- **Gemini / Cursor / others** — unaffected.

One-line manifest change; no commands added or removed for any tool.
