### PR TITLE
test: add skill validation battery with node:test

### DIFF
--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -15,10 +15,28 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Validate all skills
         run: node scripts/validate-skills.js
+
+  test-skills:
+    name: Skill validation battery
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run skill test battery
+        run: npm test
+
+      - name: Report skill length metrics
+        if: always()
+        run: npm run metrics
 
   validate-commands:
     name: Validate command parity and description sync
@@ -29,7 +47,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Validate commands across all tool directories
         run: node scripts/validate-commands.js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "agent-skills",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Production-grade engineering skills for AI coding agents.",
+  "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "test": "node --test \"tests/**/*.test.js\"",
+    "validate:skills": "node scripts/validate-skills.js",
+    "validate:commands": "node scripts/validate-commands.js",
+    "validate": "npm run validate:skills && npm run validate:commands",
+    "metrics": "node scripts/skill-metrics.js"
+  }
+}

--- a/scripts/skill-metrics.js
+++ b/scripts/skill-metrics.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * skill-metrics.js
+ *
+ * Renders a length table for every skill: description chars and body bytes,
+ * each flagged against the thresholds in tests/lib/skill-lint.js. Purely
+ * informational — always exits 0. Use it to spot anemic or oversized skills.
+ *
+ * Run: node scripts/skill-metrics.js
+ */
+
+'use strict';
+
+const lint = require('../tests/lib/skill-lint');
+
+function flagDescription(len) {
+  if (len == null) return '  (none)';
+  if (len > lint.MAX_DESCRIPTION_LENGTH) return ' OVER-MAX';
+  if (len < lint.MIN_DESCRIPTION_LENGTH) return ' under-min';
+  return '';
+}
+
+function flagBody(len) {
+  if (len > lint.BODY_WARN_MAX_BYTES) return ' over-max';
+  if (len < lint.BODY_WARN_MIN_BYTES) return ' under-min';
+  return '';
+}
+
+function main() {
+  const skillDirs   = lint.listSkillDirs();
+  const knownSkills = new Set(skillDirs);
+
+  const rows = skillDirs.map(dirName => {
+    const { metrics } = lint.lintSkill(dirName, knownSkills);
+    return { dirName, ...metrics };
+  });
+
+  const nameWidth = Math.max(...rows.map(r => r.dirName.length), 4);
+
+  console.log(
+    `${'skill'.padEnd(nameWidth)}  ${'desc'.padStart(6)}  ${'flag'.padEnd(9)}  ${'body'.padStart(7)}  flag`
+  );
+  console.log('─'.repeat(nameWidth + 36));
+
+  for (const r of rows) {
+    console.log(
+      `${r.dirName.padEnd(nameWidth)}  ` +
+      `${String(r.descriptionLength ?? '—').padStart(6)}  ` +
+      `${flagDescription(r.descriptionLength).padEnd(9)}  ` +
+      `${String(r.bodyLength ?? '—').padStart(7)}  ` +
+      `${flagBody(r.bodyLength)}`
+    );
+  }
+
+  const descs = rows.map(r => r.descriptionLength).filter(n => n != null);
+  const bodies = rows.map(r => r.bodyLength).filter(n => n != null);
+  const range = (arr) => `${Math.min(...arr)}–${Math.max(...arr)}`;
+  const summary =
+    `${rows.length} skills — description ${range(descs)} chars ` +
+    `(limit ${lint.MAX_DESCRIPTION_LENGTH}, min guideline ${lint.MIN_DESCRIPTION_LENGTH}), ` +
+    `body ${range(bodies)} bytes (warn >${lint.BODY_WARN_MAX_BYTES})`;
+  console.log(`\n${summary}`);
+
+  // In GitHub Actions, also render a markdown table on the run summary page.
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    writeStepSummary(rows, summary);
+  }
+}
+
+/** Append a markdown table to the GitHub Actions step summary. */
+function writeStepSummary(rows, summary) {
+  const fs = require('fs');
+  const cell = (n, flag) => (flag ? `\`${n}\` ⚠️ ${flag.trim()}` : `\`${n}\``);
+  const lines = [
+    '## Skill length metrics',
+    '',
+    '| Skill | Description (chars) | Body (bytes) |',
+    '|---|---|---|',
+    ...rows.map(r =>
+      `| ${r.dirName} | ${cell(r.descriptionLength ?? '—', flagDescription(r.descriptionLength))} ` +
+      `| ${cell(r.bodyLength ?? '—', flagBody(r.bodyLength))} |`
+    ),
+    '',
+    summary,
+    '',
+  ];
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n'));
+}
+
+main();

--- a/scripts/validate-skills.js
+++ b/scripts/validate-skills.js
@@ -2,207 +2,33 @@
 /**
  * validate-skills.js
  *
- * Validates every skill in skills/ against the rules in docs/skill-anatomy.md.
+ * CI entry point for skill validation. The rules themselves live in
+ * tests/lib/skill-lint.js (single source of truth, shared with the
+ * node:test battery in tests/skills.test.js). This script is a thin CLI
+ * that renders the lint results and sets the exit code.
  *
- * Checks (errors block CI):
- *   - SKILL.md exists in every skill directory
- *   - YAML frontmatter present with 'name' and 'description' fields
- *   - frontmatter 'name' matches the directory name
- *   - description does not exceed 1024 characters
- *   - required sections are present
- *
- * Checks (warnings, do not block CI):
- *   - cross-skill references point to known skills
- *
- * Exit codes: 0 = all clear, 1 = one or more errors
+ * Exit codes: 0 = no errors, 1 = one or more errors (warnings never fail).
  */
 
 'use strict';
 
 const fs   = require('fs');
-const path = require('path');
-
-// ─── Config ──────────────────────────────────────────────────────────────────
-
-const SKILLS_DIR = path.resolve(__dirname, '..', 'skills');
-
-const MAX_DESCRIPTION_LENGTH = 1024;
-
-// Sections every standard SKILL.md must contain.
-// Each entry is an array of acceptable heading strings — the first
-// match wins, so you can list canonical + legacy aliases.
-const REQUIRED_SECTIONS = [
-  ['## Overview'],
-  ['## When to Use'],
-  ['## Common Rationalizations'],
-  ['## Red Flags'],
-  ['## Verification'],
-];
-
-// Skills that are intentionally exempt from section checks.
-// Exemptions live HERE, not in skill frontmatter, so contributors
-// cannot bypass the validator by editing their own skill file.
-// Every entry must have a documented reason.
-const SECTION_EXEMPT_SKILLS = {
-  'using-agent-skills': 'Meta-skill — orchestrates other skills; When-to-Use and Verification are not applicable to a routing document.',
-  'idea-refine':        'Legacy structure predating skill-anatomy.md — uses How-It-Works/Usage/Anti-patterns instead of standard headings. Tracked for conformance in https://github.com/addyosmani/agent-skills/issues',
-};
-
-// Regex patterns that indicate an explicit cross-skill reference.
-// Only these patterns trigger the dead-reference warning — generic
-// backtick strings in code blocks are intentionally excluded.
-const SKILL_REF_PATTERNS = [
-  /\buse the `([a-z][a-z0-9-]+[a-z0-9])` skill/g,
-  /\bfollow the `([a-z][a-z0-9-]+[a-z0-9])` skill/g,
-  /\binvoke the `([a-z][a-z0-9-]+[a-z0-9])` skill/g,
-  /\bcontinue with `([a-z][a-z0-9-]+[a-z0-9])`/g,
-  /\buse `([a-z][a-z0-9-]+[a-z0-9])` skill/g,
-  /`([a-z][a-z0-9-]+[a-z0-9])` skill\b/g,
-  /`([a-z][a-z0-9-]+[a-z0-9])` persona\b/g,
-  /\bsee `([a-z][a-z0-9-]+[a-z0-9])`/g,
-  /──→ ([a-z][a-z0-9-]+[a-z0-9])\b/g,          // ASCII diagram arrows
-  /→ `([a-z][a-z0-9-]+[a-z0-9])`/g,
-];
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/**
- * Parse YAML-style frontmatter from the top of a markdown file.
- * Returns a key→value object, or null if no frontmatter block found.
- * Values are stripped of surrounding quotes.
- */
-function parseFrontmatter(content) {
-  const match = content.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n/);
-  if (!match) return null;
-
-  const result = {};
-  for (const line of match[1].split(/\r?\n/)) {
-    const colonIdx = line.indexOf(':');
-    if (colonIdx === -1) continue;
-    const key   = line.slice(0, colonIdx).trim();
-    const value = line.slice(colonIdx + 1).trim().replace(/^['"]|['"]$/g, '');
-    if (key) result[key] = value;
-  }
-  return result;
-}
-
-/**
- * Collect all explicit skill cross-references from content.
- * Only matches against the SKILL_REF_PATTERNS list to avoid
- * false-positives from inline code snippets.
- */
-function extractSkillReferences(content) {
-  const refs = new Set();
-  for (const pattern of SKILL_REF_PATTERNS) {
-    // Reset lastIndex for global regexes
-    pattern.lastIndex = 0;
-    let m;
-    while ((m = pattern.exec(content)) !== null) {
-      refs.add(m[1]);
-    }
-  }
-  return refs;
-}
-
-// ─── Validator ───────────────────────────────────────────────────────────────
-
-function validateSkill(dirName, knownSkills) {
-  const errors   = [];
-  const warnings = [];
-  let   exempt   = false;
-  const skillPath = path.join(SKILLS_DIR, dirName, 'SKILL.md');
-
-  if (!fs.existsSync(skillPath)) {
-    errors.push('Missing SKILL.md');
-    return { errors, warnings, exempt };
-  }
-
-  let content;
-  try {
-    content = fs.readFileSync(skillPath, 'utf8');
-  } catch (err) {
-    errors.push(`Unreadable SKILL.md: ${err.message}`);
-    return { errors, warnings, exempt };
-  }
-
-  // ── Frontmatter ──────────────────────────────────────────────────────────
-  const fm = parseFrontmatter(content);
-  if (!fm) {
-    errors.push('Missing or malformed YAML frontmatter (expected --- block at top of file)');
-    return { errors, warnings, exempt };
-  }
-
-  if (!fm.name) {
-    errors.push("Frontmatter missing required field: 'name'");
-  } else if (fm.name !== dirName) {
-    errors.push(`Frontmatter name '${fm.name}' does not match directory name '${dirName}'`);
-  }
-
-  if (!fm.description) {
-    errors.push("Frontmatter missing required field: 'description'");
-  } else if (fm.description.length > MAX_DESCRIPTION_LENGTH) {
-    errors.push(
-      `Description is ${fm.description.length} chars — exceeds the ${MAX_DESCRIPTION_LENGTH}-char limit` +
-      ` (agents inject this into the system prompt)`
-    );
-  }
-
-  // ── Exemption guard ──────────────────────────────────────────────────────
-  // Exemptions are validator-owned (SECTION_EXEMPT_SKILLS above).
-  // If a skill's frontmatter tries to declare its own exemption, fail loud —
-  // that's a sign someone is trying to bypass the validator.
-  if (fm.type === 'meta' || fm.exempt === 'sections') {
-    if (!SECTION_EXEMPT_SKILLS[dirName]) {
-      errors.push(
-        `Frontmatter declares 'type: meta' or 'exempt: sections' but '${dirName}' is not in ` +
-        `the validator's SECTION_EXEMPT_SKILLS allowlist. ` +
-        `Add an entry to scripts/validate-skills.js with a documented reason.`
-      );
-    }
-  }
-
-  // ── Required sections ────────────────────────────────────────────────────
-  exempt = dirName in SECTION_EXEMPT_SKILLS;
-
-  if (!exempt) {
-    for (const aliases of REQUIRED_SECTIONS) {
-      const found = aliases.some(heading => content.includes(heading));
-      if (!found) {
-        errors.push(`Missing required section: ${aliases[0]}`);
-      }
-    }
-  }
-
-  // ── Cross-skill references ───────────────────────────────────────────────
-  const refs = extractSkillReferences(content);
-  for (const ref of refs) {
-    if (!knownSkills.has(ref)) {
-      warnings.push(`Dead cross-reference: \`${ref}\` is not a known skill`);
-    }
-  }
-
-  return { errors, warnings, exempt };
-}
-
-// ─── Main ────────────────────────────────────────────────────────────────────
+const lint = require('../tests/lib/skill-lint');
 
 function main() {
-  if (!fs.existsSync(SKILLS_DIR)) {
-    console.error(`ERROR: skills directory not found at ${SKILLS_DIR}`);
+  if (!fs.existsSync(lint.SKILLS_DIR)) {
+    console.error(`ERROR: skills directory not found at ${lint.SKILLS_DIR}`);
     process.exit(1);
   }
 
-  const skillDirs = fs.readdirSync(SKILLS_DIR)
-    .filter(d => fs.statSync(path.join(SKILLS_DIR, d)).isDirectory())
-    .sort();
-
+  const skillDirs   = lint.listSkillDirs();
   const knownSkills = new Set(skillDirs);
 
   let totalErrors   = 0;
   let totalWarnings = 0;
 
   for (const dirName of skillDirs) {
-    const { errors, warnings, exempt } = validateSkill(dirName, knownSkills);
+    const { errors, warnings, exempt } = lint.lintSkill(dirName, knownSkills);
     totalErrors   += errors.length;
     totalWarnings += warnings.length;
 

--- a/tests/lib/skill-lint.js
+++ b/tests/lib/skill-lint.js
@@ -1,0 +1,281 @@
+'use strict';
+/**
+ * skill-lint.js — single source of truth for skill validation.
+ *
+ * Parses and lints every skill in skills/ against the rules in
+ * docs/skill-anatomy.md. Both the CI validator (scripts/validate-skills.js)
+ * and the node:test battery (tests/skills.test.js) consume this module, so
+ * the rules live in exactly one place.
+ *
+ * lintSkill() classifies findings into:
+ *   - errors   → block CI (structural and format-correctness violations)
+ *   - warnings → informational (length thresholds, phrasing, dead refs)
+ *
+ * It also returns `metrics` (description and body character counts) so the
+ * metrics reporter can render a length table without re-parsing files.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+const SKILLS_DIR = path.resolve(__dirname, '..', '..', 'skills');
+
+// Hard limit: descriptions are injected into the agent system prompt.
+const MAX_DESCRIPTION_LENGTH = 1024;
+
+// Soft thresholds (warnings only). A description shorter than this is usually
+// too thin to convey both what + when; the body bounds flag skills that are
+// either anemic or large enough to consider a supporting file.
+const MIN_DESCRIPTION_LENGTH = 100;
+const BODY_WARN_MIN_BYTES    = 1500;
+const BODY_WARN_MAX_BYTES    = 15000;
+
+// Sections every standard SKILL.md must contain. Each entry is an array of
+// acceptable headings — the first match wins (canonical + legacy aliases).
+const REQUIRED_SECTIONS = [
+  ['## Overview'],
+  ['## When to Use'],
+  ['## Common Rationalizations'],
+  ['## Red Flags'],
+  ['## Verification'],
+];
+
+// Skills intentionally exempt from section + section-format checks.
+// Exemptions live HERE, not in skill frontmatter, so contributors cannot
+// bypass the validator by editing their own file. Each needs a documented why.
+const SECTION_EXEMPT_SKILLS = {
+  'using-agent-skills': 'Meta-skill — orchestrates other skills; When-to-Use and Verification are not applicable to a routing document.',
+  'idea-refine':        'Legacy structure predating skill-anatomy.md — uses How-It-Works/Usage/Anti-patterns instead of standard headings. Tracked for conformance in https://github.com/addyosmani/agent-skills/issues',
+};
+
+// Explicit cross-skill reference patterns. Only these trigger the dead-reference
+// warning — generic backtick strings in code blocks are intentionally excluded.
+const SKILL_REF_PATTERNS = [
+  /\buse the `([a-z][a-z0-9-]+[a-z0-9])` skill/g,
+  /\bfollow the `([a-z][a-z0-9-]+[a-z0-9])` skill/g,
+  /\binvoke the `([a-z][a-z0-9-]+[a-z0-9])` skill/g,
+  /\bcontinue with `([a-z][a-z0-9-]+[a-z0-9])`/g,
+  /\buse `([a-z][a-z0-9-]+[a-z0-9])` skill/g,
+  /`([a-z][a-z0-9-]+[a-z0-9])` skill\b/g,
+  /`([a-z][a-z0-9-]+[a-z0-9])` persona\b/g,
+  /\bsee `([a-z][a-z0-9-]+[a-z0-9])`/g,
+  /──→ ([a-z][a-z0-9-]+[a-z0-9])\b/g,
+  /→ `([a-z][a-z0-9-]+[a-z0-9])`/g,
+];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function listSkillDirs() {
+  return fs.readdirSync(SKILLS_DIR)
+    .filter(d => fs.statSync(path.join(SKILLS_DIR, d)).isDirectory())
+    .sort();
+}
+
+function skillPath(dirName) {
+  return path.join(SKILLS_DIR, dirName, 'SKILL.md');
+}
+
+/**
+ * Split a markdown file into its raw frontmatter block and body.
+ * Returns { frontmatter, body } where frontmatter is the inner YAML text
+ * (or null if no block), and body is everything after the closing ---.
+ */
+function splitFrontmatter(content) {
+  const match = content.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*\r?\n/);
+  if (!match) return { frontmatter: null, body: content };
+  return { frontmatter: match[1], body: content.slice(match[0].length) };
+}
+
+/** Parse a YAML-style frontmatter block into a key→value object. */
+function parseFrontmatter(frontmatterText) {
+  if (frontmatterText == null) return null;
+  const result = {};
+  for (const line of frontmatterText.split(/\r?\n/)) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key   = line.slice(0, colonIdx).trim();
+    const value = line.slice(colonIdx + 1).trim().replace(/^['"]|['"]$/g, '');
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
+/** Collect explicit cross-skill references from body content. */
+function extractSkillReferences(content) {
+  const refs = new Set();
+  for (const pattern of SKILL_REF_PATTERNS) {
+    pattern.lastIndex = 0;
+    let m;
+    while ((m = pattern.exec(content)) !== null) refs.add(m[1]);
+  }
+  return refs;
+}
+
+/** Find the section body for a heading, up to the next ## heading (or EOF). */
+function sectionBody(body, heading) {
+  const start = body.indexOf(heading);
+  if (start === -1) return null;
+  const after = body.slice(start + heading.length);
+  const nextHeading = after.search(/\r?\n## /);
+  return nextHeading === -1 ? after : after.slice(0, nextHeading);
+}
+
+// ─── Linter ──────────────────────────────────────────────────────────────────
+
+/**
+ * Lint one skill by reading its SKILL.md from disk. Thin I/O wrapper around
+ * lintSkillContent — keeps filesystem concerns out of the rule logic so the
+ * rules can be unit-tested with in-memory fixtures (tests/skill-lint.test.js).
+ *
+ * `knownSkills` is a Set of valid skill names used to detect dead
+ * cross-references. Returns { errors, warnings, metrics, exempt }.
+ */
+function lintSkill(dirName, knownSkills) {
+  const file = skillPath(dirName);
+
+  if (!fs.existsSync(file)) {
+    return {
+      errors: ['Missing SKILL.md'], warnings: [],
+      metrics: { descriptionLength: null, bodyLength: null }, exempt: false,
+    };
+  }
+
+  let content;
+  try {
+    content = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    return {
+      errors: [`Unreadable SKILL.md: ${err.message}`], warnings: [],
+      metrics: { descriptionLength: null, bodyLength: null }, exempt: false,
+    };
+  }
+
+  return lintSkillContent(dirName, content, knownSkills);
+}
+
+/**
+ * Lint raw SKILL.md content (no filesystem access). All rules live here.
+ * `dirName` is the expected skill name (for the name-match + exemption checks).
+ * Returns { errors, warnings, metrics, exempt }.
+ */
+function lintSkillContent(dirName, content, knownSkills) {
+  const errors   = [];
+  const warnings = [];
+  const metrics  = { descriptionLength: null, bodyLength: null };
+  let   exempt   = false;
+
+  const { frontmatter, body } = splitFrontmatter(content);
+  metrics.bodyLength = body.length;
+
+  const fm = parseFrontmatter(frontmatter);
+  if (!fm) {
+    errors.push('Missing or malformed YAML frontmatter (expected --- block at top of file)');
+    return { errors, warnings, metrics, exempt };
+  }
+
+  // ── name ──
+  if (!fm.name) {
+    errors.push("Frontmatter missing required field: 'name'");
+  } else if (fm.name !== dirName) {
+    errors.push(`Frontmatter name '${fm.name}' does not match directory name '${dirName}'`);
+  }
+
+  // ── description: presence + length ──
+  if (!fm.description) {
+    errors.push("Frontmatter missing required field: 'description'");
+  } else {
+    metrics.descriptionLength = fm.description.length;
+    if (fm.description.length > MAX_DESCRIPTION_LENGTH) {
+      errors.push(
+        `Description is ${fm.description.length} chars — exceeds the ${MAX_DESCRIPTION_LENGTH}-char limit ` +
+        `(agents inject this into the system prompt)`
+      );
+    }
+    if (fm.description.length < MIN_DESCRIPTION_LENGTH) {
+      warnings.push(
+        `Description is ${fm.description.length} chars — below the ${MIN_DESCRIPTION_LENGTH}-char guideline; ` +
+        `it may not convey both what the skill does and when to use it`
+      );
+    }
+    if (!/use when/i.test(fm.description)) {
+      warnings.push(
+        `Description has no "Use when" trigger clause — agents rely on it to decide when the skill applies`
+      );
+    }
+  }
+
+  // ── Exemption bypass guard ──
+  if (fm.type === 'meta' || fm.exempt === 'sections') {
+    if (!SECTION_EXEMPT_SKILLS[dirName]) {
+      errors.push(
+        `Frontmatter declares 'type: meta' or 'exempt: sections' but '${dirName}' is not in ` +
+        `the validator's SECTION_EXEMPT_SKILLS allowlist. ` +
+        `Add an entry to tests/lib/skill-lint.js with a documented reason.`
+      );
+    }
+  }
+
+  // ── Body length (soft) ──
+  if (metrics.bodyLength < BODY_WARN_MIN_BYTES) {
+    warnings.push(
+      `Body is ${metrics.bodyLength} bytes — below ${BODY_WARN_MIN_BYTES}; the skill may be too thin to encode a real process`
+    );
+  } else if (metrics.bodyLength > BODY_WARN_MAX_BYTES) {
+    warnings.push(
+      `Body is ${metrics.bodyLength} bytes — above ${BODY_WARN_MAX_BYTES}; consider moving detail into a supporting file`
+    );
+  }
+
+  // ── H1 (format correctness) ──
+  if (!/^#\s+\S/m.test(body)) {
+    errors.push('Missing top-level H1 title (expected a "# Skill Title" line in the body)');
+  }
+
+  // ── Required sections + section-format checks ──
+  exempt = dirName in SECTION_EXEMPT_SKILLS;
+  if (!exempt) {
+    for (const aliases of REQUIRED_SECTIONS) {
+      const found = aliases.some(heading => body.includes(heading));
+      if (!found) errors.push(`Missing required section: ${aliases[0]}`);
+    }
+
+    const rationalizations = sectionBody(body, '## Common Rationalizations');
+    if (rationalizations !== null && !/\|.*\|/.test(rationalizations)) {
+      errors.push('"Common Rationalizations" section must contain a markdown table (| ... |)');
+    }
+
+    const verification = sectionBody(body, '## Verification');
+    if (verification !== null && !/- \[ \]/.test(verification)) {
+      errors.push('"Verification" section must contain at least one checkbox item (- [ ])');
+    }
+  }
+
+  // ── Dead cross-references (soft) ──
+  for (const ref of extractSkillReferences(body)) {
+    if (!knownSkills.has(ref)) {
+      warnings.push(`Dead cross-reference: \`${ref}\` is not a known skill`);
+    }
+  }
+
+  return { errors, warnings, metrics, exempt };
+}
+
+module.exports = {
+  SKILLS_DIR,
+  MAX_DESCRIPTION_LENGTH,
+  MIN_DESCRIPTION_LENGTH,
+  BODY_WARN_MIN_BYTES,
+  BODY_WARN_MAX_BYTES,
+  REQUIRED_SECTIONS,
+  SECTION_EXEMPT_SKILLS,
+  listSkillDirs,
+  skillPath,
+  splitFrontmatter,
+  parseFrontmatter,
+  extractSkillReferences,
+  sectionBody,
+  lintSkill,
+  lintSkillContent,
+};

--- a/tests/skill-lint.test.js
+++ b/tests/skill-lint.test.js
@@ -1,0 +1,193 @@
+'use strict';
+/**
+ * skill-lint.test.js — tests for the linter itself ("test the tests").
+ *
+ * skills.test.js proves the 24 real skills are valid. It cannot prove the
+ * linter rejects invalid input — every real skill passes, so a linter that
+ * silently accepts everything would still show green. These fixture-driven
+ * cases close that blind spot: each feeds crafted invalid content to the pure
+ * lintSkillContent() and asserts the specific error/warning it must raise.
+ *
+ * Run: npm test
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const lint = require('./lib/skill-lint');
+
+const KNOWN = new Set(['sample-skill', 'test-driven-development']);
+
+// A representative, fully valid SKILL.md. Cases mutate copies of this via
+// string replacement so each test isolates exactly one rule violation.
+// Body is padded past BODY_WARN_MIN_BYTES so the baseline raises no warnings.
+const VALID = `---
+name: sample-skill
+description: Validates a sample thing for the linter fixtures. Use when you need a representative skill description comfortably above the minimum length guideline.
+---
+
+# Sample Skill
+
+## Overview
+${'This sentence pads the body above the minimum byte threshold so the valid baseline is warning-free. '.repeat(16)}
+
+## When to Use
+- When testing the linter
+
+## Common Rationalizations
+| Rationalization | Reality |
+|---|---|
+| "I'll skip it" | You won't |
+
+## Red Flags
+- Skipping the process
+
+## Verification
+- [ ] The check passed
+`;
+
+function lintContent(content, name = 'sample-skill') {
+  return lint.lintSkillContent(name, content, KNOWN);
+}
+
+function hasMatch(list, substr) {
+  return list.some(item => item.includes(substr));
+}
+
+// ─── Baseline: valid content is clean ─────────────────────────────────────────
+
+test('valid content produces no errors and no warnings', () => {
+  const { errors, warnings } = lintContent(VALID);
+  assert.deepEqual(errors, [], `unexpected errors:\n  ${errors.join('\n  ')}`);
+  assert.deepEqual(warnings, [], `unexpected warnings:\n  ${warnings.join('\n  ')}`);
+});
+
+// ─── Error cases (must block CI) ──────────────────────────────────────────────
+
+const ERROR_CASES = [
+  {
+    name: 'name mismatch',
+    content: VALID.replace('name: sample-skill', 'name: wrong-name'),
+    expect: 'does not match directory name',
+  },
+  {
+    name: 'missing description field',
+    content: VALID.replace(/^description: .*$/m, 'foo: bar'),
+    expect: "missing required field: 'description'",
+  },
+  {
+    name: 'description over the 1024-char limit',
+    content: VALID.replace(/^description: .*$/m, `description: Use when ${'x'.repeat(1100)}`),
+    expect: 'exceeds the 1024-char limit',
+  },
+  {
+    name: 'missing H1 title',
+    content: VALID.replace('# Sample Skill', 'Sample Skill (no hash)'),
+    expect: 'Missing top-level H1 title',
+  },
+  {
+    name: 'missing required section',
+    content: VALID.replace('## Overview', '## Summary'),
+    expect: 'Missing required section: ## Overview',
+  },
+  {
+    name: 'rationalizations section without a table',
+    content: VALID.replace(
+      '| Rationalization | Reality |\n|---|---|\n| "I\'ll skip it" | You won\'t |',
+      'Just a paragraph, no table here.'
+    ),
+    expect: 'must contain a markdown table',
+  },
+  {
+    name: 'verification section without a checkbox',
+    content: VALID.replace('- [ ] The check passed', '- The check passed'),
+    expect: 'must contain at least one checkbox',
+  },
+  {
+    name: 'malformed frontmatter (no block)',
+    content: VALID.replace(/^---[\s\S]*?---\n/, ''),
+    expect: 'Missing or malformed YAML frontmatter',
+  },
+  {
+    name: 'exemption bypass attempt (type: meta on non-exempt skill)',
+    content: VALID.replace('name: sample-skill', 'name: sample-skill\ntype: meta'),
+    expect: 'is not in',
+  },
+];
+
+describe('error cases block CI', () => {
+  for (const c of ERROR_CASES) {
+    test(c.name, () => {
+      const { errors } = lintContent(c.content);
+      assert.ok(
+        hasMatch(errors, c.expect),
+        `expected an error containing "${c.expect}", got:\n  ${errors.join('\n  ') || '(none)'}`
+      );
+    });
+  }
+});
+
+// ─── Warning cases (informational, must not block CI) ─────────────────────────
+
+const WARNING_CASES = [
+  {
+    name: 'description below the minimum length',
+    content: VALID.replace(/^description: .*$/m, 'description: Use when short.'),
+    expect: `below the ${lint.MIN_DESCRIPTION_LENGTH}-char guideline`,
+  },
+  {
+    name: 'description without a "Use when" clause',
+    content: VALID.replace(
+      /^description: .*$/m,
+      'description: Validates a sample thing for the linter fixtures with a description long enough to clear the minimum length threshold easily.'
+    ),
+    expect: 'no "Use when" trigger clause',
+  },
+  {
+    name: 'oversized body',
+    content: VALID.replace('## Red Flags', `${'x'.repeat(16000)}\n\n## Red Flags`),
+    expect: `above ${lint.BODY_WARN_MAX_BYTES}`,
+  },
+  {
+    name: 'dead cross-reference',
+    content: VALID.replace(
+      '## Red Flags\n- Skipping the process',
+      '## Red Flags\n- See the `nonexistent-skill` skill for details'
+    ),
+    expect: 'Dead cross-reference',
+  },
+];
+
+describe('warning cases do not block CI', () => {
+  for (const c of WARNING_CASES) {
+    test(c.name, () => {
+      const { errors, warnings } = lintContent(c.content);
+      assert.ok(
+        hasMatch(warnings, c.expect),
+        `expected a warning containing "${c.expect}", got:\n  ${warnings.join('\n  ') || '(none)'}`
+      );
+      assert.deepEqual(errors, [], `warning case must not raise errors:\n  ${errors.join('\n  ')}`);
+    });
+  }
+});
+
+// ─── Exemption path: exempt skills skip section + format checks ────────────────
+
+test('exempt skill skips section checks even with no standard sections', () => {
+  const exemptName = Object.keys(lint.SECTION_EXEMPT_SKILLS)[0];
+  const content = `---
+name: ${exemptName}
+description: A meta routing document. Use when you need to discover which skill applies, with a description long enough to clear the minimum.
+---
+
+# ${exemptName}
+
+Some prose without any of the standard sections.
+${'Padding to clear the body minimum byte threshold for this fixture. '.repeat(24)}
+`;
+  const { errors, exempt } = lint.lintSkillContent(exemptName, content, KNOWN);
+  assert.equal(exempt, true, `${exemptName} should be section-exempt`);
+  assert.ok(
+    !hasMatch(errors, 'Missing required section'),
+    `exempt skill must not raise section errors:\n  ${errors.join('\n  ')}`
+  );
+});

--- a/tests/skills.test.js
+++ b/tests/skills.test.js
@@ -1,0 +1,66 @@
+'use strict';
+/**
+ * skills.test.js — per-skill validation battery.
+ *
+ * Generates one describe() block per skill so failures point at the exact
+ * skill. Hard errors (structure + format correctness) become assertions that
+ * fail CI; soft findings (length thresholds, missing "Use when", dead refs)
+ * surface as non-failing diagnostics.
+ *
+ * Run: npm test   (or: node --test)
+ */
+
+const { test, describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const lint = require('./lib/skill-lint');
+
+const skillDirs   = lint.listSkillDirs();
+const knownSkills = new Set(skillDirs);
+
+assert.ok(skillDirs.length > 0, 'expected at least one skill under skills/');
+
+for (const dirName of skillDirs) {
+  describe(`skill: ${dirName}`, () => {
+    const { errors, warnings, metrics, exempt } = lint.lintSkill(dirName, knownSkills);
+
+    it('has no structural or format errors', () => {
+      assert.deepEqual(
+        errors,
+        [],
+        errors.length ? `\n  - ${errors.join('\n  - ')}` : undefined
+      );
+    });
+
+    it('description is within the hard 1024-char limit', () => {
+      if (metrics.descriptionLength == null) return; // missing description already failed above
+      assert.ok(
+        metrics.descriptionLength <= lint.MAX_DESCRIPTION_LENGTH,
+        `description is ${metrics.descriptionLength} chars (limit ${lint.MAX_DESCRIPTION_LENGTH})`
+      );
+    });
+
+    it(`reports length metrics${exempt ? ' (section checks exempt)' : ''}`, (t) => {
+      t.diagnostic(
+        `description=${metrics.descriptionLength ?? 'n/a'} chars, body=${metrics.bodyLength ?? 'n/a'} bytes`
+      );
+      for (const w of warnings) t.diagnostic(`WARN: ${w}`);
+    });
+  });
+}
+
+// Suite-wide invariant: no two skills share a description (would confuse routing).
+test('skill descriptions are unique', () => {
+  const seen = new Map();
+  for (const dirName of skillDirs) {
+    const file = lint.skillPath(dirName);
+    const fs = require('node:fs');
+    const { frontmatter } = lint.splitFrontmatter(fs.readFileSync(file, 'utf8'));
+    const fm = lint.parseFrontmatter(frontmatter);
+    const desc = fm && fm.description;
+    if (!desc) continue;
+    if (seen.has(desc)) {
+      assert.fail(`'${dirName}' and '${seen.get(desc)}' share an identical description`);
+    }
+    seen.set(desc, dirName);
+  }
+});


### PR DESCRIPTION
> [!NOTE]
> **Draft: blocked on #323.** This PR overlaps with #323, which was open first and closes #233. The overlap:
> - **Same file:** #323 edits `scripts/validate-skills.js`; this PR refactors that file into a thin CLI over a shared `tests/lib/skill-lint.js`, so the two will conflict at merge.
> - **Trigger rule:** #323 enforces a "when to use" trigger as a hard error with a broader regex (`Use when` / `Use before/after/during`); this PR currently treats it as a warning with a narrower regex.
> - **Naming rule:** #323 adds a kebab-case directory-name check that this PR does not have.
>
> Plan: keep this as a draft, wait for #323 to merge, then rebase on top of it and adopt both of its rules (kebab-case as error, trigger as a hard error with #323's regex) into the shared lib. Marking draft to avoid review churn until then.

---

## What

Adds a test battery for the skills on top of the existing CI validator, using the native `node:test` runner with zero new dependencies. Three layers:

1. **Per-skill battery** (`tests/skills.test.js`): one `describe` block per skill (24 suites) so a failure points at the exact skill. Hard checks fail CI: valid frontmatter, `name` matches the directory, an H1 title is present, the five required sections exist, `Common Rationalizations` is a real markdown table, `Verification` has at least one checkbox, and no two skills share a description. Length metrics surface as non-failing diagnostics.

2. **Linter self-tests** (`tests/skill-lint.test.js`): fixture-driven cases that feed crafted *invalid* content to the linter and assert the specific error or warning it must raise (name mismatch, missing description, over-limit description, missing H1, missing section, rationalizations without a table, verification without a checkbox, malformed frontmatter, exemption-bypass attempt, plus the warning paths).

3. **Length metrics** (`scripts/skill-metrics.js`): a report of description chars and body bytes per skill, flagged against thresholds. In CI it also renders a markdown table to the GitHub Actions step summary.

Supporting changes:
- Rules now live in a single source of truth (`tests/lib/skill-lint.js`), shared by the CI validator and both test suites. It is split into a pure `lintSkillContent()` with no I/O and a thin `lintSkill()` file wrapper, which is what makes the rules unit-testable.
- `scripts/validate-skills.js` is refactored into a thin CLI over that shared lib (no behavior change, no duplicated rules).
- `package.json` with `test` / `validate` / `metrics` scripts and `engines: node >= 22`.
- CI bumped from Node 20 to Node 24 (Node 20 nears end-of-life) and a new `test-skills` job runs the battery plus the metrics report.

## Why

The existing validator only proves one half of the contract: that the 24 real skills are valid. It cannot prove the *other* half, that the linter actually rejects invalid input, because every real skill passes. A linter that silently accepted everything (a regex that stops matching, an inverted condition, an early return introduced by a refactor) would still show green and nobody would notice. The self-test layer closes that blind spot: if a rule breaks, the matching fixture test goes red.

Length checks are deliberately split by severity to avoid false friction: `description > 1024` chars is a hard error (it is injected into the agent system prompt), while a short description (`< 100`), an out-of-range body (outside 1500-15000 bytes), and a missing "Use when" trigger clause are warnings, not blockers.

The metrics step makes skill size visible on every run, which already surfaces three skills above the soft body threshold (`security-and-hardening`, `code-review-and-quality`, `doubt-driven-development`) as candidates for moving detail into supporting files.

## Verification

- `npm test` is green: 88 tests, 26 suites, 0 failures.
- The self-tests have teeth: neutralizing the H1 rule in the linter turns the `missing H1 title` fixture test red (87/88), and reverting restores green.
- `node scripts/validate-skills.js` still passes (24 skills, 0 errors), now via the shared lib.
- The quality heuristics were checked against all 24 current skills before being made hard assertions, so this does not retroactively break any existing skill.

## Notes

- `scripts/validate-commands.js` is untouched; it is only referenced from the new `npm run validate` script.
- The quality heuristics are intentionally structural (presence of a table, a checkbox, an H1), not semantic, to keep false positives near zero.
- Section exemptions remain validator-owned (`SECTION_EXEMPT_SKILLS`), so a skill cannot exempt itself via its own frontmatter.

