### PR TITLE
fix(evals): cover description vocabulary gaps

### DIFF
--- a/evals/cases/api-and-interface-design.json
+++ b/evals/cases/api-and-interface-design.json
@@ -21,7 +21,8 @@
         "owner": "debugging-and-error-recovery"
       },
       {
-        "prompt": "Make this landing page responsive on mobile"
+        "prompt": "Make this landing page responsive on mobile",
+        "owner": "frontend-ui-engineering"
       }
     ]
   },

--- a/evals/cases/frontend-ui-engineering.json
+++ b/evals/cases/frontend-ui-engineering.json
@@ -3,8 +3,16 @@
   "trigger": {
     "positive": [
       {
+        "prompt": "Make this page responsive and WCAG compliant",
+        "top_k": 1
+      },
+      {
         "prompt": "Build an accessible modal component with keyboard support",
         "top_k": 3
+      },
+      {
+        "prompt": "Make the pricing page accessible and responsive on mobile",
+        "top_k": 1
       },
       {
         "prompt": "Refactor the dashboard into reusable components with sane state management",

--- a/evals/cases/performance-optimization.json
+++ b/evals/cases/performance-optimization.json
@@ -3,8 +3,16 @@
   "trigger": {
     "positive": [
       {
+        "prompt": "Optimize this N+1 query",
+        "top_k": 1
+      },
+      {
         "prompt": "The dashboard takes eight seconds to load, profile it and fix the bottleneck",
         "top_k": 3
+      },
+      {
+        "prompt": "Profile these slow database queries and add the right indexes",
+        "top_k": 1
       },
       {
         "prompt": "The orders endpoint has a slow N+1 query pattern, profile it and fix the bottleneck",

--- a/skills/frontend-ui-engineering/SKILL.md
+++ b/skills/frontend-ui-engineering/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontend-ui-engineering
-description: Builds production-quality UIs. Use when building or modifying user-facing interfaces. Use when creating components, implementing layouts, managing state, or when the output needs to look and feel production-quality rather than AI-generated.
+description: Builds production-quality, accessible, responsive user-facing UIs. Use when building or modifying interfaces and pages, creating components, implementing layouts, meeting WCAG accessibility requirements, managing state, or when the output needs to look and feel production-quality rather than AI-generated.
 ---
 
 # Frontend UI Engineering

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-optimization
-description: Optimizes application performance. Use when performance requirements exist, when you suspect performance regressions, or when Core Web Vitals or load times need improvement. Use when profiling reveals bottlenecks that need fixing.
+description: Optimizes application performance across frontend, backend, queries, and databases. Use when performance requirements exist, when you suspect performance regressions, when Core Web Vitals or load times need improvement, when N+1 query patterns need fixing, or when profiling reveals bottlenecks.
 ---
 
 # Performance Optimization


### PR DESCRIPTION
## Summary

- Enrich `frontend-ui-engineering` and `performance-optimization` descriptions with the user vocabulary called out in #351.
- Restore stricter trigger coverage for responsive/WCAG page work and N+1/database query optimization.
- Add the deferred `frontend-ui-engineering` owner to the `api-and-interface-design` responsive landing page negative.

## Why

The deterministic trigger evals surfaced that fair user prompts could miss these skills because the frontmatter descriptions did not include vocabulary users actually say. This keeps the descriptions in the repo's what-then-Use-when format while making those routing cues explicit.

Fixes #351.

## Validation

- `node scripts/validate-skills.js`
- `node scripts/run-evals.js` -> 124 checks passed, 0 errors, 0 warnings; trigger rank-1 rate 86% (65/76)
