### PR TITLE
docs: list orchestration-patterns.md in the Reference Checklists table

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Quick-reference material that skills pull in when needed:
 | [security-checklist.md](references/security-checklist.md) | Pre-commit checks, auth, input validation, headers, CORS, OWASP Top 10 |
 | [performance-checklist.md](references/performance-checklist.md) | Core Web Vitals targets, frontend/backend checklists, measurement commands |
 | [accessibility-checklist.md](references/accessibility-checklist.md) | Keyboard nav, screen readers, visual design, ARIA, testing tools |
+| [orchestration-patterns.md](references/orchestration-patterns.md) | Endorsed multi-persona orchestration patterns, anti-patterns, and the "personas don't invoke personas" rule |
 
 ---
 


### PR DESCRIPTION
## What

Add the missing `orchestration-patterns.md` row to the **Reference Checklists** table in the README.

## Why

The `references/` directory ships **five** files, but the table listed only four:

```
references/
├── testing-patterns.md          ✅ listed
├── security-checklist.md        ✅ listed
├── performance-checklist.md     ✅ listed
├── accessibility-checklist.md   ✅ listed
└── orchestration-patterns.md    ❌ missing from the table
```

`orchestration-patterns.md` is a real, actively-referenced doc — `AGENTS.md` points to it as "the full pattern catalog" and the agents docs link to it too. It was simply never added to this table. This adds it for parity with the other four entries (one-line, docs-only change).