### PR TITLE
fix(gemini): correct agent path in ship.toml from .gemini/agents/ to agents/

### DIFF
--- a/.gemini/commands/ship.toml
+++ b/.gemini/commands/ship.toml
@@ -7,7 +7,7 @@ Invoke the shipping-and-launch skill.
 
 ## Phase A — Parallel fan-out
 
-Spawn three subagents concurrently. Gemini CLI exposes each custom subagent in `.gemini/agents/` as a tool with the same name — so `code-reviewer.md` becomes a `code-reviewer` tool the main agent can call, and `@code-reviewer` works as an explicit invocation in the prompt. **Issue all three subagent tool calls in a single assistant turn so they execute in parallel** — sequential calls defeat the purpose of this command.
+Spawn three subagents concurrently. Gemini CLI exposes each custom subagent in `agents/` as a tool with the same name — so `code-reviewer.md` becomes a `code-reviewer` tool the main agent can call, and `@code-reviewer` works as an explicit invocation in the prompt. **Issue all three subagent tool calls in a single assistant turn so they execute in parallel** — sequential calls defeat the purpose of this command.
 
 Dispatch each persona by tool name:
 
@@ -22,7 +22,7 @@ Constraints (from Gemini CLI's subagent model):
 - Do not let one persona delegate to another — keep the fan-out flat.
 - For richer multi-agent collaboration where teammates talk to each other instead of just reporting back, see `references/orchestration-patterns.md`.
 
-**Persona resolution.** If you've defined your own `code-reviewer`, `security-auditor`, or `test-engineer` in `.gemini/agents/` or `~/.gemini/agents/`, those take precedence over this plugin's versions — `/ship` picks up your customizations automatically. This is intentional: plugin subagents sit at the bottom of Gemini CLI's scope priority table, so user-level definitions win by design.
+**Persona resolution.** If you've defined your own `code-reviewer`, `security-auditor`, or `test-engineer` in `agents/` (this plugin's agents, at the repo root) or `~/.gemini/agents/` (user-level), those take precedence over this plugin's versions — `/ship` picks up your customizations automatically. This is intentional: plugin subagents sit at the bottom of Gemini CLI's scope priority table, so user-level definitions win by design.
 
 ## Phase B — Merge in main context
 


### PR DESCRIPTION
## Summary

- Fixes #259: `.gemini/commands/ship.toml` references non-existent `.gemini/agents/` directory
- Updates two path references in `ship.toml` to point to `agents/` (the actual location of the agent definitions at the repo root)

## Changes

- `.gemini/commands/ship.toml` line 10: `.gemini/agents/` → `agents/`
- `.gemini/commands/ship.toml` line 25: `.gemini/agents/` → `agents/` (with a clarifying note that these are the plugin's agents at the repo root, distinct from user-level `~/.gemini/agents/`)

## Testing

Docs/config-only change. Verified by:
1. Confirming `agents/` exists at the repo root and contains `code-reviewer.md`, `security-auditor.md`, `test-engineer.md`
2. Confirming `.gemini/agents/` does not exist (checked via `git ls-tree`)
3. Reviewing the diff to ensure only the two incorrect path strings were changed and all surrounding text is preserved

Closes #259

🤖 Generated with [Claude Code](https://claude.ai/code)