### PR TITLE
docs(code-review): add dependency upgrade workflow to Dependency Discipline

### DIFF
--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -289,6 +289,16 @@ Part of code review is dependency review:
 
 **Rule:** Prefer standard library and existing utilities over new dependencies. Every dependency is a liability.
 
+**Upgrading an existing dependency** is a code change like any other, and the riskiest upgrades are the ones merged in bulk with a message like "bump deps." Review them with the same discipline:
+
+1. **Read the changelog, not just the version number.** Semver is a promise the maintainer may not have kept — a "patch" can carry a behavioral change. For a major bump, read the migration notes and find what breaks.
+2. **One dependency per change.** Upgrade and merge them individually (or in small related groups). When a bulk bump breaks the build, you've lost which package did it; a single-package change makes the cause obvious and the revert clean.
+3. **Let the tests decide.** The upgrade is verified by a green suite before *and* after, not by "it installed." If coverage around the dependency's behavior is thin, that gap is the real finding — add a test first.
+4. **Mind the transitive graph.** Most installed packages are ones nobody chose directly. Review the lockfile diff, not just `package.json`; a single direct bump can pull in dozens of indirect changes.
+5. **Keep the lockfile honest.** Commit it, review its diff, and never hand-edit it. The lockfile is the thing that actually pins what ships.
+
+For triaging `npm audit` findings and supply-chain risk (typosquatting, compromised maintainers), follow the `security-and-hardening` skill — this section covers the upgrade *workflow*, that one covers the security verdict.
+
 ## The Review Checklist
 
 ```markdown
@@ -352,6 +362,8 @@ Part of code review is dependency review:
 | "The tests pass, so it's good" | Tests are necessary but not sufficient. They don't catch architecture problems, security issues, or readability concerns. |
 | "The refactor makes it cleaner" | Relocating complexity isn't reducing it. If the reader still holds the same number of concepts, the structure didn't improve — look for the version where branches disappear. |
 | "It's only a small addition to this file" | Small diffs still push files past a healthy size and bolt branches onto unrelated flows. Judge the resulting structure, not the diff size. |
+| "It's just a version bump" | A bump is a behavior change you didn't write. Read the changelog; semver doesn't guarantee no breakage. |
+| "I'll upgrade everything in one PR to save time" | A bulk bump that breaks the build hides which package did it. One dependency per change keeps the cause and the revert clean. |
 
 ## Red Flags
 
@@ -367,6 +379,8 @@ Part of code review is dependency review:
 - A change that grows an already-large file instead of decomposing it
 - New conditionals scattered into unrelated code paths (a missing abstraction)
 - A bespoke helper that duplicates an existing canonical one, or feature logic placed in a shared module
+- A bulk "bump dependencies" PR with no changelog review and no per-package isolation
+- A lockfile change that's hand-edited, uncommitted, or merged without reviewing its diff
 
 ## Verification
 
@@ -377,5 +391,6 @@ After review is complete:
 - [ ] Tests pass
 - [ ] Build succeeds
 - [ ] The verification story is documented (what changed, how it was verified)
+- [ ] Dependency upgrades were reviewed against their changelog, isolated per package, and verified by a green suite with the lockfile diff reviewed
 
 **Presumptive blockers:** surface and propose the simpler design for each of these; escalate to Required only when the change actively makes structure worse: a refactor that relocates complexity instead of reducing it; a change that pushes a file past the size boundary with no decomposition; feature logic added to a shared module; a near-duplicate of an existing canonical helper; a silent fallback that hides an unclear invariant.


### PR DESCRIPTION
## What this adds

An upgrade workflow appended to the existing `## Dependency Discipline` section in `skills/code-review-and-quality/SKILL.md`. The current section is an *adopt* gate (five questions to ask before adding a dependency). This extension adds the missing *upgrade* path.

## The gap it fills

Once a dependency is in the project, the skill has no guidance on when or how to upgrade it — breaking-change triage, staged upgrade sequencing, lockfile discipline, and transitive-dependency risk. Teams regularly defer upgrades until they're painful; a concrete process reduces that drift.

## Non-duplication check

`security-and-hardening` already owns `npm audit` results and supply-chain hygiene. This section explicitly does **not** re-teach those topics — it cross-links the security skill instead and focuses only on the upgrade workflow itself (changelog triage, staged one-at-a-time upgrades, lockfile verification, before/after test gates).

## Checklist

- [x] Fully additive — extends an existing section, no edits to existing prose
- [x] `node scripts/validate-skills.js` → 0 errors, 0 warnings
- [x] All cross-refs resolve to existing skills
- [x] Touches only `skills/code-review-and-quality/SKILL.md`
- [x] Rationalization row, red flags, and verification checkbox added in host skill's style