### PR TITLE
fix: enable slash commands for GitHub Copilot CLI

### DIFF
--- a/docs/copilot-setup.md
+++ b/docs/copilot-setup.md
@@ -2,6 +2,30 @@
 
 ## Setup
 
+### Slash Commands (GitHub Copilot CLI)
+
+After installing the plugin, all 8 lifecycle slash commands are available natively in the GitHub Copilot CLI:
+
+| Command | What it does |
+| --- | --- |
+| `/spec` | Write a structured spec before coding |
+| `/plan` | Break work into small, ordered tasks |
+| `/build` | Implement the next task incrementally (add `auto` for full plan in one pass) |
+| `/test` | TDD workflow — red, green, refactor |
+| `/review` | Five-axis code review before merge |
+| `/webperf` | Web performance audit |
+| `/code-simplify` | Simplify code for clarity |
+| `/ship` | Pre-launch checklist and go/no-go |
+
+Install the plugin if you haven't already:
+
+```bash
+/plugin marketplace add addyosmani/agent-skills
+/plugin install agent-skills@addy-agent-skills
+```
+
+Then type `/spec`, `/plan`, and the other commands directly in any session. Type `/clear` to reload if you installed the plugin in a running session.
+
 ### Copilot Instructions
 
 Copilot supports creating agent skills using a `.github/skills`, `.claude/skills`, or `.agents/skills` directory in your repository.

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "agent-skills",
   "version": "1.0.0",
-  "description": "Production-grade engineering skills for AI coding agents."
+  "description": "Production-grade engineering skills for AI coding agents.",
+  "commands": ".claude/commands"
 }


### PR DESCRIPTION
## Problem

After installing `agent-skills` as a GitHub Copilot CLI plugin, the 8 lifecycle slash commands (`/spec`, `/plan`, `/build`, etc.) listed in the README do not work. Users see no commands registered when installing `agent-skills` using Copilot's marketplace.

## Root Cause

The `plugin.json` file was missing a `"commands"` field. Without it, GitHub Copilot CLI never discovers the command files. The `.claude/commands/*.md` files already existed with the correct content and format — they just weren't being pointed to.The commands were only wired up for Claude Code (via `.claude/commands/` auto-discovery) and Antigravity CLI (via `commands/*.toml` filesystem convention). Copilot CLI requires an explicit `"commands"` field in `plugin.json`.

## Fix

Add `"commands": ".claude/commands"` to `plugin.json`. This tells Copilot CLI to load the existing `.claude/commands/*.md` files as slash commands.

## Testing

Tested locally by modifying the installed plugin at `~/.copilot/installed-plugins/` and reloading the session. All 8 commands resolved correctly.