### PR TITLE
docs: fix step range in debugging skill (Steps 4-10 → 4-6)

### DIFF
--- a/skills/debugging-and-error-recovery/SKILL.md
+++ b/skills/debugging-and-error-recovery/SKILL.md
@@ -31,7 +31,7 @@ When anything unexpected happens:
 6. RESUME only after verification passes
 ```
 
-**Don't push past a failing test or broken build to work on the next feature.** Errors compound. A bug in Step 3 that goes unfixed makes Steps 4-10 wrong.
+**Don't push past a failing test or broken build to work on the next feature.** Errors compound. A bug in Step 3 that goes unfixed makes Steps 4-6 wrong.
 
 ## The Triage Checklist
 


### PR DESCRIPTION
The Stop-the-Line Rule and Triage Checklist each have exactly 6 steps, but the text referenced "Steps 4-10" — steps that don't exist.

`A bug in Step 3 that goes unfixed makes Steps 4-10 wrong.` → `... makes Steps 4-6 wrong.`