### PR TITLE
docs(spec): point Plan and Tasks phases to planning-and-task-breakdown

### DIFF
--- a/skills/spec-driven-development/SKILL.md
+++ b/skills/spec-driven-development/SKILL.md
@@ -138,7 +138,7 @@ With the validated spec, generate a technical implementation plan:
 4. Identify what can be built in parallel vs. what must be sequential
 5. Define verification checkpoints between phases
 
-> Follow `planning-and-task-breakdown` for the dependency-graph mapping and vertical-slicing mechanics behind these steps; it is the canonical source.
+> Follow `planning-and-task-breakdown` for the dependency-graph mapping and vertical-slicing mechanics behind these steps; it is the canonical source. The bullets above are a lightweight summary; if they ever diverge, `planning-and-task-breakdown` takes precedence.
 
 The plan should be reviewable: the human should be able to read it and say "yes, that's the right approach" or "no, change X."
 
@@ -152,7 +152,7 @@ Break the plan into discrete, implementable tasks:
 - Tasks are ordered by dependency, not by perceived importance
 - No task should require changing more than ~5 files
 
-This step mirrors `planning-and-task-breakdown`; use it for the full task-sizing and dependency-ordering mechanics. The template below is the lightweight inline form.
+> Follow `planning-and-task-breakdown` for the full task-sizing and dependency-ordering mechanics; it is the canonical source. The template below is a lightweight inline form; if they ever diverge, `planning-and-task-breakdown` takes precedence.
 
 **Task template:**
 ```markdown

--- a/skills/spec-driven-development/SKILL.md
+++ b/skills/spec-driven-development/SKILL.md
@@ -138,6 +138,8 @@ With the validated spec, generate a technical implementation plan:
 4. Identify what can be built in parallel vs. what must be sequential
 5. Define verification checkpoints between phases
 
+> Follow `planning-and-task-breakdown` for the dependency-graph mapping and vertical-slicing mechanics behind these steps; it is the canonical source.
+
 The plan should be reviewable: the human should be able to read it and say "yes, that's the right approach" or "no, change X."
 
 ### Phase 3: Tasks
@@ -149,6 +151,8 @@ Break the plan into discrete, implementable tasks:
 - Each task includes a verification step (test, build, manual check)
 - Tasks are ordered by dependency, not by perceived importance
 - No task should require changing more than ~5 files
+
+This step mirrors `planning-and-task-breakdown`; use it for the full task-sizing and dependency-ordering mechanics. The template below is the lightweight inline form.
 
 **Task template:**
 ```markdown


### PR DESCRIPTION
## What

Adds a one-line delegation pointer to the Plan and Tasks phases of `spec-driven-development`, naming `planning-and-task-breakdown` as the canonical source for the planning mechanics.

## Why

The Plan (Phase 2) and Tasks (Phase 3) phases restated planning mechanics, dependency-graph mapping, vertical slicing, task sizing, and ordering, that the dedicated `planning-and-task-breakdown` skill already owns. That risks drift between the two skills as one evolves. The Implement phase (Phase 4) already delegates to `incremental-implementation` and `test-driven-development`; this brings phases 2 and 3 in line with that pattern.

The change is deliberately light: it keeps the inline bullets and the short task template as a quick reference, and only adds a pointer to the authoritative skill. No content is removed.

## Changes

- Phase 2: pointer to `planning-and-task-breakdown` for dependency-graph and vertical-slicing mechanics.
- Phase 3: pointer to `planning-and-task-breakdown` for task-sizing and dependency-ordering mechanics.

## Scope

Documentation only, +4 lines, 0 deletions. `node scripts/validate-skills.js` passes (24 skills, 0 errors).