### PR TITLE
docs(contributing): guidelines to curb duplicate skill proposals

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,19 @@ Thanks for your interest in contributing! This project is a collection of produc
 
 ## Adding a New Skill
 
+### Before proposing a new skill
+
+This pack already covers most of the development lifecycle, and many proposals overlap with an existing skill or another open PR. Before opening one, do these checks so reviewers aren't triaging duplicates:
+
+1. **Search the catalog.** Browse [the skill list in the README](README.md#all-24-skills) and skim `skills/` for an existing skill that covers your idea, whole or in part.
+2. **Check open PRs.** Run `gh pr list --state open` (or browse the PRs tab) and look for proposals on the same topic. Clusters of near-duplicate skills already exist; don't add to them.
+3. **Read the anatomy.** Confirm your idea fits the format in [docs/skill-anatomy.md](docs/skill-anatomy.md), an actionable workflow with verification, not vague advice.
+4. **Justify the gap in your PR description.** State explicitly why this isn't covered by an existing skill or open PR. If it overlaps, propose extending the existing skill instead of adding a new one.
+
+If your idea is a refinement of an existing skill, prefer a focused edit to that skill over a new directory.
+
+### Creating the skill
+
 1. Create a directory under `skills/` with a kebab-case name
 2. Add a `SKILL.md` following the format in [docs/skill-anatomy.md](docs/skill-anatomy.md)
 3. Include YAML frontmatter with `name` and `description` fields

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for your interest in contributing! This project is a collection of produc
 
 This pack already covers most of the development lifecycle, and many proposals overlap with an existing skill or another open PR. Before opening one, do these checks so reviewers aren't triaging duplicates:
 
-1. **Search the catalog.** Browse [the skill list in the README](README.md#all-24-skills) and skim `skills/` for an existing skill that covers your idea, whole or in part.
+1. **Search the catalog.** Browse [the skill list in the README](README.md) and skim `skills/` for an existing skill that covers your idea, whole or in part.
 2. **Check open PRs.** Run `gh pr list --state open` (or browse the PRs tab) and look for proposals on the same topic. Clusters of near-duplicate skills already exist; don't add to them.
 3. **Read the anatomy.** Confirm your idea fits the format in [docs/skill-anatomy.md](docs/skill-anatomy.md), an actionable workflow with verification, not vague advice.
 4. **Justify the gap in your PR description.** State explicitly why this isn't covered by an existing skill or open PR. If it overlaps, propose extending the existing skill instead of adding a new one.


### PR DESCRIPTION
## What

Adds a "Before proposing a new skill" subsection to `CONTRIBUTING.md` with a short checklist contributors run before opening a new-skill PR.

## Why

The goal is to define clear rules/guidelines that curb duplication. The open-PR backlog has accumulated clusters of near-duplicate skill proposals (several overlapping LLM/agent skills, meta-skills, and browser skills proposed independently). Most of these overlap with an existing skill or with each other, which makes triage slower.

The checklist asks contributors to:

1. Search the existing catalog (README + `skills/`).
2. Check open PRs for overlapping proposals (`gh pr list --state open`).
3. Confirm the idea fits the skill anatomy (actionable workflow, not vague advice).
4. Justify in the PR description why it isn't already covered; if it overlaps, extend the existing skill instead.

It also splits the section into "Before proposing a new skill" and "Creating the skill" so the decision step comes before the how-to.

## Scope

Documentation only. No skills, commands, or hooks touched.