### PR TITLE
feat(plugin): add .agents/skills for slash-command auto-discovery

### DIFF
--- a/.agents/skills/source-command-build/SKILL.md
+++ b/.agents/skills/source-command-build/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: "source-command-build"
+description: "Implement the next task incrementally — build, test, verify, commit"
+---
+
+# source-command-build
+
+Use this skill when the user asks to run the migrated source command `build`.
+
+## Command Template
+
+Invoke the agent-skills:incremental-implementation skill alongside agent-skills:test-driven-development.
+
+Pick the next pending task from the plan. For each task:
+
+1. Read the task's acceptance criteria
+2. Load relevant context (existing code, patterns, types)
+3. Write a failing test for the expected behavior (RED)
+4. Implement the minimum code to pass the test (GREEN)
+5. Run the full test suite to check for regressions
+6. Run the build to verify compilation
+7. Commit with a descriptive message
+8. Mark the task complete and move to the next one
+
+If any step fails, follow the agent-skills:debugging-and-error-recovery skill.

--- a/.agents/skills/source-command-code-simplify/SKILL.md
+++ b/.agents/skills/source-command-code-simplify/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: "source-command-code-simplify"
+description: "Simplify code for clarity and maintainability — reduce complexity without changing behavior"
+---
+
+# source-command-code-simplify
+
+Use this skill when the user asks to run the migrated source command `code-simplify`.
+
+## Command Template
+
+Invoke the agent-skills:code-simplification skill.
+
+Simplify recently changed code (or the specified scope) while preserving exact behavior:
+
+1. Read AGENTS.md and study project conventions
+2. Identify the target code — recent changes unless a broader scope is specified
+3. Understand the code's purpose, callers, edge cases, and test coverage before touching it
+4. Scan for simplification opportunities:
+   - Deep nesting → guard clauses or extracted helpers
+   - Long functions → split by responsibility
+   - Nested ternaries → if/else or switch
+   - Generic names → descriptive names
+   - Duplicated logic → shared functions
+   - Dead code → remove after confirming
+5. Apply each simplification incrementally — run tests after each change
+6. Verify all tests pass, the build succeeds, and the diff is clean
+
+If tests fail after a simplification, revert that change and reconsider. Use `code-review-and-quality` to review the result.

--- a/.agents/skills/source-command-plan/SKILL.md
+++ b/.agents/skills/source-command-plan/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: "source-command-plan"
+description: "Break work into small verifiable tasks with acceptance criteria and dependency ordering"
+---
+
+# source-command-plan
+
+Use this skill when the user asks to run the migrated source command `plan`.
+
+## Command Template
+
+Invoke the agent-skills:planning-and-task-breakdown skill.
+
+Read the existing spec (SPEC.md or equivalent) and the relevant codebase sections. Then:
+
+1. Enter plan mode — read only, no code changes
+2. Identify the dependency graph between components
+3. Slice work vertically (one complete path per task, not horizontal layers)
+4. Write tasks with acceptance criteria and verification steps
+5. Add checkpoints between phases
+6. Present the plan for human review
+
+Save the plan to tasks/plan.md and task list to tasks/todo.md.

--- a/.agents/skills/source-command-review/SKILL.md
+++ b/.agents/skills/source-command-review/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: "source-command-review"
+description: "Conduct a five-axis code review — correctness, readability, architecture, security, performance"
+---
+
+# source-command-review
+
+Use this skill when the user asks to run the migrated source command `review`.
+
+## Command Template
+
+Invoke the agent-skills:code-review-and-quality skill.
+
+Review the current changes (staged or recent commits) across all five axes:
+
+1. **Correctness** — Does it match the spec? Edge cases handled? Tests adequate?
+2. **Readability** — Clear names? Straightforward logic? Well-organized?
+3. **Architecture** — Follows existing patterns? Clean boundaries? Right abstraction level?
+4. **Security** — Input validated? Secrets safe? Auth checked? (Use security-and-hardening skill)
+5. **Performance** — No N+1 queries? No unbounded ops? (Use performance-optimization skill)
+
+Categorize findings as Critical, Important, or Suggestion.
+Output a structured review with specific file:line references and fix recommendations.

--- a/.agents/skills/source-command-ship/SKILL.md
+++ b/.agents/skills/source-command-ship/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: "source-command-ship"
+description: "Run the pre-launch checklist via parallel fan-out to specialist personas, then synthesize a go/no-go decision"
+---
+
+# source-command-ship
+
+Use this skill when the user asks to run the migrated source command `ship`.
+
+## Command Template
+
+Invoke the agent-skills:shipping-and-launch skill.
+
+`/ship` is a **fan-out orchestrator**. It runs three specialist personas in parallel against the current change, then merges their reports into a single go/no-go decision with a rollback plan. The personas operate independently — no shared state, no ordering — which is what makes parallel execution safe and useful here.
+
+## Phase A — Parallel fan-out
+
+Spawn three subagents concurrently using the Agent tool. **Issue all three Agent tool calls in a single assistant turn so they execute in parallel** — sequential calls defeat the purpose of this command.
+
+In Codex, each call passes `subagent_type` matching the persona's `name` field:
+
+1. **`code-reviewer`** — Run a five-axis review (correctness, readability, architecture, security, performance) on the staged changes or recent commits. Output the standard review template.
+2. **`security-auditor`** — Run a vulnerability and threat-model pass. Check OWASP Top 10, secrets handling, auth/authz, dependency CVEs. Output the standard audit report.
+3. **`test-engineer`** — Analyze test coverage for the change. Identify gaps in happy path, edge cases, error paths, and concurrency scenarios. Output the standard coverage analysis.
+
+In other harnesses without an Agent tool, invoke each persona's system prompt sequentially and treat their outputs as if returned in parallel — the merge phase still works.
+
+Constraints (from Codex's subagent model):
+- Subagents cannot spawn other subagents — do not let one persona delegate to another.
+- Each subagent gets its own context window and returns only its report to this main session.
+- If you need teammates that talk to each other instead of just reporting back, use Codex Agent Teams and reference these personas as teammate types (see `references/orchestration-patterns.md`).
+
+**Persona resolution.** If you've defined your own `code-reviewer`, `security-auditor`, or `test-engineer` in `.Codex/agents/` or `~/.Codex/agents/`, those take precedence over this plugin's versions — `/ship` picks up your customizations automatically. This is intentional: plugin subagents sit at the bottom of Codex's scope priority table, so user-level definitions win by design.
+
+## Phase B — Merge in main context
+
+Once all three reports are back, the main agent (not a sub-persona) synthesizes them:
+
+1. **Code Quality** — Aggregate Critical/Important findings from `code-reviewer` and any failing tests, lint, or build output. Resolve duplicates between reviewers.
+2. **Security** — Promote any Critical/High `security-auditor` findings to launch blockers. Cross-reference with `code-reviewer`'s security axis.
+3. **Performance** — Pull from `code-reviewer`'s performance axis; cross-check Core Web Vitals if applicable.
+4. **Accessibility** — Verify keyboard nav, screen reader support, contrast (not covered by the three personas — handle directly here, or invoke the accessibility checklist).
+5. **Infrastructure** — Env vars, migrations, monitoring, feature flags. Verify directly.
+6. **Documentation** — README, ADRs, changelog. Verify directly.
+
+## Phase C — Decision and rollback
+
+Produce a single output:
+
+```markdown
+## Ship Decision: GO | NO-GO
+
+### Blockers (must fix before ship)
+- [Source persona: Critical finding + file:line]
+
+### Recommended fixes (should fix before ship)
+- [Source persona: Important finding + file:line]
+
+### Acknowledged risks (shipping anyway)
+- [Risk + mitigation]
+
+### Rollback plan
+- Trigger conditions: [what signals would prompt rollback]
+- Rollback procedure: [exact steps]
+- Recovery time objective: [target]
+
+### Specialist reports (full)
+- [code-reviewer report]
+- [security-auditor report]
+- [test-engineer report]
+```
+
+## Rules
+
+1. The three Phase A personas run in parallel — never sequentially.
+2. Personas do not call each other. The main agent merges in Phase B.
+3. The rollback plan is mandatory before any GO decision.
+4. If any persona returns a Critical finding, the default verdict is NO-GO unless the user explicitly accepts the risk.
+5. **Skip the fan-out only if all of the following are true:** the change touches 2 files or fewer, the diff is under 50 lines, and it does not touch auth, payments, data access, or config/env. Otherwise, default to fan-out. `/ship` is designed for production-bound changes — when the blast radius is non-trivial, run the parallel review even if the diff looks small.

--- a/.agents/skills/source-command-spec/SKILL.md
+++ b/.agents/skills/source-command-spec/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: "source-command-spec"
+description: "Start spec-driven development — write a structured specification before writing code"
+---
+
+# source-command-spec
+
+Use this skill when the user asks to run the migrated source command `spec`.
+
+## Command Template
+
+Invoke the agent-skills:spec-driven-development skill.
+
+Begin by understanding what the user wants to build. Ask clarifying questions about:
+1. The objective and target users
+2. Core features and acceptance criteria
+3. Tech stack preferences and constraints
+4. Known boundaries (what to always do, ask first about, and never do)
+
+Then generate a structured spec covering all six core areas: objective, commands, project structure, code style, testing strategy, and boundaries.
+
+Save the spec as SPEC.md in the project root and confirm with the user before proceeding.

--- a/.agents/skills/source-command-test/SKILL.md
+++ b/.agents/skills/source-command-test/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: "source-command-test"
+description: "Run TDD workflow — write failing tests, implement, verify. For bugs, use the Prove-It pattern."
+---
+
+# source-command-test
+
+Use this skill when the user asks to run the migrated source command `test`.
+
+## Command Template
+
+Invoke the agent-skills:test-driven-development skill.
+
+For new features:
+1. Write tests that describe the expected behavior (they should FAIL)
+2. Implement the code to make them pass
+3. Refactor while keeping tests green
+
+For bug fixes (Prove-It pattern):
+1. Write a test that reproduces the bug (must FAIL)
+2. Confirm the test fails
+3. Implement the fix
+4. Confirm the test passes
+5. Run the full test suite for regressions
+
+For browser-related issues, also invoke agent-skills:browser-testing-with-devtools to verify with Chrome DevTools MCP.


### PR DESCRIPTION
## Summary

- Adds `.agents/skills/` directory with plugin-compatible `SKILL.md` files for each slash command: `build`, `plan`, `spec`, `test`, `review`, `code-simplify`, and `ship`
- Each skill file mirrors the corresponding `.claude/commands/` implementation so agent runtimes that scan `.agents/skills/` for auto-discovery can invoke the same skill logic without manual registration
- Follows the directory form introduced in #114 for plugin skill auto-discovery

## What changed

Seven new `SKILL.md` files under `.agents/skills/`:

| Skill | Maps to |
|---|---|
| `source-command-build` | `build` slash command |
| `source-command-plan` | `plan` slash command |
| `source-command-spec` | `spec` slash command |
| `source-command-test` | `test` slash command |
| `source-command-review` | `review` slash command |
| `source-command-code-simplify` | `code-simplify` slash command |
| `source-command-ship` | `ship` slash command |

## Reviewer notes

These files are intentionally thin wrappers — they delegate to the canonical skill implementations already in `skills/` rather than duplicating logic. The naming convention (`source-command-*`) makes the origin clear while fitting the auto-discovery pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)