### PR TITLE
docs(skills): add the eval→learn→improve feedback loop (TDD evals + observability step 8)

### DIFF
--- a/skills/observability-and-instrumentation/SKILL.md
+++ b/skills/observability-and-instrumentation/SKILL.md
@@ -163,6 +163,31 @@ Instrumentation is code; it can be wrong. Before calling the work done, trigger 
 - Follow one request across services in the tracing UI → no broken spans
 - Fire each new alert once (lower the threshold temporarily) → confirm it reaches the right channel and the runbook link works
 
+### 8. Feedback loops: learn from production runs
+
+Telemetry that's only read during an incident is a sunk cost. For LLM and agent features the highest-value use of it is the opposite direction: feeding what production reveals back into the system so the same failure doesn't recur. Steps 1–7 make each run *visible*; this step makes the system *improve across runs*. It's the operate-and-learn arc the forward lifecycle (spec → ship) leaves open.
+
+The structured failure logs and per-run traces you already emit are the raw material. Close the loop on a regular cadence, not just when paged:
+
+```
+   ┌─────────────────────────────────────────────────────────────┐
+   │                                                               │
+   ▼                                                               │
+ CAPTURE          TRIAGE            DISTILL              RE-EVAL    │
+ traces &    ──▶  cluster     ──▶   into durable   ──▶   confirm ──┘
+ failures         recurring        artifacts:            the score
+ (already         failure          • new eval cases      actually
+  logged)         modes            • prompt/tool fixes    rose, then
+                                   • few-shot / memory     ship
+```
+
+1. **Capture.** Sample real runs and route every failure (errors, low judge scores, user thumbs-down) into one reviewable place, keyed by `requestId` so the full trace is one click away. You built this in steps 3 and 5 — point it at a triage queue.
+2. **Triage.** Cluster failures by mode (wrong tool, hallucinated policy, format drift) rather than fixing one-offs. A mode that recurs is worth a durable fix; a true one-off usually isn't.
+3. **Distill into durable artifacts.** Each recurring mode becomes (a) a new **eval case** so it's caught automatically from now on — see the Evals section of `test-driven-development`; and (b) a fix to the prompt, tool, or a few-shot/memory example. A lesson that lives only in a postmortem doc decays; one that lives in an eval case is enforced.
+4. **Re-evaluate, then ship.** Run the eval set against the change and confirm the score actually rose before shipping. "The new model fixed it" is a hypothesis until the suite agrees. Then ship and watch the same telemetry — the loop repeats.
+
+This closes the loop on top of two adjacent concerns without duplicating them: per-run reliability (bounding, retries, resumable side effects) is loop *control*, not loop *learning*; and the eval mechanics themselves live with `test-driven-development`. This step is only the across-runs improvement arc that connects them.
+
 ## Common Rationalizations
 
 | Rationalization | Reality |
@@ -174,6 +199,8 @@ Instrumentation is code; it can be wrong. Before calling the work done, trigger 
 | "Alert on everything important, we'll tune later" | A noisy pager trains people to ignore it. The tuning never happens; the missed real page does. |
 | "User ID as a metric label makes debugging easier" | It also makes your metrics backend fall over. High-cardinality lookups belong in logs and traces. |
 | "Tracing is overkill for our two services" | Two services already means cross-service latency questions logs can't answer. Auto-instrumentation makes the cost trivial. |
+| "We'll review the failures eventually" | Without a standing loop, "eventually" never arrives and the same failure mode reships every week. Triage on a cadence, not on outrage. |
+| "We already log the errors, so we're covered" | Logging a failure makes it visible once. It's only learned from once it becomes an eval case and a fix. Visibility is step one, not the finish line. |
 
 ## Red Flags
 
@@ -186,6 +213,9 @@ Instrumentation is code; it can be wrong. Before calling the work done, trigger 
 - Alerts on causes (CPU, memory) paging humans while user-facing error rate is unmonitored
 - Secrets, tokens, or full request bodies appearing in logs
 - "It works on my machine" as the only evidence a production feature is healthy
+- A recurring production failure mode that has triggered no new eval case or fix
+- LLM/agent failures logged but never routed anywhere a human reviews them
+- "The new model/prompt is better" shipped with no before/after on the eval set
 
 ## Verification
 
@@ -199,5 +229,6 @@ After instrumenting a feature, confirm:
 - [ ] A single request can be followed end-to-end in the tracing UI without broken spans
 - [ ] Every new alert is symptom-based, has a runbook link, and was test-fired once
 - [ ] An induced failure in staging was located via telemetry alone, without reading the source
+- [ ] For LLM/agent features: failures are routed to a triage queue keyed by `requestId`, recurring modes become eval cases, and improvements are confirmed by re-eval before shipping
 
 For the at-a-glance version of this list, including the pre-launch instrumentation gate, see `references/observability-checklist.md`.

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-driven-development
-description: Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior. Use when you need to prove that code works, when a bug report arrives, or when you're about to modify existing functionality. Use when testing LLM-backed or other non-deterministic output, where evals replace exact assertions.
+description: Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior. Use when you need to prove that code works, when a bug report arrives, or when you're about to modify existing functionality.
 ---
 
 # Test-Driven Development

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-driven-development
-description: Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior. Use when you need to prove that code works, when a bug report arrives, or when you're about to modify existing functionality.
+description: Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior. Use when you need to prove that code works, when a bug report arrives, or when you're about to modify existing functionality. Use when testing LLM-backed or other non-deterministic output, where evals replace exact assertions.
 ---
 
 # Test-Driven Development
@@ -356,9 +356,30 @@ then verifies the test passes.
 
 This separation ensures the test is written without knowledge of the fix, making it more robust.
 
+## Evals: Testing Non-Deterministic (LLM-Backed) Behavior
+
+Deterministic tests assert on exact values. They can't pin down the free-form output of a prompt, model, or agent — the same input yields different text each run, so there's nothing stable to assert. The counterpart to a unit test here is an **eval**: a versioned set of representative inputs you re-grade on every prompt, model, or tool change, so a quality drop shows up in CI instead of in user reports. Use TDD for the deterministic code around the model; use evals for the part that returns natural language.
+
+Keep the eval set small and graded by the cheapest method that works:
+
+```ts
+// Structured output → assert directly (fast, exact)
+expect(out.toolCalls[0].name).toBe("issueRefund");
+
+// Open-ended text → grade against a rubric with an LLM judge
+const verdict = await judge({ rubric: "On topic? Invents no policy? yes/no + reason", input, output: out.text });
+expect(verdict.pass).toBe(true);
+```
+
+For agents, assert on the **trajectory** — which tool ran, with what arguments, whether the run recovered from an injected failure — not just the final text. The costly failures are wrong-tool and wrong-argument, and the final text often looks fine anyway.
+
+**Grow the suite from incidents.** A happy-path eval set gives false confidence; the inputs that reach users are the ones nobody wrote a case for. Every production failure becomes a new case, the same way a bug fix gets a reproduction test (the Prove-It Pattern, applied to model behavior). That turns the eval set into a ratchet that only tightens. To capture those production failures systematically and feed them back, see the **Feedback Loops** section of `observability-and-instrumentation`.
+
 ## See Also
 
 For JavaScript/TypeScript testing patterns illustrating these principles — Jest, React Testing Library, Supertest, Playwright — see `references/testing-patterns.md`. The principles transfer to any ecosystem; the syntax and tools there are JS/TS-specific.
+
+For closing the loop on LLM/agent failures found in production — turning them into new eval cases and shipping confirmed improvements — see the Feedback Loops section of `observability-and-instrumentation`.
 
 ## Common Rationalizations
 
@@ -371,6 +392,8 @@ For JavaScript/TypeScript testing patterns illustrating these principles — Jes
 | "The code is self-explanatory" | Tests ARE the specification. They document what the code should do, not what it does. |
 | "It's just a prototype" | Prototypes become production code. Tests from day one prevent the "test debt" crisis. |
 | "Let me run the tests again just to be extra sure" | After a clean test run, repeating the same command adds nothing unless the code has changed since. Run again after subsequent edits, not as reassurance. |
+| "The LLM output is too open-ended to test" | Rubric-based grading scores open-ended text against criteria instead of an exact string. Open-endedness is a reason to use evals, not to skip them. |
+| "I tried the prompt a few times and it looked fine" | By hand you check the cases you happen to think of, once. A versioned eval set checks all of them on every prompt, model, or tool change. |
 
 ## Red Flags
 
@@ -383,6 +406,8 @@ For JavaScript/TypeScript testing patterns illustrating these principles — Jes
 - Test names that don't describe the expected behavior
 - Skipping tests to make the suite pass
 - Running the same test command twice in a row without any intervening code change
+- A prompt, model, or tool change merged with no eval run to catch quality regressions
+- An LLM/agent feature whose only QA is "I ran it a few times by hand"
 
 ## Verification
 
@@ -394,5 +419,7 @@ After completing any implementation:
 - [ ] Test names describe the behavior being verified
 - [ ] No tests were skipped or disabled
 - [ ] Coverage hasn't decreased (if tracked)
+- [ ] LLM/agent behavior is covered by a versioned eval set, not by manual spot-checks
+- [ ] Each known production failure of that behavior has been added as an eval case
 
 **Note:** Run each test command after a change that could affect the result. After a clean run, don't repeat the same command unless the code has changed since — re-running on unchanged code adds no confidence.


### PR DESCRIPTION
## TL;DR

Two small, **purely additive** edits to existing skills that together add the one thing the pack is missing for LLM/agent work: the **eval → learn → improve** feedback loop. No new skill directory, no README/manifest/count changes, fully revert-safe. `node scripts/validate-skills.js` → **0 errors, 0 warnings**.

| File | What's added |
|---|---|
| `skills/test-driven-development/SKILL.md` | *Evals: Testing Non-Deterministic (LLM-Backed) Behavior* — golden set + rubric-judge grading, trajectory assertions, and growing the suite from production incidents |
| `skills/observability-and-instrumentation/SKILL.md` | *Step 8: Feedback loops — learn from production runs* — route failures to triage → distill recurring modes into eval cases + prompt/tool fixes → re-eval before shipping |

## The gap this fills

The pack's lifecycle runs **forward**: spec → plan → build → verify → review → ship. Once an LLM/agent feature is live, there's no documented **operate-and-learn** arc — no workflow for turning what production reveals back into durable improvements. That's the across-runs loop this PR adds, and it slots into the two skills that already own its two ends (verification and observability) rather than inventing a new scope.

## Why this is *not* a duplicate (per CONTRIBUTING)

CONTRIBUTING asks contributors to justify the gap and prefer **referencing over duplicating**. This PR is built to that rule:

| Adjacent work | What it owns | What this PR does instead |
|---|---|---|
| #286 `evaluating-llm-output` (proposed) | How to **build** an eval suite | Keeps eval mechanics lean and homes them in `test-driven-development`; **references**, doesn't re-teach |
| #285 `reliable-agent-loops` (proposed) | Single-run **loop control** (bounding, idempotent retries, resume) | Describes per-run reliability generically and leaves it to that domain |
| #253 `harness-engineering` (proposed) | Repo-local **guardrails/governance** for coding agents | This is about operating an LLM/agent **product** in production, framed in the observability skill |

The new content is only the **connective tissue** none of them own: capture → triage → distill → re-eval, across runs.

## Why this form (extensions, not a new skill)

CONTRIBUTING: *"If your idea is a refinement of an existing skill, prefer a focused edit to that skill over a new directory."* These are exactly that — additive sections that strengthen two existing skills, matching their structure, tone, and table format. Each follows the standard anatomy additions: a process section, rationalization rows, red flags, and verification checkboxes.

## Validation

- [x] `node scripts/validate-skills.js` → **PASSED (0 errors, 0 warnings)** — all 24 skills, required sections intact
- [x] Frontmatter valid; TDD description 332 chars (< 1024 limit)
- [x] Cross-references resolve to existing skills only (no dead refs)
- [x] Diff touches **only** the two `SKILL.md` files — no README, manifest, or count edits
