### PR TITLE
ci: standardize actions/checkout to v6 across all jobs

### DIFF
--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -10,7 +10,7 @@ jobs:
     name: Validate skill content
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## What

The `validate-skills` job in `.github/workflows/test-plugin-install.yml` pins `actions/checkout@v4`, while the other two jobs in the same workflow (`test-fresh-install` and `test-plugin-structure`) use `actions/checkout@v6`.

This PR aligns all three jobs on `@v6`.

## Why

Keeping action versions consistent within a single workflow avoids confusion, makes future bulk-bumps a single search-and-replace, and ensures every job runs on the same checkout behavior.

```diff
       validate-skills:
         steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
```

No functional change to what the workflow does.