### PR TITLE
Harden opt-in lifecycle hooks (SSRF, cache poisoning, symlink overwrite, data loss)

### DIFF
--- a/hooks/sdd-cache-post.sh
+++ b/hooks/sdd-cache-post.sh
@@ -63,6 +63,30 @@ if [ -z "$CONTENT" ]; then
 fi
 dbg "extracted content bytes=${#CONTENT}"
 
+# Reject non-https URLs and internal/metadata hosts before any curl runs.
+# Mirror of the pre hook's guard. Conservative: only public https hosts pass.
+url_is_safe() {
+  local u="$1" host
+  case "$u" in
+    https://*) ;;
+    *) return 1 ;;
+  esac
+  host="${u#https://}"
+  host="${host%%/*}"; host="${host%%\?*}"; host="${host%%#*}"
+  host="${host##*@}"; host="${host%%:*}"
+  host=$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]')
+  case "$host" in
+    localhost|localhost.*|*.localhost) return 1 ;;
+    127.*|0.*|10.*|169.254.*|192.168.*) return 1 ;;
+    172.1[6-9].*|172.2[0-9].*|172.3[0-1].*) return 1 ;;
+    100.6[4-9].*|100.[7-9][0-9].*|100.1[0-1][0-9].*|100.12[0-7].*) return 1 ;;
+    \[*) return 1 ;;
+    metadata|metadata.*|*.internal|*.local) return 1 ;;
+    "") return 1 ;;
+  esac
+  return 0
+}
+
 # Must match the pre hook: sha256(URL), first 32 hex chars.
 hash_key() {
   if command -v shasum >/dev/null 2>&1; then
@@ -72,14 +96,24 @@ hash_key() {
   fi
 }
 
+# SSRF guard: do not issue the validator HEAD request to non-public hosts.
+if ! url_is_safe "$URL"; then
+  dbg "url failed safety check (scheme/host), not caching"
+  exit 0
+fi
+
 CACHE_DIR="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
-mkdir -p "$CACHE_DIR"
+# Restrictive perms: cache may hold fetched response bodies. Dir 0700, and
+# files written below inherit 0600 via the umask set here.
+( umask 077; mkdir -p "$CACHE_DIR" )
+chmod 700 "$CACHE_DIR" 2>/dev/null || true
+umask 077
 CACHE_FILE="$CACHE_DIR/$(hash_key "$URL").json"
 
-# Capture validators from the origin. Follow redirects so they match the
-# URL the agent actually talked to. Strip CR so awk's paragraph mode
-# recognises blank separators between response blocks on a redirect chain.
-HEAD_OUT=$(curl -sI -L --max-time 5 "$URL" 2>/dev/null | tr -d '\r' || true)
+# Capture validators from the origin. Redirects are NOT followed (a redirect
+# could point the validator request at an internal host). Strip CR so awk's
+# paragraph mode recognises blank separators between response blocks.
+HEAD_OUT=$(curl -sI --proto '=https' --max-redirs 0 --max-time 5 "$URL" 2>/dev/null | tr -d '\r' || true)
 
 # Take only the final response's headers (last paragraph) to avoid picking
 # up validators from intermediate 301/302 hops.

--- a/hooks/sdd-cache-pre.sh
+++ b/hooks/sdd-cache-pre.sh
@@ -47,11 +47,42 @@ hash_key() {
   fi
 }
 
+# Reject non-https URLs and internal/metadata hosts before any curl runs.
+# Returns 0 if safe to revalidate, 1 otherwise. Conservative: anything that
+# cannot be confidently classified as a public https host is rejected.
+url_is_safe() {
+  local u="$1" host
+  case "$u" in
+    https://*) ;;
+    *) return 1 ;;
+  esac
+  host="${u#https://}"
+  host="${host%%/*}"; host="${host%%\?*}"; host="${host%%#*}"
+  host="${host##*@}"; host="${host%%:*}"
+  host=$(printf '%s' "$host" | tr '[:upper:]' '[:lower:]')
+  case "$host" in
+    localhost|localhost.*|*.localhost) return 1 ;;
+    127.*|0.*|10.*|169.254.*|192.168.*) return 1 ;;
+    172.1[6-9].*|172.2[0-9].*|172.3[0-1].*) return 1 ;;
+    100.6[4-9].*|100.[7-9][0-9].*|100.1[0-1][0-9].*|100.12[0-7].*) return 1 ;;
+    \[*) return 1 ;;                       # bracketed IPv6 literal (e.g. [::1])
+    metadata|metadata.*|*.internal|*.local) return 1 ;;
+    "") return 1 ;;
+  esac
+  return 0
+}
+
 CACHE_DIR="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
 CACHE_FILE="$CACHE_DIR/$(hash_key "$URL").json"
 
 if [ ! -f "$CACHE_FILE" ]; then dbg "no cache file at $CACHE_FILE, exit"; exit 0; fi
 dbg "cache file exists: $CACHE_FILE"
+
+# SSRF guard: only ever issue the revalidation request to a public https host.
+if ! url_is_safe "$URL"; then
+  dbg "url failed safety check (scheme/host), bypass without revalidating"
+  exit 0
+fi
 
 FETCHED_AT=$(jq -r '.fetched_at // 0' "$CACHE_FILE" 2>/dev/null || echo 0)
 ORIGINAL_PROMPT=$(jq -r '.prompt // empty' "$CACHE_FILE" 2>/dev/null || true)
@@ -64,12 +95,25 @@ if [ -z "$ETAG" ] && [ -z "$LAST_MOD" ]; then
   exit 0
 fi
 
+# TTL cap: even a 304 must not resurrect a stale entry. Refuse to serve any
+# entry older than SDD_CACHE_MAX_AGE seconds (default 24h). Defends against
+# validator-confused origins and long-lived poisoned entries.
+MAX_AGE="${SDD_CACHE_MAX_AGE:-86400}"
+case "$MAX_AGE" in *[!0-9]*|"") MAX_AGE=86400 ;; esac
+AGE_NOW=$(date +%s 2>/dev/null || echo 0)
+case "$FETCHED_AT" in *[!0-9]*|"") FETCHED_AT=0 ;; esac
+if [ "$AGE_NOW" -gt 0 ] && [ "$FETCHED_AT" -gt 0 ] \
+   && [ $((AGE_NOW - FETCHED_AT)) -ge "$MAX_AGE" ]; then
+  dbg "entry age $((AGE_NOW - FETCHED_AT))s >= max-age ${MAX_AGE}s, refusing to serve"
+  exit 0
+fi
+
 HEADERS=()
 [ -n "$ETAG" ]     && HEADERS+=(-H "If-None-Match: $ETAG")
 [ -n "$LAST_MOD" ] && HEADERS+=(-H "If-Modified-Since: $LAST_MOD")
 
 STATUS=$(curl -sI -o /dev/null -w "%{http_code}" \
-  --max-time 5 -L \
+  --max-time 5 --proto '=https' --max-redirs 0 \
   "${HEADERS[@]}" \
   "$URL" 2>/dev/null || echo "000")
 dbg "revalidation HEAD status=$STATUS"

--- a/hooks/simplify-ignore.sh
+++ b/hooks/simplify-ignore.sh
@@ -40,7 +40,31 @@ hash_cmd() {
   elif command -v sha1sum >/dev/null 2>&1; then sha1sum
   else printf '%s\n' "error: missing shasum or sha1sum" >&2; exit 1; fi
 }
-file_id() { printf '%s' "$1" | hash_cmd | cut -c1-16; }
+# Normalize a path to a canonical form before hashing so the same physical
+# file gets one identity regardless of spelling (C:\x vs /c/x, slashes, case
+# of the drive letter). Graceful fallback chain; never aborts under set -e.
+normalize_path() {
+  local p="$1" n=""
+  if command -v cygpath >/dev/null 2>&1; then
+    n=$(cygpath -u "$p" 2>/dev/null) || n=""
+  fi
+  if [ -z "$n" ] && command -v realpath >/dev/null 2>&1; then
+    n=$(realpath -m "$p" 2>/dev/null) || n=""
+  fi
+  [ -z "$n" ] && n="$p"
+  n="${n//\\//}"                          # backslashes -> forward slashes
+  # Lowercase a leading "C:" drive letter -> "/c" (portable, no GNU sed \L).
+  case "$n" in
+    [A-Za-z]:*)
+      local drive rest
+      drive=$(printf '%s' "${n%%:*}" | tr '[:upper:]' '[:lower:]')
+      rest="${n#*:}"
+      n="/${drive}${rest}"
+      ;;
+  esac
+  printf '%s' "$n"
+}
+file_id() { printf '%s' "$(normalize_path "$1")" | hash_cmd | cut -c1-16; }
 block_hash() { printf '%s' "$1" | hash_cmd | cut -c1-8; }
 # Escape glob metacharacters so ${var/pattern/repl} treats pattern as literal.
 # Needed for Bash 3.2 (macOS) where quotes don't suppress globbing in PE patterns.
@@ -132,10 +156,12 @@ ${line}"
     printf '%s\n' "$buf" >> "$dest"
   fi
 
-  # Preserve trailing newline status of source
+  # Preserve trailing newline status of source. Source has no trailing
+  # newline -> strip the single trailing newline from dest. No perl dependency:
+  # read dest and re-emit without a trailing \n.
   if [ -s "$dest" ] && [ -s "$src" ] && [ -n "$(tail -c 1 "$src")" ]; then
-    perl -pe 'chomp if eof' "$dest" > "${dest}.nnl" && \
-      cat "${dest}.nnl" > "$dest" && rm -f "${dest}.nnl"
+    nnl=$(cat "$dest"; printf x); nnl="${nnl%x}"; nnl="${nnl%$'\n'}"
+    printf '%s' "$nnl" > "$dest"
   fi
 
   [ $count -gt 0 ] && return 0 || return 1
@@ -151,7 +177,12 @@ if [ -z "$TOOL_NAME" ]; then
     [ -f "$pathfile" ] || { rm -f "$bak"; continue; }
     orig=$(cat "$pathfile")
     if [ -f "$orig" ]; then
-      cat "$bak" > "$orig"
+      # TOCTOU/symlink guard: only write back to a regular, non-symlink file.
+      if [ -L "$orig" ]; then
+        printf 'Warning: restore target %s is a symlink; skipping write-back\n' "$orig" >&2
+      else
+        cat "$bak" > "$orig"
+      fi
       rm -f "$bak" "$pathfile" "$CACHE/${fid}".block.* "$CACHE/${fid}".reason.* "$CACHE/${fid}".prefix.* "$CACHE/${fid}".suffix.*
       rmdir "$CACHE/${fid}.lock" 2>/dev/null
     else
@@ -176,6 +207,9 @@ fi
 # ── PreToolUse Read: filter in-place ──────────────────────────────────────────
 if [ "$TOOL_NAME" = "Read" ]; then
   [ -f "$FILE_PATH" ] || exit 0
+  # Refuse to operate on symlinks: a symlinked target could redirect our
+  # in-place rewrite/backup/restore at a file outside the intended path.
+  [ -L "$FILE_PATH" ] && exit 0
   case "$(basename "$FILE_PATH")" in simplify-ignore*|SIMPLIFY-IGNORE*) exit 0 ;; esac
 
   mkdir -p "$CACHE"
@@ -206,8 +240,19 @@ if [ "$TOOL_NAME" = "Read" ]; then
   FILTERED="$CACHE/${ID}.$$.tmp"
   rm -f "$FILTERED"
   if filter_file "$FILE_PATH" "$FILTERED" "$ID"; then
+    # Recheck the target is still a regular non-symlink (TOCTOU since entry).
+    if [ -L "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+      printf 'Warning: %s is a symlink or not a regular file; skipping in-place filter\n' "$FILE_PATH" >&2
+      rm -f "$FILTERED" "$CACHE/${ID}.bak" "$CACHE/${ID}.path"
+      rmdir "$CACHE/${ID}.lock" 2>/dev/null
+      exit 0
+    fi
+    # Arm restore-on-failure: an abort during the write must not leave the
+    # user's file half-placeholdered with the backup intact but unused.
+    trap 'cat "$CACHE/${ID}.bak" > "$FILE_PATH" 2>/dev/null; rm -f "$FILTERED"; rmdir "$CACHE/${ID}.lock" 2>/dev/null; exit 1' EXIT
     cat "$FILTERED" > "$FILE_PATH"
     rm -f "$FILTERED"
+    trap - EXIT
   else
     rm -f "$FILTERED" "$CACHE/${ID}.bak" "$CACHE/${ID}.path"
     rmdir "$CACHE/${ID}.lock" 2>/dev/null
@@ -264,10 +309,11 @@ if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
     ;; esac
     printf '%s\n' "$line" >> "$EXPANDED"
   done < "$FILE_PATH"
-  # Preserve trailing newline status
+  # Preserve trailing newline status. No perl dependency: strip the single
+  # trailing newline from EXPANDED when the source lacked one.
   if [ -s "$EXPANDED" ] && [ -s "$FILE_PATH" ] && [ -n "$(tail -c 1 "$FILE_PATH")" ]; then
-    perl -pe 'chomp if eof' "$EXPANDED" > "${EXPANDED}.nnl" && \
-      cat "${EXPANDED}.nnl" > "$EXPANDED" && rm -f "${EXPANDED}.nnl"
+    nnl=$(cat "$EXPANDED"; printf x); nnl="${nnl%x}"; nnl="${nnl%$'\n'}"
+    printf '%s' "$nnl" > "$EXPANDED"
   fi
   # Warn if model deleted a protected block entirely
   for bf in "$CACHE/${ID}".block.*; do
@@ -283,6 +329,18 @@ if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
       fi
     fi
   done
+  # Symlink/TOCTOU guard: refuse to write through a symlinked target.
+  if [ -L "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+    printf 'Warning: %s is a symlink or not a regular file; skipping expand write-back\n' "$FILE_PATH" >&2
+    rm -f "$EXPANDED"
+    exit 0
+  fi
+  # Arm a restore-on-failure guard: from here until placeholders are written,
+  # any unexpected exit must leave the user's file recoverable. Restore the
+  # expanded (real, just-unhidden) content rather than a half-placeholdered file.
+  _guard="$CACHE/${ID}.$$.guard"
+  cp "$EXPANDED" "$_guard" 2>/dev/null || cp "$FILE_PATH" "$_guard"
+  trap 'cat "$_guard" > "$FILE_PATH" 2>/dev/null; rm -f "$_guard" "$EXPANDED"; rmdir "$CACHE/${ID}.lock" 2>/dev/null; exit 1' EXIT
   # Preserve inode and permissions
   cat "$EXPANDED" > "$FILE_PATH"
   rm -f "$EXPANDED"
@@ -294,9 +352,16 @@ if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
   FILTERED="$CACHE/${ID}.$$.tmp"
   rm -f "$FILTERED"
   if filter_file "$FILE_PATH" "$FILTERED" "$ID"; then
-    cat "$FILTERED" > "$FILE_PATH"
+    if [ -L "$FILE_PATH" ]; then
+      printf 'Warning: %s became a symlink; skipping re-filter write-back\n' "$FILE_PATH" >&2
+    else
+      cat "$FILTERED" > "$FILE_PATH"
+    fi
     rm -f "$FILTERED"
   fi
+  # Success: disarm guard. Backup already holds the real expanded content.
+  trap - EXIT
+  rm -f "$_guard"
 
   exit 0
 fi


### PR DESCRIPTION
## What

Hardens the three **opt-in** lifecycle hooks (`sdd-cache-pre.sh`, `sdd-cache-post.sh`, `simplify-ignore.sh`) against security and data-integrity issues surfaced during a review. These hooks are not enabled by `hooks/hooks.json` (which only wires `session-start.sh`), so this affects users who manually enable the WebFetch cache or simplify-ignore per the docs. `session-start.sh` is unchanged (reviewed clean).

## Why / findings addressed

| Severity | Issue | Fix |
|----------|-------|-----|
| Critical | **SSRF** — `curl -L "$URL"` on an unvalidated, redirect-following URL fires automatically on every WebFetch; a 302 can reach `169.254.169.254`, `localhost`, RFC1918 | `url_is_safe()` allowlist + drop `-L` (`--proto =https --max-redirs 0`) |
| High | **Cache poisoning** — no TTL; any `304` re-serves the cached body forever as "unchanged" | TTL cap via existing `fetched_at` (`SDD_CACHE_MAX_AGE`, default 24h) |
| High | **World-readable / tamperable cache** — default perms on fetched bodies | cache dir `0700`, files `0600` via `umask 077` |
| High | **Symlink / arbitrary-file overwrite** — `cat > "$target"` on untrusted `file_path` follows symlinks; session-long TOCTOU | reject symlinks at entry + re-verify regular-file target before every write-back |
| Critical (integrity) | **Data loss** — non-atomic in-place rewrite under `set -e` can leave a half-placeholdered file after the backup was consumed | `trap`-guarded restore-from-backup around the rewrite |
| — | **Undeclared `perl` dependency** — abort point on minimal Git Bash | replaced with pure-shell trailing-newline trim (dependency removed) |
| — | **Path-identity collisions** — `C:\x` vs `/c/x` hash to different IDs → stale restore | normalize path before hashing `file_id` |

## How it's verified

- `bash -n` clean on all four hooks.
- Existing suites pass: **21/21** `simplify-ignore-test.sh`, `session-start-test.sh` OK.
- Added smoke test for the new SSRF guard: **15/15** (covers https-only, loopback, RFC1918, link-local/metadata, CGNAT, IPv6 literal, `user@host` userinfo trick, and correctly-allowed public hosts incl. just-outside-range `172.15.0.1`).

## Notes / open design decisions (flagged, not silently chosen)

- **DNS rebinding** is *not* fully closed — a public hostname resolving to a private IP still passes without resolved-IP pinning (`curl --resolve`), which adds platform variance on Git Bash. Left as a follow-up; relies on WebFetch's own egress controls for that case.
- **`--max-redirs 0`** trades cache hit-rate on redirecting origins for SSRF safety. A middle ground (`--max-redirs N --proto-redir =https` + re-validating `%{url_effective}`) is possible if hit-rate matters.
- **TTL default (24h)** is a guess; tune to how stale a cached "reading" may be.
- **`cat >` kept (not `mv`)** to preserve inode/permissions as the original intended; atomicity-of-outcome is provided by the `trap` instead.
- **`file_id` change** orphans any pre-existing cache entries from the old scheme (one-time; Stop already tolerates orphans).

Happy to split this into per-file PRs or adjust any of the above. Related findings filed as an issue for tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
