### PR TITLE
fix(antigravity): read AGENTS.md (not CLAUDE.md) in code-simplify command

### DIFF
--- a/commands/code-simplify.toml
+++ b/commands/code-simplify.toml
@@ -5,7 +5,7 @@ Invoke the code-simplification skill.
 
 Simplify recently changed code (or the specified scope) while preserving exact behavior:
 
-1. Read CLAUDE.md or AGENTS.md and study project conventions
+1. Read AGENTS.md and study project conventions
 2. Identify the target code — recent changes unless a broader scope is specified
 3. Understand the code's purpose, callers, edge cases, and test coverage before touching it
 4. Scan for simplification opportunities:


### PR DESCRIPTION
## What

In `commands/code-simplify.toml` (the Antigravity command), change step 1 from "Read CLAUDE.md or AGENTS.md" to "Read AGENTS.md".

## Why

Each platform's command set tells the agent to read that platform's own conventions file:

- `.claude/commands/code-simplify.md` → `Read CLAUDE.md and study project conventions`
- `.gemini/commands/code-simplify.toml` → `Read GEMINI.md and study project conventions`
- `commands/code-simplify.toml` (Antigravity) → `Read CLAUDE.md or AGENTS.md ...` ← inconsistent

Per the project's own docs, the Antigravity CLI reads `AGENTS.md`:

> ### Project-Specific Enforcements (`AGENTS.md`)
> ... Antigravity CLI reads this file to align the agent's behavior and planning phase with your team's conventions.
> — `docs/antigravity-setup.md`

The `CLAUDE.md` reference looks like a leftover from copying the Claude command variant. This is the only place in `commands/` that references `CLAUDE.md`; aligning it makes the Antigravity command point at the file the Antigravity CLI actually reads.

```diff
-1. Read CLAUDE.md or AGENTS.md and study project conventions
+1. Read AGENTS.md and study project conventions
```

## How to verify

```bash
grep -rn 'study project conventions' .claude/commands .gemini/commands commands
# .claude → CLAUDE.md, .gemini → GEMINI.md, antigravity → AGENTS.md (after this PR)
grep -n 'Antigravity CLI reads' docs/antigravity-setup.md   # confirms AGENTS.md
```