### PR TITLE
docs: add PR-overlap guideline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,16 @@ docs/         → Setup guides for different tools
 - `npm test` — Not applicable (this is a documentation project)
 - Validate: Check that all SKILL.md files have valid YAML frontmatter with name and description
 
+## Pull Requests
+
+PRs target the upstream repository's default branch. In a typical fork setup the upstream remote is `upstream` and your fork is `origin`, but the exact remote names are not what matters here.
+
+- Before opening a PR, search the upstream repository's open PRs and issues for work that touches the same files or rules. If any overlaps, coordinate (build on it, align your rules with it, or rebase after it merges) instead of opening a conflicting PR.
+- Prefer small, focused PRs over large refactors of widely shared files (for example, files under `scripts/`), which are more likely to collide with in-flight work.
+
 ## Boundaries
 
 - Always: Follow the skill-anatomy.md format for new skills
+- Always: Check the upstream repo's open PRs and issues for overlap before opening a new PR
 - Never: Add skills that are vague advice instead of actionable processes
 - Never: Duplicate content between skills — reference other skills instead


### PR DESCRIPTION
## What

Adds a `## Pull Requests` section and a Boundaries bullet to `CLAUDE.md`: before opening a PR, search the upstream repo's open PRs and issues for overlapping work, and coordinate instead of opening a conflicting PR. It also nudges toward small, focused PRs over large refactors of widely shared files.

## Why

There was no guidance to check for in-flight work before opening a PR, and it bit us in practice: #324 was opened without noticing #323, which was already open against the same file (`scripts/validate-skills.js`) and overlapping on the same rule (the description "when to use" trigger). The result is a guaranteed merge conflict and duplicated effort that a quick scan of open PRs would have prevented.

The wording is intentionally generic about remote names (`origin` / `upstream` are mentioned only as the common convention) so it applies regardless of how a contributor's remotes are set up.

## Scope

Docs only. No code or validator behavior changes.
