### PR TITLE
fix: replace /mnt/skills/user/ paths with repo-relative paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ description: {One sentence describing when to use this skill. Include trigger ph
 ## Usage
 
 ```bash
-bash /mnt/skills/user/{skill-name}/scripts/{script}.sh [args]
+bash skills/{skill-name}/scripts/{script}.sh [args]
 ```
 
 **Arguments:**
@@ -159,7 +159,7 @@ Skills are loaded on-demand — only the skill name and description are loaded a
 - Write status messages to stderr: `echo "Message" >&2`
 - Write machine-readable output (JSON) to stdout
 - Include a cleanup trap for temp files
-- Reference the script path as `/mnt/skills/user/{skill-name}/scripts/{script}.sh`
+- Reference the script path as `skills/{skill-name}/scripts/{script}.sh`
 
 ### Creating the Zip Package
 

--- a/skills/idea-refine/SKILL.md
+++ b/skills/idea-refine/SKILL.md
@@ -19,7 +19,7 @@ This skill is primarily an interactive dialogue. Invoke it with an idea, and the
 
 ```bash
 # Optional: Initialize the ideas directory
-bash /mnt/skills/user/idea-refine/scripts/idea-refine.sh
+bash skills/idea-refine/scripts/idea-refine.sh
 ```
 
 **Trigger Phrases:**


### PR DESCRIPTION
## Summary

- Fixes #136: SKILL.md files reference non-existent scripts
- Replaces three `/mnt/skills/user/` absolute paths (an artefact of the Anthropic workbench) with correct repo-relative `skills/…` paths that work in any git clone

## Changes

- `skills/idea-refine/SKILL.md`: `/mnt/skills/user/idea-refine/scripts/idea-refine.sh` → `skills/idea-refine/scripts/idea-refine.sh` (the script exists at this path)
- `AGENTS.md` (Usage template): `/mnt/skills/user/{skill-name}/scripts/{script}.sh` → `skills/{skill-name}/scripts/{script}.sh`
- `AGENTS.md` (Script Requirements): same path pattern updated in prose

## Testing

Docs-only change. Verified by:
1. Confirming `skills/idea-refine/scripts/idea-refine.sh` exists in the repo
2. Searching the entire repo for remaining `/mnt/` references — none found after this change
3. Confirming `spec-driven-development/SKILL.md` (mentioned in the issue) no longer has the stale path in the current fork

Closes #136

🤖 Generated with [Claude Code](https://claude.ai/code)