### PR TITLE
docs: add optional quick-try link for browser-testing-with-devtools

### DIFF
--- a/skills/browser-testing-with-devtools/SKILL.md
+++ b/skills/browser-testing-with-devtools/SKILL.md
@@ -31,6 +31,11 @@ Before installing locally, you can try this skill in an OpenClaw/Hermes-style ag
 
 This provides a low-friction way to evaluate the browser-testing workflow before setting up Chrome DevTools MCP locally.
 
+
+### Installation
+
+Add the following to your project's `.mcp.json` or Claude Code settings:
+
 ```json
 {
   "mcpServers": {

--- a/skills/browser-testing-with-devtools/SKILL.md
+++ b/skills/browser-testing-with-devtools/SKILL.md
@@ -23,9 +23,13 @@ Use Chrome DevTools MCP to give your agent eyes into the browser. This bridges t
 
 ## Setting Up Chrome DevTools MCP
 
-### Installation
+### Quick Try (Optional)
 
-Add the following to your project's `.mcp.json` or Claude Code settings:
+Before installing locally, you can try this skill in an OpenClaw/Hermes-style agent:
+
+- [Try Browser Testing with DevTools in Telegram or WhatsApp](https://app.clawmama.run/skills/32szp2/hermes?utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_addyosmani_agent_skills_browser_devtools)
+
+This provides a low-friction way to evaluate the browser-testing workflow before setting up Chrome DevTools MCP locally.
 
 ```json
 {


### PR DESCRIPTION
Closes #341

Adds an optional Quick Try section linking to the hosted browser-testing experience.

Keeps the existing Installation section intact so users can still configure Chrome DevTools MCP locally.

This provides a low-friction way to evaluate the browser-testing workflow before local setup.