### PR TITLE
fix(skills): point shared references at GitHub URLs for npx installs (#361)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ The frontmatter fields above are required. The section anatomy is a recommended 
 - Don't create supporting files unless content exceeds 100 lines
 - Don't create an empty `scripts/` directory just to match another skill — add `scripts/` only when the skill includes runnable helpers
 - Don't put reference material inside skill directories — use `references/` instead
+- When a skill links to a shared checklist in `references/`, use the canonical GitHub URL (`https://github.com/addyosmani/agent-skills/blob/main/references/<file>.md`), not a bare relative path — per-skill `npx` installs do not include the repo-root `references/` folder ([#361](https://github.com/addyosmani/agent-skills/issues/361))
 
 ## Modifying Existing Skills
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ npx skills add addyosmani/agent-skills --skill interview-me              # requi
 npx skills add addyosmani/agent-skills --skill test-driven-development   # red-green-refactor, enforced
 ```
 
+> **Per-skill installs and shared checklists:** `npx skills add … --skill <name>` copies only that skill directory. Shared checklists live in the repo-root [`references/`](references/) folder and are not included. Skills link to those checklists via their GitHub URLs so the links still resolve; for offline/local copies of the checklists, install the full pack or clone the repo.
+
 Prefer a native integration? Pick your tool below.
 
 <details>

--- a/docs/skill-anatomy.md
+++ b/docs/skill-anatomy.md
@@ -143,6 +143,7 @@ When a skill ships runnable helpers under `scripts/`, each script follows these 
 - Skill files: `SKILL.md` (always uppercase)
 - Supporting files: `lowercase-hyphen-separated.md`
 - References: stored in `references/` at the project root, not inside skill directories
+- Links from a skill to a shared checklist should use the canonical GitHub URL (`https://github.com/addyosmani/agent-skills/blob/main/references/<file>.md`), not a bare relative path — per-skill installs do not include the repo-root `references/` folder
 
 ## Cross-Skill References
 

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -338,8 +338,8 @@ Part of code review is dependency review:
 ```
 ## See Also
 
-- For detailed security review guidance, see `references/security-checklist.md`
-- For performance review checks, see `references/performance-checklist.md`
+- For detailed security review guidance, see [references/security-checklist.md](https://github.com/addyosmani/agent-skills/blob/main/references/security-checklist.md)
+- For performance review checks, see [references/performance-checklist.md](https://github.com/addyosmani/agent-skills/blob/main/references/performance-checklist.md)
 
 ## Common Rationalizations
 

--- a/skills/doubt-driven-development/SKILL.md
+++ b/skills/doubt-driven-development/SKILL.md
@@ -43,7 +43,7 @@ If you doubt every keystroke, you ship nothing. The skill applies only to non-tr
 
 This skill is designed for the **main-session orchestrator**, where Step 3 (DOUBT, detailed below) can spawn a fresh-context reviewer.
 
-- **Do NOT add this skill to a persona's `skills:` frontmatter.** A persona that follows Step 3 would spawn another persona — the orchestration anti-pattern explicitly forbidden by `references/orchestration-patterns.md` ("personas do not invoke other personas").
+- **Do NOT add this skill to a persona's `skills:` frontmatter.** A persona that follows Step 3 would spawn another persona — the orchestration anti-pattern explicitly forbidden by [references/orchestration-patterns.md](https://github.com/addyosmani/agent-skills/blob/main/references/orchestration-patterns.md) ("personas do not invoke other personas").
 - **If you find yourself applying this skill from inside a subagent context** (where Claude Code prevents nested subagent spawn): the preferred path is to surface to the user that doubt-driven cannot run nested and let the main session handle it. As a last resort only, a degraded self-questioning fallback exists — rewrite ARTIFACT + CONTRACT as a fresh self-prompt with a hard mental separator from your prior reasoning, and walk Steps 1–5. This is **not fresh-context review** (you carry your own context with you), so flag the result as degraded and prefer escalation whenever the user is reachable.
 
 ## The Process
@@ -226,7 +226,7 @@ If 3 cycles is "obviously insufficient" because the artifact is large: the artif
 - **`source-driven-development`**: SDD verifies *facts about frameworks* against official docs. Doubt-driven verifies *your reasoning about the artifact*. SDD checks the API exists; doubt-driven checks you used it correctly under the contract.
 - **`test-driven-development`**: TDD's RED step is doubt made concrete — a failing test is a disproof attempt. When TDD applies, that failing test *is* the doubt step for behavioral claims.
 - **`debugging-and-error-recovery`**: when the reviewer surfaces a real failure mode, drop into the debugging skill to localize and fix.
-- **Repo orchestration rules** (`references/orchestration-patterns.md`): this skill orchestrates from the main session. A persona calling another persona is anti-pattern B — see Loading Constraints above.
+- **Repo orchestration rules** ([references/orchestration-patterns.md](https://github.com/addyosmani/agent-skills/blob/main/references/orchestration-patterns.md)): this skill orchestrates from the main session. A persona calling another persona is anti-pattern B — see Loading Constraints above.
 
 ## Verification
 

--- a/skills/frontend-ui-engineering/SKILL.md
+++ b/skills/frontend-ui-engineering/SKILL.md
@@ -294,7 +294,7 @@ function useToggleTask() {
 
 ## See Also
 
-For detailed accessibility requirements and testing tools, see `references/accessibility-checklist.md`.
+For detailed accessibility requirements and testing tools, see [references/accessibility-checklist.md](https://github.com/addyosmani/agent-skills/blob/main/references/accessibility-checklist.md).
 
 ## Common Rationalizations
 

--- a/skills/incremental-implementation/SKILL.md
+++ b/skills/incremental-implementation/SKILL.md
@@ -246,4 +246,4 @@ After completing all increments for a task:
 
 ## See Also
 
-Per-increment verification is the local check. Before declaring a task done, apply the project-wide Definition of Done as the final gate, the standing bar every increment clears regardless of the task. See `references/definition-of-done.md`.
+Per-increment verification is the local check. Before declaring a task done, apply the project-wide Definition of Done as the final gate, the standing bar every increment clears regardless of the task. See [references/definition-of-done.md](https://github.com/addyosmani/agent-skills/blob/main/references/definition-of-done.md).

--- a/skills/observability-and-instrumentation/SKILL.md
+++ b/skills/observability-and-instrumentation/SKILL.md
@@ -200,4 +200,4 @@ After instrumenting a feature, confirm:
 - [ ] Every new alert is symptom-based, has a runbook link, and was test-fired once
 - [ ] An induced failure in staging was located via telemetry alone, without reading the source
 
-For the at-a-glance version of this list, including the pre-launch instrumentation gate, see `references/observability-checklist.md`.
+For the at-a-glance version of this list, including the pre-launch instrumentation gate, see [references/observability-checklist.md](https://github.com/addyosmani/agent-skills/blob/main/references/observability-checklist.md).

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -314,7 +314,7 @@ npx lhci autorun
 
 ## See Also
 
-For detailed performance checklists, optimization commands, and anti-pattern reference, see `references/performance-checklist.md`.
+For detailed performance checklists, optimization commands, and anti-pattern reference, see [references/performance-checklist.md](https://github.com/addyosmani/agent-skills/blob/main/references/performance-checklist.md).
 
 
 ## Common Rationalizations

--- a/skills/planning-and-task-breakdown/SKILL.md
+++ b/skills/planning-and-task-breakdown/SKILL.md
@@ -231,4 +231,4 @@ Before starting implementation, confirm:
 
 ## See Also
 
-Acceptance criteria are per-task and answer "did we build the right thing?". They sit on top of the project-wide Definition of Done, the standing bar every task clears before it counts as done. See `references/definition-of-done.md`.
+Acceptance criteria are per-task and answer "did we build the right thing?". They sit on top of the project-wide Definition of Done, the standing bar every task clears before it counts as done. See [references/definition-of-done.md](https://github.com/addyosmani/agent-skills/blob/main/references/definition-of-done.md).

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -74,7 +74,7 @@ If you can't name the trust boundaries for a feature, you're not ready to secure
 
 ## OWASP Top 10 Prevention Patterns
 
-These are prevention patterns, not a ranking. For the 2021 ordering, see the quick-reference table in `references/security-checklist.md`.
+These are prevention patterns, not a ranking. For the 2021 ordering, see the quick-reference table in [references/security-checklist.md](https://github.com/addyosmani/agent-skills/blob/main/references/security-checklist.md).
 
 ### Injection (SQL, NoSQL, OS Command)
 
@@ -419,7 +419,7 @@ container.textContent = await llm.reply(userMessage);
 ```
 ## See Also
 
-For detailed security checklists and pre-commit verification steps, see `references/security-checklist.md`.
+For detailed security checklists and pre-commit verification steps, see [references/security-checklist.md](https://github.com/addyosmani/agent-skills/blob/main/references/security-checklist.md).
 
 ## Common Rationalizations
 

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -265,10 +265,10 @@ Every deployment needs a rollback plan before it happens:
 ```
 ## See Also
 
-- For the project-wide Definition of Done that every change must clear before this checklist, see `references/definition-of-done.md`
-- For security pre-launch checks, see `references/security-checklist.md`
-- For performance pre-launch checklist, see `references/performance-checklist.md`
-- For accessibility verification before launch, see `references/accessibility-checklist.md`
+- For the project-wide Definition of Done that every change must clear before this checklist, see [references/definition-of-done.md](https://github.com/addyosmani/agent-skills/blob/main/references/definition-of-done.md)
+- For security pre-launch checks, see [references/security-checklist.md](https://github.com/addyosmani/agent-skills/blob/main/references/security-checklist.md)
+- For performance pre-launch checklist, see [references/performance-checklist.md](https://github.com/addyosmani/agent-skills/blob/main/references/performance-checklist.md)
+- For accessibility verification before launch, see [references/accessibility-checklist.md](https://github.com/addyosmani/agent-skills/blob/main/references/accessibility-checklist.md)
 
 ## Common Rationalizations
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -344,7 +344,7 @@ This separation ensures the test is written without knowledge of the fix, making
 
 ## See Also
 
-For detailed testing patterns, examples, and anti-patterns across frameworks, see `references/testing-patterns.md`.
+For detailed testing patterns, examples, and anti-patterns across frameworks, see [references/testing-patterns.md](https://github.com/addyosmani/agent-skills/blob/main/references/testing-patterns.md).
 
 ## Common Rationalizations
 

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -110,7 +110,7 @@ Your job is surgical precision, not unsolicited renovation.
 
 Every skill includes a verification step. A task is not complete until verification passes. "Seems right" is never sufficient — there must be evidence (passing tests, build output, runtime data).
 
-Per-skill verification is the local check. The project-wide bar that applies to *every* change, regardless of which skill is active, is the Definition of Done: tests pass, no regressions, behavior verified at runtime, docs updated. See `references/definition-of-done.md`. It complements each task's acceptance criteria rather than replacing them.
+Per-skill verification is the local check. The project-wide bar that applies to *every* change, regardless of which skill is active, is the Definition of Done: tests pass, no regressions, behavior verified at runtime, docs updated. See [references/definition-of-done.md](https://github.com/addyosmani/agent-skills/blob/main/references/definition-of-done.md). It complements each task's acceptance criteria rather than replacing them.
 
 ## Failure Modes to Avoid
 


### PR DESCRIPTION
## Summary
Per-skill `npx skills add … --skill <name>` installs only that skill directory, so relative links like `` `references/definition-of-done.md` `` resolve to nothing. This switches the 17 shared-checklist mentions across 11 skills to canonical GitHub blob URLs, and documents the convention so future skills stay portable under both whole-repo and per-skill installs.

Fixes #361. Implements the approach suggested by @nucliweb on that issue (and addresses the portability concern raised in #329 without duplicating checklists into each skill).

## Problem
`planning-and-task-breakdown` (and 10 other skills) point at repo-root checklists via a bare relative path:

```markdown
See `references/definition-of-done.md`.
```

That path only exists when the full repo is present (Claude Code marketplace plugin, whole-repo clone). Under `npx skills add addyosmani/agent-skills --skill planning-and-task-breakdown`, the sibling `references/` folder is never copied, so the link is dead. The skill still runs — these are See Also deep-dives — but the checklist is unreachable.

## Solution
- Replace every `` `references/<file>.md` `` mention in `skills/*/SKILL.md` with a markdown link to `https://github.com/addyosmani/agent-skills/blob/main/references/<file>.md` (11 skills, 17 links).
- Note the per-skill install gap in the README Quick Start next to the `--skill` examples.
- Codify the URL convention in `CONTRIBUTING.md` and `docs/skill-anatomy.md` so new skills don't reintroduce relative paths.

Whole-repo installs keep working: the URLs resolve either way, and the checklists remain unduplicated at the repo root.

## Out of scope
- Did not colocate or copy `references/` under each skill (would fight the no-duplication rule in CONTRIBUTING).
- Did not change the third-party `npx skills` installer.
- Did not touch open PRs that already cover adjacent work (#201 local-reference audit, #358 description vocabulary, draft #228 SessionStart quoting).

## Test plan
- [x] `node scripts/validate-skills.js` — 24 skills, 0 errors, 0 warnings
- [x] `bash hooks/session-start-test.sh` — `session-start JSON payload OK` (meta-skill content changed)
- [x] `rg '\`references/' skills/ --glob '**/SKILL.md'` — no remaining relative checklist refs
- [ ] CI to confirm the rest

## Related
- #361 — original report (npx packs only `skills/`)
- #329 — layout/portability question that motivated documenting the pack-level `references/` design
- Comment on #361 by @nucliweb — proposed the URL approach this PR implements

Made with [Cursor](https://cursor.com)