### PR TITLE
docs: explain expected commands/ warning when installed as Claude Code plugin

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -112,6 +112,12 @@ The `.claude/commands/` directory contains slash commands for Claude Code:
 | `/review` | code-review-and-quality |
 | `/ship` | shipping-and-launch |
 
+> **Note:** When installed as a Claude Code plugin you may see a warning like
+> _"Default commands/ folder is ignored because the manifest sets 'commands'"_.
+> This is expected. The root `commands/` directory belongs to the Antigravity CLI
+> and is intentionally separate from `.claude/commands/`. All Claude Code slash
+> commands load correctly from `.claude/commands/`; the warning is cosmetic.
+
 ## Using References
 
 The `references/` directory contains supplementary checklists:


### PR DESCRIPTION
## Summary

- Fixes #298: Claude Code `/plugin` warns that root `commands/` (Antigravity) folder is ignored
- Adds a short Note callout under the "Using Commands" section in `docs/getting-started.md` explaining that the warning is cosmetic and expected

## Changes

- `docs/getting-started.md`: added a blockquote note explaining that the `"Default commands/ folder is ignored"` warning is expected when the plugin is installed in Claude Code, and that all Claude Code slash commands load correctly from `.claude/commands/`

## Testing

Docs-only change. Verified by re-reading the section before and after to confirm the note accurately describes the situation documented in #298 (the root `commands/` folder is intentionally for Antigravity CLI; `.claude/commands/` is the correct path for Claude Code; the warning is cosmetic).

Closes #298

🤖 Generated with [Claude Code](https://claude.ai/code)