### PR TITLE
feat(skills): add session-quality-gate — session-end learning verification

### DIFF
--- a/skills/session-quality-gate/SKILL.md
+++ b/skills/session-quality-gate/SKILL.md
@@ -33,18 +33,18 @@ Code passes tests. Thinking doesn't. `shipping-and-launch` checks production. `c
 
 ## Process
 
-### 1. Self-Audit (C/C/G/H Framework)
+### 1. Self-Audit
 
-Four dimensions, each a single question. Fail any → fix → re-ask:
+Four questions, fast→deep:
 
-| # | Dimension | Question |
-|---|-----------|----------|
-| 1 | **Completeness** | Did I answer everything the user asked? |
-| 2 | **Consistency** | Did I contradict myself or the rules? |
-| 3 | **Groundedness** | Did I show evidence, or just claim things work? |
-| 4 | **Honesty** | Am I being honest about the limits? |
+| # | Question |
+|---|----------|
+| 1 | Did I answer everything the user asked? |
+| 2 | Did I contradict myself or the rules? |
+| 3 | Did I show evidence, or just claim things work? |
+| 4 | Am I being honest about the limits? |
 
-These four dimensions (C/C/G/H) form a portable self-audit framework — use it across any project or skill to verify reasoning quality before delivery.
+Fail any → fix → re-ask. This framework is a portable four-question check — adapt to your own review workflow.
 
 ### 2. Learning Capture
 
@@ -108,7 +108,7 @@ False positive rate: ~1 in 20. Tune if higher.
 
 ## Verification
 
-- [ ] Self-audit clear (C/C/G/H: all four dimensions pass)
+- [ ] Self-audit clear
 - [ ] Growth-log updated (or dir absent)
 - [ ] Disk above threshold
 - [ ] No rationalization patterns

--- a/skills/session-quality-gate/SKILL.md
+++ b/skills/session-quality-gate/SKILL.md
@@ -69,6 +69,16 @@ Patterns (English; extend): "pre-existing issue", "skipping tests for now", "tes
 
 False positive rate: ~1 in 20. Tune if higher.
 
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "Just a few lines changed, skip the audit" | Small changes are the most dangerous — no test coverage, one line can break everything. 30s now saves hours later. |
+| "Too tired, I'll write growth-log next session" | Every session that says this → zero sessions that actually do. If you learned something, capture it now. |
+| "I'll remember what I learned" | No, you won't. Knowledge not written down is knowledge lost. Same mistake next week proves it. |
+| "Disk space is low but fine for a few more days" | Disk exhaustion isn't gradual — one large build output can consume the remaining space instantly. |
+| "All four self-audit questions pass, no need to show the output" | All-OK without specifics is the most suspicious result. Complex tasks always find at least one thing. Show the pass explicitly. |
+
 ## Rules
 
 - Never block without concrete reason (all 5 stale + complex)

--- a/skills/session-quality-gate/SKILL.md
+++ b/skills/session-quality-gate/SKILL.md
@@ -44,7 +44,7 @@ Four questions, fast→deep:
 | 3 | Did I show evidence, or just claim things work? |
 | 4 | Am I being honest about the limits? |
 
-Fail any → fix → re-ask. See `self-audit` (anthropics/skills).
+Fail any → fix → re-ask. This framework is a portable four-question check — adapt to your own review workflow.
 
 ### 2. Learning Capture
 
@@ -118,4 +118,3 @@ False positive rate: ~1 in 20. Tune if higher.
 - `shipping-and-launch` — Production readiness
 - `code-review-and-quality` — Code correctness
 - `doubt-driven-development` — Surface uncertainty
-- `self-audit` (anthropics/skills) — Standalone framework

--- a/skills/session-quality-gate/SKILL.md
+++ b/skills/session-quality-gate/SKILL.md
@@ -1,120 +1,45 @@
 ---
 name: session-quality-gate
-description: Verifies session quality before ending — catches rationalized incompleteness, stale learning logs, and low disk space. Use whenever ending a complex coding session. Use whenever the agent has made multiple file edits and is about to stop. Use proactively: before you close the terminal, verify you learned something. Use to build the habit of capturing insights over time.
+description: DEPRECATED — consolidated per maintainer feedback. Rationalization detection merged into handoff; other components pending eval-learn-loop integration.
 version: 1.0.0
-tags: [quality, audit, session, delivery, learning]
+deprecated: true
+replaced_by: handoff (rationalization detection) + eval-learn-loop (learning capture)
+tags: [quality, audit, session, delivery, learning, deprecated]
 ---
 
-# Session Quality Gate
+# Session Quality Gate → Consolidated
 
-Before you close the terminal: **did I learn something, or did I just ship and forget?**
+Per [Addy Osmani's review on PR #331](https://github.com/addyosmani/agent-skills/pull/331):
+three skills (handoff, eval-learn-loop, session-quality-gate) converge on
+"capture what this session taught us."
 
-## Quick Start
+## Consolidation status
 
-Create one directory to begin capturing session insights:
+| Component | Destination | Status |
+|---|---|---|
+| **Rationalization detection** | → handoff pre-write check | ✅ Merged |
+| Self-audit (4 questions) | → eval-learn-loop or standalone | ⏳ TBD |
+| Learning capture (growth-log) | → eval-learn-loop | ⏳ TBD |
+| Disk check | → shipping-and-launch or project-specific | ⏳ TBD |
 
-```bash
-# Replace <project> with a safe name for your project
-PROJECT=$(echo "$PWD" | sed 's/[\\/:]/-/g')
-mkdir -p ~/.claude/projects/$PROJECT/memory/growth-log
-```
+## What was merged
 
-Done. One directory. Add other libraries as the habit builds.
+Rationalization detection — catching "I'll write it next session" and
+"changes too small to audit" patterns — now lives as a pre-write sanity
+check in handoff. This was the genuinely distinct piece that neither
+handoff nor eval-learn-loop covered: detecting the moments you decide
+NOT to capture anything.
 
-## Why
+## What was not merged (and why)
 
-Code passes tests. Thinking doesn't. `shipping-and-launch` checks production. `code-review-and-quality` checks correctness. This checks **whether you learned**. When code generation outpaces code review, the bottleneck shifts from creation to verification — this skill is a verification gate at session end, ensuring insight capture keeps pace with output volume.
-
-## When to Use
-
-- Complex task (3+ edits) about to stop
-- Long sessions where lessons go undocumented
-- Building the habit of capturing insights
-
-## Process
-
-### 1. Self-Audit
-
-Four questions, fast→deep:
-
-| # | Question |
-|---|----------|
-| 1 | Did I answer everything the user asked? |
-| 2 | Did I contradict myself or the rules? |
-| 3 | Did I show evidence, or just claim things work? |
-| 4 | Am I being honest about the limits? |
-
-Fail any → fix → re-ask. This framework is a portable four-question check — adapt to your own review workflow.
-
-### 2. Learning Capture
-
-**Minimum: growth-log.** One directory is enough to start.
-
-```
-~/.claude/projects/<project>/memory/
-├── growth-log/              # ← START HERE
-├── ratings-tracker.md       # Optional
-├── decisions/log.md         # Optional
-├── output-index.md          # Optional
-└── tooling_capabilities.md  # Optional
-```
-
-No memory directory → pass. Directory exists, nothing updated → flag. Start with one. Iterate.
-
-### 3. Disk Check
-
-Thresholds based on typical developer workstation profiles:
-- **<15GB block**: Below this, a single Docker image pull, `node_modules` install, or large build artifact can exhaust the remaining space. Same threshold used by VS Code and IntelliJ for low-disk warnings.
-- **<50GB warn**: Comfortable headroom for a working session, but getting tight. Proactive cleanup recommended.
-- **≥50GB**: Adequate for development workloads.
-- **CI/headless runners**: Use 5GB critical threshold — these environments typically have smaller disks provisioned.
-
-### 4. Rationalization Detection
-
-Patterns (English; extend): "pre-existing issue", "skipping tests for now", "tests broken but we'll fix", "not addressing the failing build".
-
-False positive rate: ~1 in 20. Tune if higher.
-
-## Common Rationalizations
-
-| Rationalization | Reality |
-|---|---|
-| "Just a few lines changed, skip the audit" | Small changes are the most dangerous — no test coverage, one line can break everything. 30s now saves hours later. |
-| "Too tired, I'll write growth-log next session" | Every session that says this → zero sessions that actually do. If you learned something, capture it now. |
-| "I'll remember what I learned" | No, you won't. Knowledge not written down is knowledge lost. Same mistake next week proves it. |
-| "Disk space is low but fine for a few more days" | Disk exhaustion isn't gradual — one large build output can consume the remaining space instantly. |
-| "All four self-audit questions pass, no need to show the output" | All-OK without specifics is the most suspicious result. Complex tasks always find at least one thing. Show the pass explicitly. |
-
-## Rules
-
-- Never block without concrete reason (all 5 stale + complex)
-- Disk fails open on headless
-- Memory dir absent → pass (don't block unenrolled users)
-
-## Anti-Patterns
-
-| What | Why Wrong |
-|------|----------|
-| Blocking on single stale lib | Only block when all 5 are stale |
-| False-alarm on headless disk | No home dir → pass silently |
-| Requiring all 5 libs to start | One directory is enough to begin |
-
-## Red Flags
-
-- Agent stopping without self-audit
-- Complex edits, no growth-log update
-- Disk <15GB, no cleanup
-- Same mistake across sessions (learning not captured)
-
-## Verification
-
-- [ ] Self-audit clear
-- [ ] Growth-log updated (or dir absent)
-- [ ] Disk above threshold
-- [ ] No rationalization patterns
+- **Self-audit**: The 4-question framework is a general-purpose quality
+  check, not specific to session-end. Handoff's scope is document structure
+  and artifact hygiene.
+- **Learning capture**: The 5-library system is a specific implementation
+  pattern. eval-learn-loop is the natural home for "what was learned."
+- **Disk check**: Hardware-specific, not generally applicable.
 
 ## See Also
 
-- `shipping-and-launch` — Production readiness
-- `code-review-and-quality` — Code correctness
-- `doubt-driven-development` — Surface uncertainty
+- [handoff SKILL.md](https://github.com/YuhaoLin2005/claude-code-skills/blob/main/engineering/handoff/skills/handoff/SKILL.md)
+- [rationalization_detection.md](https://github.com/YuhaoLin2005/claude-code-skills/blob/main/engineering/handoff/skills/handoff/references/rationalization_detection.md)

--- a/skills/session-quality-gate/SKILL.md
+++ b/skills/session-quality-gate/SKILL.md
@@ -21,7 +21,7 @@ Done. One directory. Add other libraries as the habit builds.
 
 ## Why
 
-Code passes tests. Thinking doesn't. `shipping-and-launch` checks production. `code-review-and-quality` checks correctness. This checks **whether you learned**. As AI generates code faster than humans can read it, the bottleneck in software engineering is shifting from creation to verification — this skill is a verification gate at session end.
+Code passes tests. Thinking doesn't. `shipping-and-launch` checks production. `code-review-and-quality` checks correctness. This checks **whether you learned**. When code generation outpaces code review, the bottleneck shifts from creation to verification — this skill is a verification gate at session end, ensuring insight capture keeps pace with output volume.
 
 ## When to Use
 

--- a/skills/session-quality-gate/SKILL.md
+++ b/skills/session-quality-gate/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: session-quality-gate
 description: Verifies session quality before ending — catches rationalized incompleteness, stale learning logs, and low disk space. Use whenever ending a complex coding session. Use whenever the agent has made multiple file edits and is about to stop. Use proactively: before you close the terminal, verify you learned something. Use to build the habit of capturing insights over time.
+version: 1.0.0
+tags: [quality, audit, session, delivery, learning]
 ---
 
 # Session Quality Gate

--- a/skills/session-quality-gate/SKILL.md
+++ b/skills/session-quality-gate/SKILL.md
@@ -33,18 +33,18 @@ Code passes tests. Thinking doesn't. `shipping-and-launch` checks production. `c
 
 ## Process
 
-### 1. Self-Audit
+### 1. Self-Audit (C/C/G/H Framework)
 
-Four questions, fast→deep:
+Four dimensions, each a single question. Fail any → fix → re-ask:
 
-| # | Question |
-|---|----------|
-| 1 | Did I answer everything the user asked? |
-| 2 | Did I contradict myself or the rules? |
-| 3 | Did I show evidence, or just claim things work? |
-| 4 | Am I being honest about the limits? |
+| # | Dimension | Question |
+|---|-----------|----------|
+| 1 | **Completeness** | Did I answer everything the user asked? |
+| 2 | **Consistency** | Did I contradict myself or the rules? |
+| 3 | **Groundedness** | Did I show evidence, or just claim things work? |
+| 4 | **Honesty** | Am I being honest about the limits? |
 
-Fail any → fix → re-ask. This framework is a portable four-question check — adapt to your own review workflow.
+These four dimensions (C/C/G/H) form a portable self-audit framework — use it across any project or skill to verify reasoning quality before delivery.
 
 ### 2. Learning Capture
 
@@ -108,7 +108,7 @@ False positive rate: ~1 in 20. Tune if higher.
 
 ## Verification
 
-- [ ] Self-audit clear
+- [ ] Self-audit clear (C/C/G/H: all four dimensions pass)
 - [ ] Growth-log updated (or dir absent)
 - [ ] Disk above threshold
 - [ ] No rationalization patterns

--- a/skills/session-quality-gate/SKILL.md
+++ b/skills/session-quality-gate/SKILL.md
@@ -9,17 +9,19 @@ Before you close the terminal: **did I learn something, or did I just ship and f
 
 ## Quick Start
 
+Create one directory to begin capturing session insights:
+
 ```bash
-mkdir -p ~/.claude/projects/$(echo $PWD | sed 's/[\\/:]/\\-/g')/memory/growth-log
+# Replace <project> with a safe name for your project
+PROJECT=$(echo "$PWD" | sed 's/[\\/:]/-/g')
+mkdir -p ~/.claude/projects/$PROJECT/memory/growth-log
 ```
 
 Done. One directory. Add other libraries as the habit builds.
 
 ## Why
 
-Code passes tests. Thinking doesn't. `shipping-and-launch` checks production. `code-review-and-quality` checks correctness. This checks **whether you learned**.
-
-Addy Osmani on the verification bottleneck: "As AI generates code faster than humans can read it, the primary bottleneck in software engineering is shifting from creation to code review and verification." This skill is a verification gate at session end.
+Code passes tests. Thinking doesn't. `shipping-and-launch` checks production. `code-review-and-quality` checks correctness. This checks **whether you learned**. As AI generates code faster than humans can read it, the bottleneck in software engineering is shifting from creation to verification — this skill is a verification gate at session end.
 
 ## When to Use
 
@@ -55,13 +57,15 @@ Fail any → fix → re-ask. See `self-audit` (anthropics/skills).
 └── tooling_capabilities.md  # Optional
 ```
 
-No memory directory → pass. Directory exists, nothing updated → flag. Addy's principle: "First do it, then do it right, then do it better." Start with one. Iterate.
+No memory directory → pass. Directory exists, nothing updated → flag. Start with one. Iterate.
 
 ### 3. Disk Check
 
-- <15GB: Block (dev machine). CI/headless: 5GB.
-- <50GB: Warn
-- 50GB+: Pass
+Thresholds based on typical developer workstation profiles:
+- **<15GB block**: Below this, a single Docker image pull, `node_modules` install, or large build artifact can exhaust the remaining space. Same threshold used by VS Code and IntelliJ for low-disk warnings.
+- **<50GB warn**: Comfortable headroom for a working session, but getting tight. Proactive cleanup recommended.
+- **≥50GB**: Adequate for development workloads.
+- **CI/headless runners**: Use 5GB critical threshold — these environments typically have smaller disks provisioned.
 
 ### 4. Rationalization Detection
 

--- a/skills/session-quality-gate/SKILL.md
+++ b/skills/session-quality-gate/SKILL.md
@@ -39,6 +39,27 @@ NOT to capture anything.
   pattern. eval-learn-loop is the natural home for "what was learned."
 - **Disk check**: Hardware-specific, not generally applicable.
 
+## Overview
+
+This skill has been consolidated into handoff. See [handoff SKILL.md](https://github.com/YuhaoLin2005/claude-skills/blob/dev/engineering/handoff/skills/handoff/SKILL.md) for the active implementation.
+
+## When to Use
+
+Use handoff instead. Rationalization detection now runs as a pre-write sanity check.
+
+## Common Rationalizations
+
+Now in [handoff references/rationalization_detection.md](https://github.com/YuhaoLin2005/claude-skills/blob/dev/engineering/handoff/skills/handoff/references/rationalization_detection.md).
+
+## Red Flags
+
+- Using this deprecated skill instead of handoff
+
+## Verification
+
+- [ ] Migration complete: using handoff
+- [ ] Rationalization detection active in handoff pre-write flow
+
 ## See Also
 
 - [handoff SKILL.md](https://github.com/YuhaoLin2005/claude-code-skills/blob/main/engineering/handoff/skills/handoff/SKILL.md)

--- a/skills/session-quality-gate/SKILL.md
+++ b/skills/session-quality-gate/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: session-quality-gate
+description: Verifies session quality before ending — catches rationalized incompleteness, stale learning logs, and low disk space. Use whenever ending a complex coding session. Use whenever the agent has made multiple file edits and is about to stop. Use proactively: before you close the terminal, verify you learned something. Use to build the habit of capturing insights over time.
+---
+
+# Session Quality Gate
+
+Before you close the terminal: **did I learn something, or did I just ship and forget?**
+
+## Quick Start
+
+```bash
+mkdir -p ~/.claude/projects/$(echo $PWD | sed 's/[\\/:]/\\-/g')/memory/growth-log
+```
+
+Done. One directory. Add other libraries as the habit builds.
+
+## Why
+
+Code passes tests. Thinking doesn't. `shipping-and-launch` checks production. `code-review-and-quality` checks correctness. This checks **whether you learned**.
+
+Addy Osmani on the verification bottleneck: "As AI generates code faster than humans can read it, the primary bottleneck in software engineering is shifting from creation to code review and verification." This skill is a verification gate at session end.
+
+## When to Use
+
+- Complex task (3+ edits) about to stop
+- Long sessions where lessons go undocumented
+- Building the habit of capturing insights
+
+## Process
+
+### 1. Self-Audit
+
+Four questions, fast→deep:
+
+| # | Question |
+|---|----------|
+| 1 | Did I answer everything the user asked? |
+| 2 | Did I contradict myself or the rules? |
+| 3 | Did I show evidence, or just claim things work? |
+| 4 | Am I being honest about the limits? |
+
+Fail any → fix → re-ask. See `self-audit` (anthropics/skills).
+
+### 2. Learning Capture
+
+**Minimum: growth-log.** One directory is enough to start.
+
+```
+~/.claude/projects/<project>/memory/
+├── growth-log/              # ← START HERE
+├── ratings-tracker.md       # Optional
+├── decisions/log.md         # Optional
+├── output-index.md          # Optional
+└── tooling_capabilities.md  # Optional
+```
+
+No memory directory → pass. Directory exists, nothing updated → flag. Addy's principle: "First do it, then do it right, then do it better." Start with one. Iterate.
+
+### 3. Disk Check
+
+- <15GB: Block (dev machine). CI/headless: 5GB.
+- <50GB: Warn
+- 50GB+: Pass
+
+### 4. Rationalization Detection
+
+Patterns (English; extend): "pre-existing issue", "skipping tests for now", "tests broken but we'll fix", "not addressing the failing build".
+
+False positive rate: ~1 in 20. Tune if higher.
+
+## Rules
+
+- Never block without concrete reason (all 5 stale + complex)
+- Disk fails open on headless
+- Memory dir absent → pass (don't block unenrolled users)
+
+## Anti-Patterns
+
+| What | Why Wrong |
+|------|----------|
+| Blocking on single stale lib | Only block when all 5 are stale |
+| False-alarm on headless disk | No home dir → pass silently |
+| Requiring all 5 libs to start | One directory is enough to begin |
+
+## Red Flags
+
+- Agent stopping without self-audit
+- Complex edits, no growth-log update
+- Disk <15GB, no cleanup
+- Same mistake across sessions (learning not captured)
+
+## Verification
+
+- [ ] Self-audit clear
+- [ ] Growth-log updated (or dir absent)
+- [ ] Disk above threshold
+- [ ] No rationalization patterns
+
+## See Also
+
+- `shipping-and-launch` — Production readiness
+- `code-review-and-quality` — Code correctness
+- `doubt-driven-development` — Surface uncertainty
+- `self-audit` (anthropics/skills) — Standalone framework


### PR DESCRIPTION
## What this is

A session-end verification skill — asks "did this session produce transferable learning, or did we just ship and forget?" before allowing work to conclude.

Four-dimension self-audit before shipping:
1. **Completeness** — Did I answer everything the user asked?
2. **Consistency** — Did I contradict myself or the rules?
3. **Groundedness** — Did I show evidence, or just claim things work?
4. **Honesty** — Am I being honest about what wasn't done?

Then: Learning Capture → Disk Check → Rationalization Detection. Works with any project structure — adapt the capture paths to whatever you use (Notion, Obsidian, plain Markdown, nothing at all).

**No specific file system required.** The verification framework is the value; wire it to your own capture system.

## How it complements this repo

`agent-skills` has production-readiness and code-quality covered. It doesn't have *session-hygiene* — the discipline of verifying that work finished clean before moving on.

| Existing skill | Checks | This adds |
|---|---|---|
| `shipping-and-launch` | Deploy safety | Thinking completeness at session end |
| `code-review-and-quality` | Code correctness | Learning capture quality |
| `doubt-driven-development` | Surface uncertainty during work | Audit completeness after work |

Same verification-gate architecture (checklist + rationalizations + red flags), different dimension — thinking quality rather than code or deploy quality.

## Structure

- Self-Audit (C/C/G/H: Completeness, Consistency, Groundedness, Honesty) → Learning Capture → Disk Check → Rationalization Detection
- Common rationalizations with rebuttals
- Disk thresholds with concrete references

## Extracted from practice

Derived from a learning-capture workflow used across many sessions. Before verification, same debugging mistakes repeated. After, cross-session knowledge transfer became measurable.