### PR TITLE
feat(scripts): enforce naming + description-trigger rules in skill validator

### DIFF
--- a/scripts/validate-skills.js
+++ b/scripts/validate-skills.js
@@ -8,7 +8,9 @@
  *   - SKILL.md exists in every skill directory
  *   - YAML frontmatter present with 'name' and 'description' fields
  *   - frontmatter 'name' matches the directory name
+ *   - directory name is lowercase-hyphen-separated (skill-anatomy.md: Naming Conventions)
  *   - description does not exceed 1024 characters
+ *   - description includes a 'when to use' trigger (skill-anatomy.md: Required)
  *   - required sections are present
  *
  * Checks (warnings, do not block CI):
@@ -27,6 +29,15 @@ const path = require('path');
 const SKILLS_DIR = path.resolve(__dirname, '..', 'skills');
 
 const MAX_DESCRIPTION_LENGTH = 1024;
+
+// A skill directory name must be lowercase-hyphen-separated
+// (docs/skill-anatomy.md → Naming Conventions).
+const KEBAB_CASE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+// A description must state WHEN to use the skill, not just what it does
+// (docs/skill-anatomy.md → Required). Accept the canonical "Use when …"
+// plus the equivalent "Use before/after/during …" phrasings in use today.
+const DESCRIPTION_TRIGGER = /\buse (this )?when\b|\buse (before|after|during)\b/i;
 
 // Sections every standard SKILL.md must contain.
 // Each entry is an array of acceptable heading strings — the first
@@ -138,13 +149,25 @@ function validateSkill(dirName, knownSkills) {
     errors.push(`Frontmatter name '${fm.name}' does not match directory name '${dirName}'`);
   }
 
+  if (!KEBAB_CASE.test(dirName)) {
+    errors.push(`Directory name '${dirName}' is not lowercase-hyphen-separated (skill-anatomy.md: Naming Conventions)`);
+  }
+
   if (!fm.description) {
     errors.push("Frontmatter missing required field: 'description'");
-  } else if (fm.description.length > MAX_DESCRIPTION_LENGTH) {
-    errors.push(
-      `Description is ${fm.description.length} chars — exceeds the ${MAX_DESCRIPTION_LENGTH}-char limit` +
-      ` (agents inject this into the system prompt)`
-    );
+  } else {
+    if (fm.description.length > MAX_DESCRIPTION_LENGTH) {
+      errors.push(
+        `Description is ${fm.description.length} chars — exceeds the ${MAX_DESCRIPTION_LENGTH}-char limit` +
+        ` (agents inject this into the system prompt)`
+      );
+    }
+    if (!DESCRIPTION_TRIGGER.test(fm.description)) {
+      errors.push(
+        `Description has no 'when to use' trigger — add a "Use when …" clause ` +
+        `(skill-anatomy.md: Required — the description must say both what the skill does and when to use it)`
+      );
+    }
   }
 
   // ── Exemption guard ──────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #233.

## What

The validator already exists (added in `Add CI skill validator`) and checks frontmatter, `name === dirName`, and required sections — so most of #233 already ships today. This PR closes the **remaining gap**: two rules `docs/skill-anatomy.md` marks as **Required** but the validator never enforced.

| Rule (skill-anatomy.md) | Before | Now |
|---|---|---|
| Directory names `lowercase-hyphen-separated` (Naming Conventions) | only `name === dirName` was checked, so `My_Skill/` passed | rejected |
| Description must say **when** to use the skill, not just what (Required vs Recommended) | unchecked | rejected if no `Use when …` trigger |

## Why this gap existed

The validator (Apr) predates the doc change (#167, May) that promoted "description includes *when to use*" to an explicit **Required** bullet. That was a docs-only PR and the validator was never updated to match — the two drifted. The naming-format check was simply never implemented.

## Non-breaking

All 24 existing skills pass (`node scripts/validate-skills.js` → `0 errors`). This is a pure guardrail for future contributions, not a change that flags current content.

```
24 skills checked — 0 error(s), 0 warning(s) — PASSED
```

The trigger regex accepts the canonical `Use when …` (23 skills) plus the `Use before/after/during …` phrasings already in use (1 skill).