### PR TITLE
feat(code-review): add structural-depth lenses to the code-review skill

### DIFF
--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -110,7 +110,7 @@ Small, focused changes are easier to review, faster to merge, and safer to deplo
 ~1000 lines changed  → Too large. Split it.
 ```
 
-**Watch file size, not just diff size.** A small diff can still push a file past a healthy boundary — around 1000 total lines is a common smell. When a change materially grows an already-large file, ask whether to extract helpers, subcomponents, or modules *first*, before piling more on. Decompose, then add.
+**Watch file size, not just diff size.** A small diff can still push a file past a healthy boundary — around 1000 *total* lines in a single file (distinct from the ~1000 *changed*-lines threshold above) is a common inspection signal, not a hard cap. When a change materially grows an already-large file, ask whether to extract helpers, subcomponents, or modules *first*, before piling more on. Decompose, then add.
 
 **What counts as "one change":** A single self-contained modification that addresses one thing, includes related tests, and keeps the system functional after submission. One part of a feature — not the whole feature.
 

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -45,6 +45,8 @@ Can another engineer (or agent) understand this code without the author explaini
 - **Are abstractions earning their complexity?** (Don't generalize until the third use case)
 - Would comments help clarify non-obvious intent? (But don't comment obvious code.)
 - Are there dead code artifacts: no-op variables (`_unused`), backwards-compat shims, or `// removed` comments?
+- **Is a new conditional bolted onto an unrelated flow?** That's a design smell, not a nit — push the logic into its own helper, state, or policy instead of tangling an existing path.
+- **Do repeated conditionals on the same shape appear?** They signal a missing model or dispatcher. A "temporary" branch is usually permanent debt.
 
 ### 3. Architecture
 
@@ -55,6 +57,9 @@ Does the change fit the system's design?
 - Is there code duplication that should be shared?
 - Are dependencies flowing in the right direction (no circular dependencies)?
 - Is the abstraction level appropriate (not over-engineered, not too coupled)?
+- **Does this refactor reduce complexity or just relocate it?** Count the concepts a reader must hold to follow the change. If a "cleaner" version leaves that count unchanged, it isn't cleaner — prefer the restructuring that makes whole branches, modes, or layers disappear over one that re-centralizes the same logic. Prefer deleting an abstraction to polishing it.
+- **Is feature-specific logic leaking into a shared or general-purpose module?** Keep logic in its owning layer, reuse the existing canonical helper instead of a near-duplicate, and don't normalize architectural drift.
+- **Are type boundaries explicit?** Question gratuitous `any`/`unknown`/optional/casts and silent fallbacks that paper over an unclear invariant — making the boundary explicit often makes the surrounding control flow simpler.
 
 ### 4. Security
 
@@ -80,6 +85,21 @@ For detailed profiling and optimization, see `performance-optimization`. Does th
 - Any missing pagination on list endpoints?
 - Any large objects created in hot paths?
 
+## Structural Remedies
+
+When you flag a structural problem, propose the move — not just the problem. A review that only says "this is complex" leaves the author guessing. Reach for a named restructuring:
+
+- **Replace a chain of conditionals** with a typed model or an explicit dispatcher.
+- **Collapse duplicate branches** into a single clearer flow.
+- **Separate orchestration from business logic** so each reads on its own.
+- **Move feature-specific logic** out of a shared module into the package that owns the concept.
+- **Reuse the canonical helper** instead of a bespoke near-duplicate.
+- **Make a type boundary explicit** so downstream branching disappears.
+- **Delete a pass-through wrapper** that adds indirection without clarifying the API.
+- **Extract a helper, or split a large file** into focused modules.
+
+Prefer the remedy that removes moving pieces over one that spreads the same complexity around.
+
 ## Change Sizing
 
 Small, focused changes are easier to review, faster to merge, and safer to deploy. Target these sizes:
@@ -89,6 +109,8 @@ Small, focused changes are easier to review, faster to merge, and safer to deplo
 ~300 lines changed   → Acceptable if it's a single logical change.
 ~1000 lines changed  → Too large. Split it.
 ```
+
+**Watch file size, not just diff size.** A small diff can still push a file past a healthy boundary — around 1000 total lines is a common smell. When a change materially grows an already-large file, ask whether to extract helpers, subcomponents, or modules *first*, before piling more on. Decompose, then add.
 
 **What counts as "one change":** A single self-contained modification that addresses one thing, includes related tests, and keeps the system functional after submission. One part of a feature — not the whole feature.
 
@@ -165,6 +187,8 @@ Label every comment with its severity so the author knows what's required vs opt
 | **FYI** | Informational only | No action needed — context for future reference |
 
 This prevents authors from treating all feedback as mandatory and wasting time on optional suggestions.
+
+**Lead with what matters.** Order findings by leverage: correctness and security first, then structural regressions and missed simplifications, then everything else. Don't bury a real issue under cosmetic nits — a few high-conviction comments beat a long list. If you have one structural problem and ten nits, the structural problem *is* the review.
 
 ### Step 5: Verify the Verification
 
@@ -288,6 +312,8 @@ Part of code review is dependency review:
 - [ ] Follows existing patterns
 - [ ] No unnecessary coupling or dependencies
 - [ ] Appropriate abstraction level
+- [ ] Refactors reduce complexity rather than relocate it
+- [ ] No feature logic in shared modules; file stays within a healthy size
 
 ### Security
 - [ ] No secrets in code
@@ -324,6 +350,8 @@ Part of code review is dependency review:
 | "We'll clean it up later" | Later never comes. The review is the quality gate — use it. Require cleanup before merge, not after. |
 | "AI-generated code is probably fine" | AI code needs more scrutiny, not less. It's confident and plausible, even when wrong. |
 | "The tests pass, so it's good" | Tests are necessary but not sufficient. They don't catch architecture problems, security issues, or readability concerns. |
+| "The refactor makes it cleaner" | Relocating complexity isn't reducing it. If the reader still holds the same number of concepts, the structure didn't improve — look for the version where branches disappear. |
+| "It's only a small addition to this file" | Small diffs still push files past a healthy size and bolt branches onto unrelated flows. Judge the resulting structure, not the diff size. |
 
 ## Red Flags
 
@@ -335,6 +363,10 @@ Part of code review is dependency review:
 - No regression tests with bug fix PRs
 - Review comments without severity labels — makes it unclear what's required vs optional
 - Accepting "I'll fix it later" — it never happens
+- A refactor that moves code around without reducing the number of concepts a reader must hold
+- A change that grows an already-large file instead of decomposing it
+- New conditionals scattered into unrelated code paths (a missing abstraction)
+- A bespoke helper that duplicates an existing canonical one, or feature logic placed in a shared module
 
 ## Verification
 
@@ -345,3 +377,5 @@ After review is complete:
 - [ ] Tests pass
 - [ ] Build succeeds
 - [ ] The verification story is documented (what changed, how it was verified)
+
+**Presumptive blockers** — treat these as Required-by-default unless the author justifies them: a refactor that relocates complexity instead of reducing it; a change that pushes a file past the size boundary with no decomposition; feature logic added to a shared module; a near-duplicate of an existing canonical helper; a silent fallback that hides an unclear invariant. Surface the simpler design and propose it, but don't hold a genuine improvement hostage to a hypothetical rewrite — flag and suggest by default, and block only when the change actively makes the structure worse.

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -378,4 +378,4 @@ After review is complete:
 - [ ] Build succeeds
 - [ ] The verification story is documented (what changed, how it was verified)
 
-**Presumptive blockers** — treat these as Required-by-default unless the author justifies them: a refactor that relocates complexity instead of reducing it; a change that pushes a file past the size boundary with no decomposition; feature logic added to a shared module; a near-duplicate of an existing canonical helper; a silent fallback that hides an unclear invariant. Surface the simpler design and propose it, but don't hold a genuine improvement hostage to a hypothetical rewrite — flag and suggest by default, and block only when the change actively makes the structure worse.
+**Presumptive blockers:** surface and propose the simpler design for each of these; escalate to Required only when the change actively makes structure worse: a refactor that relocates complexity instead of reducing it; a change that pushes a file past the size boundary with no decomposition; feature logic added to a shared module; a near-duplicate of an existing canonical helper; a silent fallback that hides an unclear invariant.


### PR DESCRIPTION
## What this does

**tl;dr:** We already had a pretty strong code-review skill, but I noticed there were some interesting ideas in Cursor's [thermo-nuclear](https://raw.githubusercontent.com/cursor/plugins/refs/heads/main/cursor-team-kit/skills/thermo-nuclear-code-quality-review/SKILL.md) and wanted to study if there is anything we could learn from them without conflicting with how many lenses our approach takes. This PR explores that.

Strengthens the `code-review-and-quality` skill with **structural-maintainability depth**. Our five-axis review (correctness, readability, architecture, security, performance) is broad and process-complete, but it treats *structure* passively - it asks "could this be fewer lines?" and moves on. A great reviewer goes further: they hunt for the simpler design hiding in the diff and reject refactors that just shuffle complexity around.

This PR folds that depth into the **existing** axes, sizing, severity, and verification (not a separate mode), so the skill stays one coherent review rather than two.

## The ideas added

- **Reduce, don't relocate** (Architecture axis). Ask whether a refactor *deletes* complexity or merely *moves* it. Count the concepts a reader must hold; if a "cleaner" version leaves that count unchanged, it isn't cleaner. Prefer the restructuring where whole branches/modes/layers disappear.
- **Missing-abstraction signals** (Readability axis). A new conditional bolted onto an unrelated flow, or repeated conditionals on the same shape, are design smells - not nits. Push the logic into a helper/state/dispatcher.
- **Structural Remedies** (new section). When you flag a structural problem, **name the move, not just the problem**: typed dispatcher over condition chains, collapse duplicate branches, separate orchestration from logic, reuse the canonical helper, make a type boundary explicit, delete pass-through wrappers, split large files.
- **File-size gate** (Change Sizing). We already size the *diff*; this also watches *total file size* — a small diff can push a file past a healthy boundary (~1000 lines), which should trigger "decompose first."
- **Lead with what matters** (Step 4). A prioritization rule: order findings by leverage and don't bury a real issue under cosmetic nits. One structural problem plus ten nits — the structural problem *is* the review.
- **Type-boundary cleanliness** (Architecture axis). Question gratuitous `any`/`unknown`/optional/casts and silent fallbacks that paper over an invariant.
- **Presumptive blockers** (Verification). A short default-block list (relocated-not-reduced complexity, file pushed past the size boundary, feature logic in shared modules, near-duplicate of a canonical helper, invariant-hiding fallback).
- Matching **Common Rationalizations** (+2) and **Red Flags** (+4).

## Calibration

We keep our pragmatic approval philosophy. The new structural lens is **flag-and-suggest by default** — surface the simpler design and propose it, but don't hold a genuine improvement hostage to a hypothetical rewrite. Block only when the change actively makes structure worse. This keeps the skill demanding on structure without tipping into "rewrite-or-reject."

## Scope and safety

- Purely additive: 348 → 381 lines, no deletions.
- `node scripts/validate-skills.js` passes (24 skills, 0 errors).
- Frontmatter and all existing sections unchanged.
