### PR TITLE
ci: label PRs that add a skill duplicating an open PR

### DIFF
--- a/.github/workflows/duplicate-skill-label.yml
+++ b/.github/workflows/duplicate-skill-label.yml
@@ -1,0 +1,100 @@
+name: Duplicate Skill Labeler
+
+# Flags PRs that add a skills/<name>/SKILL.md already added by another open PR
+# (name collisions only — see issue #315 and the scope decided in #313).
+#
+# Runs on pull_request_target so it can label fork PRs. This is safe ONLY
+# because the job never checks out or executes PR head code: it reads PR
+# metadata via the API and toggles a label. Do not add a checkout of the
+# fork code to this workflow.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: duplicate-skill-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-collisions:
+    name: Check for skill name collisions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compare added skills against other open PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const LABEL = 'duplicate';
+            const SKILL_RE = /^skills\/([^/]+)\/SKILL\.md$/;
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            const addedSkills = async (pull_number) => {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number, per_page: 100,
+              });
+              return files
+                .filter((f) => f.status === 'added')
+                .map((f) => SKILL_RE.exec(f.filename)?.[1])
+                .filter(Boolean);
+            };
+
+            const ours = new Set(await addedSkills(prNumber));
+            core.info(`PR #${prNumber} adds ${ours.size} skill(s): ${[...ours].join(', ') || '(none)'}`);
+
+            const collisions = [];
+            if (ours.size > 0) {
+              const openPRs = await github.paginate(github.rest.pulls.list, {
+                owner, repo, state: 'open', per_page: 100,
+              });
+              for (const pr of openPRs) {
+                if (pr.number === prNumber) continue;
+                const overlap = (await addedSkills(pr.number)).filter((name) => ours.has(name));
+                if (overlap.length > 0) {
+                  collisions.push({ number: pr.number, title: pr.title, url: pr.html_url, skills: overlap });
+                }
+              }
+            }
+
+            const currentLabels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const hasLabel = currentLabels.some((l) => l.name === LABEL);
+
+            if (collisions.length > 0) {
+              if (!hasLabel) {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: prNumber, labels: [LABEL],
+                });
+              }
+              core.summary.addHeading('Duplicate skill detected', 3);
+              core.summary.addRaw(
+                `This PR adds a \`skills/<name>/SKILL.md\` that another open PR also adds. ` +
+                `Per the [contributing pre-flight checks](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md#before-proposing-a-new-skill), ` +
+                `coordinate with the colliding PR instead of duplicating it.\n\n`
+              );
+              core.summary.addTable([
+                [{ data: 'Colliding PR', header: true }, { data: 'Skill(s)', header: true }],
+                ...collisions.map((c) => [
+                  `<a href="${c.url}">#${c.number} — ${c.title}</a>`,
+                  c.skills.map((s) => `<code>${s}</code>`).join(', '),
+                ]),
+              ]);
+              await core.summary.write();
+              core.notice(
+                `Labeled #${prNumber} '${LABEL}': collides with ` +
+                collisions.map((c) => `#${c.number} (${c.skills.join(', ')})`).join(', ')
+              );
+            } else if (hasLabel) {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: prNumber, name: LABEL,
+              }).catch((e) => { if (e.status !== 404) throw e; });
+              core.notice(`No remaining skill name collision — removed '${LABEL}' label from #${prNumber}.`);
+            } else {
+              core.info('No skill name collisions with other open PRs.');
+            }

--- a/.github/workflows/duplicate-skill-label.yml
+++ b/.github/workflows/duplicate-skill-label.yml
@@ -68,9 +68,21 @@ jobs:
 
             if (collisions.length > 0) {
               if (!hasLabel) {
-                await github.rest.issues.addLabels({
-                  owner, repo, issue_number: prNumber, labels: [LABEL],
-                });
+                // Self-heal if the default 'duplicate' label was deleted:
+                // create it (ignoring already-exists races), then retry once.
+                try {
+                  await github.rest.issues.addLabels({
+                    owner, repo, issue_number: prNumber, labels: [LABEL],
+                  });
+                } catch (e) {
+                  await github.rest.issues.createLabel({
+                    owner, repo, name: LABEL, color: 'cfd3d7',
+                    description: 'This issue or pull request already exists',
+                  }).catch((err) => { if (err.status !== 422) throw err; });
+                  await github.rest.issues.addLabels({
+                    owner, repo, issue_number: prNumber, labels: [LABEL],
+                  });
+                }
               }
               core.summary.addHeading('Duplicate skill detected', 3);
               core.summary.addRaw(
@@ -78,11 +90,12 @@ jobs:
                 `Per the [contributing pre-flight checks](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md#before-proposing-a-new-skill), ` +
                 `coordinate with the colliding PR instead of duplicating it.\n\n`
               );
+              const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
               core.summary.addTable([
                 [{ data: 'Colliding PR', header: true }, { data: 'Skill(s)', header: true }],
                 ...collisions.map((c) => [
-                  `<a href="${c.url}">#${c.number} — ${c.title}</a>`,
-                  c.skills.map((s) => `<code>${s}</code>`).join(', '),
+                  `<a href="${c.url}">#${c.number} — ${esc(c.title)}</a>`,
+                  c.skills.map((s) => `<code>${esc(s)}</code>`).join(', '),
                 ]),
               ]);
               await core.summary.write();


### PR DESCRIPTION
## Summary

Implements #315: a deterministic CI complement to the CONTRIBUTING pre-flight checks (#313). A new standalone workflow flags when a PR adds a `skills/<name>/SKILL.md` that another **open** PR also adds:

- On a name collision it adds the `duplicate` label and writes the colliding PR links + skill names to the job summary.
- When the collision clears (skill removed from the diff, or the colliding PR closes and this PR is pushed again), the label is removed.
- Non-blocking: the label is a reviewer signal, filterable via `is:pr is:open label:duplicate` — not a merge gate.

Closes #315

## Scope (as decided in #315 / #313)

- **Name-collision only** — no fuzzy/semantic matching. Same-topic/different-name proposals remain the job of the human/agent pre-flight checks.
- **Added files only** (`status: added`) — editing an existing `skills/<name>/SKILL.md` is a legitimate change and is never flagged.
- Not matched against already-merged skills.

## Security

Runs on `pull_request_target` so it can label fork PRs (a plain `pull_request` run has a read-only token there). This is safe because the job **never checks out or executes PR head code** — it only reads PR metadata via the API (`actions/github-script`) and toggles a label. A comment at the top of the workflow warns future editors not to add a checkout. Permissions are pinned to the minimum: `pull-requests: write`, `contents: read`. Per-PR `concurrency` group with `cancel-in-progress` avoids label races on rapid pushes.

## Evidence: dry-run against the live open-PR list

I ran the exact detection logic (same regex, same `status == "added"` filter) locally via `gh api` against all **89 currently open PRs**:

- 28 open PRs add at least one new `skills/<name>/SKILL.md`.
- Exactly **one true name collision** found: `skills/assistant/SKILL.md` is added by #181, #117, #62, and #61 — each of these would get the `duplicate` label with the others linked in its job summary.
- **No false positives**: same-topic-but-different-name clusters (e.g. #287 `llm-cost-optimization` vs #286 `evaluating-llm-output`, or the several accessibility proposals #261/#254) are correctly *not* flagged, matching the name-collision-only scope.

<details>
<summary>Dry-run output</summary>

```
Open PRs: 89

#335 adds: lightweight-design-analysis, software-design-principles
#331 adds: session-quality-gate
#326 adds: project-workflow
#311 adds: skill-builder-specialized-agents
#287 adds: llm-cost-optimization
#286 adds: evaluating-llm-output
#285 adds: reliable-agent-loops
#261 adds: accessibility-engineering
#254 adds: accessibility-testing-and-remediation, database-migrations-and-schema-design, llm-api-integration
#253 adds: harness-engineering
#250 adds: skill-router
#242 adds: slash-commands
#237 adds: handoff
#232 adds: agent-resilience-and-fuzzing
#224 adds: legacy-code-and-refactoring
#197 adds: workflow-tracker
#193 adds: vertical-slicing
#192 adds: ubiquitous-language
#181 adds: assistant
#171 adds: skill-design-patterns
#165 adds: browser-testing-with-real-sessions
#149 adds: ast-resilient-remediation, chaos-simulation-and-mocking, finops-mothballing-and-optimization, inter-agent-protocol-verification, semantic-paradigm-auditor
#129 adds: prompt-injection-defense
#117 adds: assistant
#115 adds: design-sprint
#62 adds: assistant
#61 adds: assistant, observability-and-monitoring
#52 adds: delegation-provenance

=== COLLISIONS (would be labeled 'duplicate') ===
skill "assistant": #181 <-> #117 <-> #62 <-> #61
```

</details>

Note: a `pull_request_target` workflow always runs the **base repo's** version, so it can't be exercised from a fork before merge — the dry-run above stands in for that. API cost is modest (one `listFiles` per open PR, only when the triggering PR actually adds a skill).

## Known limitations (by design / follow-ups)

- Event-driven: only the triggering PR is (un)labeled. The *older* colliding PR gets its label on its own next push. Likewise, if a colliding PR closes, the label on the survivor clears on its next `synchronize`. Re-evaluating all open PRs on `closed` events would fix this and can be a small follow-up if wanted.
- Relies on the default `duplicate` label existing (it does in GitHub repos by default, per the issue).

