### PR TITLE
docs: add missing /code-simplify row to getting-started command table

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -112,6 +112,7 @@ The `.claude/commands/` directory contains slash commands for Claude Code:
 | `/build auto` | planning-and-task-breakdown → incremental-implementation + test-driven-development (whole plan, one approval) |
 | `/test` | test-driven-development |
 | `/review` | code-review-and-quality |
+| `/code-simplify` | code-simplification |
 | `/ship` | shipping-and-launch |
 | `/webperf` | web-performance-auditor (specialist agent, web apps only) |
 


### PR DESCRIPTION
## What

The slash-command reference table in `docs/getting-started.md` is missing a row for `/code-simplify`.

## Why

The table maps each slash command to the skill(s) it invokes. It currently lists `/spec`, `/plan`, `/build`, `/build auto`, `/test`, `/review`, `/ship`, and `/webperf` — but omits `/code-simplify`, even though:

- `/code-simplify` is a documented core command in the README's Commands table
- it ships command files for every platform (`.claude/commands/code-simplify.md`, `.gemini/commands/code-simplify.toml`, `commands/code-simplify.toml`)
- the table already includes the more specialized `/webperf`, so omitting a core lifecycle command is clearly an oversight

This adds the missing row, placed between `/review` and `/ship` to match the README's command ordering:

```diff
 | `/review` | code-review-and-quality |
+| `/code-simplify` | code-simplification |
 | `/ship` | shipping-and-launch |
```

Docs-only change.