### PR TITLE
fix(code-review): align severity labels with the defined taxonomy

### DIFF
--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -201,7 +201,7 @@ This catches issues that a single model might miss — different models have dif
 ```
 Review this code change for correctness, security, and adherence to
 our project conventions. The spec says [X]. The change should [Y].
-Flag any issues as Critical, Important, or Suggestion.
+Flag any issues as Critical, Required, Optional, or Nit.
 ```
 
 ## Dead Code Hygiene
@@ -341,7 +341,7 @@ Part of code review is dependency review:
 After review is complete:
 
 - [ ] All Critical issues are resolved
-- [ ] All Important issues are resolved or explicitly deferred with justification
+- [ ] All required (non-Nit) issues are resolved or explicitly deferred with justification
 - [ ] Tests pass
 - [ ] Build succeeds
 - [ ] The verification story is documented (what changed, how it was verified)

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -341,7 +341,7 @@ Part of code review is dependency review:
 After review is complete:
 
 - [ ] All Critical issues are resolved
-- [ ] All required (non-Nit) issues are resolved or explicitly deferred with justification
+- [ ] All Required (no-prefix) changes are resolved or explicitly deferred with justification
 - [ ] Tests pass
 - [ ] Build succeeds
 - [ ] The verification story is documented (what changed, how it was verified)


### PR DESCRIPTION
## What

Aligns the severity labels used in `skills/code-review-and-quality/SKILL.md` with the taxonomy the skill itself defines.

## Why

"Step 4: Categorize Findings" defines the severity vocabulary: `Critical`, `Required` (no prefix), `Optional`/`Consider`, `Nit`, and `FYI`. Two other places in the same skill used labels outside that set:

- The Multi-Model Review prompt example said "Flag any issues as Critical, **Important**, or **Suggestion**."
- The Verification checklist referenced "All **Important** issues are resolved".

`Important` and `Suggestion` are never defined, so an agent following the skill can't map them to a real severity. This change updates both spots to use only the defined labels.

## Changes

- Multi-Model Review prompt: `Critical, Important, or Suggestion` -> `Critical, Required, Optional, or Nit`
- Verification: `All Important issues` -> `All required (non-Nit) issues`

## Scope

Documentation only, 2 lines. `node scripts/validate-skills.js` passes (24 skills, 0 errors).