### PR TITLE
feat: jq-free JSON fallback + savings tracking for sdd-cache

### DIFF
--- a/hooks/SDD-CACHE.md
+++ b/hooks/SDD-CACHE.md
@@ -151,6 +151,16 @@ mkdir -p .claude/sdd-cache && touch .claude/sdd-cache/.debug
 
 The log captures URL, detected `tool_response` shape, HEAD status, and why each invocation hit or missed. Useful when a cache miss looks unexpected (typically: the origin stopped emitting validators).
 
+## Savings tracking
+
+Every cache hit appends to `.claude/sdd-cache/.stats.json` — `{hits, bytes_saved, since, last_hit}`. View a summary with:
+
+```bash
+bash hooks/sdd-cache-stats.sh
+```
+
+`bytes_saved` is the size of cached content served in place of a fresh `WebFetch`; the script estimates tokens saved at ~4 bytes/token. This only counts hits this hook intercepted — it says nothing about Anthropic's own server-side prompt cache, which isn't visible to a hook.
+
 ## Known limitations
 
 - **Body is prompt-shaped.** A hit returns the earlier agent's reading of the page, with the original prompt surfaced so the current agent can decide whether it applies. If it doesn't, delete the file under `.claude/sdd-cache/` to force a re-fetch.
@@ -161,7 +171,9 @@ The log captures URL, detected `tool_response` shape, HEAD status, and why each 
 
 ## Requirements
 
-- `jq`
+- One of `jq`, `python3`, or `node` (auto-detected, in that preference order — see `hooks/lib/jsonutil.sh`)
 - `curl`
 - `shasum` or `sha256sum` (auto-detected)
 - Bash 3.2+
+
+If none of `jq`/`python3`/`node` is on `PATH`, both hooks bypass silently and `WebFetch` runs uncached — the same graceful-degradation behavior as a missing `curl`.

--- a/hooks/lib/jsonutil.sh
+++ b/hooks/lib/jsonutil.sh
@@ -1,0 +1,295 @@
+#!/bin/bash
+# jsonutil.sh — shared JSON helpers for the sdd-cache hooks.
+#
+# jq is preferred but not guaranteed to be installed. Falls back to python3,
+# then node. If none of the three exist, callers should bypass caching
+# entirely (source this file and check `$JSON_TOOL` for "none").
+#
+# All helpers pass values through environment variables, never shell/string
+# interpolation — cached doc content can contain backticks, quotes, and
+# newlines, and each backend's native JSON encoder handles that correctly.
+
+detect_json_tool() {
+  if command -v jq >/dev/null 2>&1; then
+    echo jq
+  elif command -v python3 >/dev/null 2>&1; then
+    echo python3
+  elif command -v node >/dev/null 2>&1; then
+    echo node
+  else
+    echo none
+  fi
+}
+
+JSON_TOOL="${JSON_TOOL:-$(detect_json_tool)}"
+
+# jf_get_file FILE PATH DEFAULT
+# PATH is a single top-level key (this codebase never nests more than one
+# level deep for the fields it reads from cache/stats files).
+jf_get_file() {
+  local file="$1" path="$2" default="${3:-}"
+  [ -f "$file" ] || { printf '%s' "$default"; return 0; }
+  case "$JSON_TOOL" in
+    jq)
+      jq -r --arg d "$default" ".${path} // \$d" "$file" 2>/dev/null
+      ;;
+    python3)
+      JF_FILE="$file" JF_PATH="$path" JF_DEFAULT="$default" python3 -c '
+import json, os
+try:
+    with open(os.environ["JF_FILE"]) as fh:
+        d = json.load(fh)
+except Exception:
+    d = {}
+v = d.get(os.environ["JF_PATH"])
+print(v if v is not None and v != "" else os.environ["JF_DEFAULT"])
+' 2>/dev/null
+      ;;
+    node)
+      JF_FILE="$file" JF_PATH="$path" JF_DEFAULT="$default" node -e '
+const fs = require("fs");
+let d = {};
+try { d = JSON.parse(fs.readFileSync(process.env.JF_FILE, "utf8")); } catch (e) {}
+const v = d[process.env.JF_PATH];
+console.log(v !== undefined && v !== null && v !== "" ? v : process.env.JF_DEFAULT);
+' 2>/dev/null
+      ;;
+    *)
+      printf '%s' "$default"
+      ;;
+  esac
+}
+
+# jf_get_input_field JSON PATH DEFAULT
+# PATH is "a.b" (max two levels — matches tool_input.url / tool_input.prompt).
+jf_get_input_field() {
+  local json="$1" path="$2" default="${3:-}"
+  case "$JSON_TOOL" in
+    jq)
+      printf '%s' "$json" | jq -r --arg d "$default" ".${path} // \$d" 2>/dev/null
+      ;;
+    python3)
+      JF_PATH="$path" JF_DEFAULT="$default" python3 -c '
+import json, os, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    d = {}
+cur = d
+for p in os.environ["JF_PATH"].split("."):
+    cur = cur.get(p) if isinstance(cur, dict) else None
+    if cur is None:
+        break
+print(cur if cur is not None and cur != "" else os.environ["JF_DEFAULT"])
+' <<<"$json" 2>/dev/null
+      ;;
+    node)
+      JF_PATH="$path" JF_DEFAULT="$default" node -e '
+let d = {};
+try { d = JSON.parse(require("fs").readFileSync(0, "utf8")); } catch (e) {}
+let cur = d;
+for (const p of process.env.JF_PATH.split(".")) {
+  cur = (cur && typeof cur === "object") ? cur[p] : undefined;
+  if (cur === undefined || cur === null) break;
+}
+console.log(cur !== undefined && cur !== null && cur !== "" ? cur : process.env.JF_DEFAULT);
+' <<<"$json" 2>/dev/null
+      ;;
+    *)
+      printf '%s' "$default"
+      ;;
+  esac
+}
+
+# jf_response_type JSON -> "object" | "string" | "other"
+jf_response_type() {
+  local json="$1"
+  case "$JSON_TOOL" in
+    jq)
+      printf '%s' "$json" | jq -r '.tool_response | type' 2>/dev/null
+      ;;
+    python3)
+      python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    d = {}
+v = d.get("tool_response")
+print("object" if isinstance(v, dict) else "string" if isinstance(v, str) else "other")
+' <<<"$json" 2>/dev/null
+      ;;
+    node)
+      node -e '
+let d = {};
+try { d = JSON.parse(require("fs").readFileSync(0, "utf8")); } catch (e) {}
+const v = d.tool_response;
+console.log(typeof v === "object" && v !== null ? "object" : typeof v === "string" ? "string" : "other");
+' <<<"$json" 2>/dev/null
+      ;;
+    *)
+      echo other
+      ;;
+  esac
+}
+
+# jf_extract_response_content JSON -> first non-empty of the known content
+# fields on tool_response (object case), or tool_response itself (string case).
+jf_extract_response_content() {
+  local json="$1"
+  case "$JSON_TOOL" in
+    jq)
+      printf '%s' "$json" | jq -r '
+        if (.tool_response | type) == "object" then
+          (.tool_response.result // .tool_response.output // .tool_response.text // .tool_response.content // .tool_response.body // empty)
+        elif (.tool_response | type) == "string" then
+          .tool_response
+        else
+          empty
+        end
+      ' 2>/dev/null
+      ;;
+    python3)
+      python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    d = {}
+tr = d.get("tool_response")
+out = ""
+if isinstance(tr, dict):
+    for k in ("result", "output", "text", "content", "body"):
+        v = tr.get(k)
+        if v:
+            out = v
+            break
+elif isinstance(tr, str):
+    out = tr
+print(out)
+' <<<"$json" 2>/dev/null
+      ;;
+    node)
+      node -e '
+let d = {};
+try { d = JSON.parse(require("fs").readFileSync(0, "utf8")); } catch (e) {}
+const tr = d.tool_response;
+let out = "";
+if (tr && typeof tr === "object") {
+  for (const k of ["result", "output", "text", "content", "body"]) {
+    if (tr[k]) { out = tr[k]; break; }
+  }
+} else if (typeof tr === "string") {
+  out = tr;
+}
+console.log(out);
+' <<<"$json" 2>/dev/null
+      ;;
+    *)
+      printf ''
+      ;;
+  esac
+}
+
+# jf_write_cache_file FILE URL PROMPT ETAG LAST_MODIFIED CONTENT FETCHED_AT
+# CONTENT/PROMPT come through env vars so arbitrary bytes (backticks, quotes,
+# newlines) never touch shell interpolation.
+jf_write_cache_file() {
+  local file="$1"
+  export JF_URL="$2" JF_PROMPT="$3" JF_ETAG="$4" JF_LAST_MOD="$5" JF_CONTENT="$6" JF_FETCHED_AT="$7"
+  local tmp="${file}.$$.tmp"
+  case "$JSON_TOOL" in
+    jq)
+      jq -n \
+        --arg url "$JF_URL" --arg prompt "$JF_PROMPT" --arg etag "$JF_ETAG" \
+        --arg last_modified "$JF_LAST_MOD" --arg content "$JF_CONTENT" \
+        --argjson fetched_at "$JF_FETCHED_AT" \
+        '{url: $url, prompt: $prompt, etag: $etag, last_modified: $last_modified, content: $content, fetched_at: $fetched_at}' \
+        >"$tmp" 2>/dev/null
+      ;;
+    python3)
+      python3 -c '
+import json, os
+out = {
+    "url": os.environ["JF_URL"],
+    "prompt": os.environ["JF_PROMPT"],
+    "etag": os.environ["JF_ETAG"],
+    "last_modified": os.environ["JF_LAST_MOD"],
+    "content": os.environ["JF_CONTENT"],
+    "fetched_at": int(os.environ["JF_FETCHED_AT"]),
+}
+print(json.dumps(out))
+' >"$tmp" 2>/dev/null
+      ;;
+    node)
+      node -e '
+const out = {
+  url: process.env.JF_URL,
+  prompt: process.env.JF_PROMPT,
+  etag: process.env.JF_ETAG,
+  last_modified: process.env.JF_LAST_MOD,
+  content: process.env.JF_CONTENT,
+  fetched_at: parseInt(process.env.JF_FETCHED_AT, 10),
+};
+console.log(JSON.stringify(out));
+' >"$tmp" 2>/dev/null
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  if [ -s "$tmp" ]; then
+    mv "$tmp" "$file"
+  else
+    rm -f "$tmp"
+    return 1
+  fi
+}
+
+# jf_write_stats_file FILE HITS BYTES_SAVED SINCE LAST_HIT
+jf_write_stats_file() {
+  local file="$1"
+  export JF_HITS="$2" JF_BYTES_SAVED="$3" JF_SINCE="$4" JF_LAST_HIT="$5"
+  local tmp="${file}.$$.tmp"
+  case "$JSON_TOOL" in
+    jq)
+      jq -n \
+        --argjson hits "$JF_HITS" --argjson bytes_saved "$JF_BYTES_SAVED" \
+        --argjson since "$JF_SINCE" --argjson last_hit "$JF_LAST_HIT" \
+        '{hits: $hits, bytes_saved: $bytes_saved, since: $since, last_hit: $last_hit}' \
+        >"$tmp" 2>/dev/null
+      ;;
+    python3)
+      python3 -c '
+import json, os
+out = {
+    "hits": int(os.environ["JF_HITS"]),
+    "bytes_saved": int(os.environ["JF_BYTES_SAVED"]),
+    "since": int(os.environ["JF_SINCE"]),
+    "last_hit": int(os.environ["JF_LAST_HIT"]),
+}
+print(json.dumps(out))
+' >"$tmp" 2>/dev/null
+      ;;
+    node)
+      node -e '
+const out = {
+  hits: parseInt(process.env.JF_HITS, 10),
+  bytes_saved: parseInt(process.env.JF_BYTES_SAVED, 10),
+  since: parseInt(process.env.JF_SINCE, 10),
+  last_hit: parseInt(process.env.JF_LAST_HIT, 10),
+};
+console.log(JSON.stringify(out));
+' >"$tmp" 2>/dev/null
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  if [ -s "$tmp" ]; then
+    mv "$tmp" "$file"
+  else
+    rm -f "$tmp"
+    return 1
+  fi
+}

--- a/hooks/sdd-cache-post.sh
+++ b/hooks/sdd-cache-post.sh
@@ -9,13 +9,18 @@
 # key) so a future cache hit can show what question produced the cached
 # reading. Entries without ETag or Last-Modified are not cached.
 #
-# Dependencies: jq, curl, shasum (or sha256sum).
+# Dependencies: curl, shasum (or sha256sum), and one JSON tool (jq preferred,
+# falling back to python3, then node — see lib/jsonutil.sh).
 
 set -euo pipefail
 
-command -v jq   >/dev/null 2>&1 || exit 0
 command -v curl >/dev/null 2>&1 || exit 0
 command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/jsonutil.sh
+source "$SCRIPT_DIR/lib/jsonutil.sh"
+[ "$JSON_TOOL" != "none" ] || exit 0
 
 if [ -t 0 ]; then INPUT="{}"; else INPUT=$(cat); fi
 
@@ -29,33 +34,20 @@ dbg() {
 }
 dbg "fired, input=$(printf '%s' "$INPUT" | head -c 400)"
 
-URL=$(printf '%s'    "$INPUT" | jq -r '.tool_input.url    // empty' 2>/dev/null || true)
-PROMPT=$(printf '%s' "$INPUT" | jq -r '.tool_input.prompt // empty' 2>/dev/null || true)
+URL=$(jf_get_input_field "$INPUT" "tool_input.url" "")
+PROMPT=$(jf_get_input_field "$INPUT" "tool_input.prompt" "")
 if [ -z "$URL" ]; then dbg "no url in tool_input, exit"; exit 0; fi
 dbg "url=$URL prompt=$(printf '%s' "$PROMPT" | head -c 80)"
 
 # WebFetch tool_response shape (Claude Code as of 2026-04): an object with
 # keys bytes, code, codeText, durationMs, result, url — content lives at
 # .result. The other keys (.output / .text / .content / .body) are kept as
-# defensive fallbacks in case the shape changes; jq returns empty if none
-# match. The string branch handles older/custom integrations.
-TOOL_RESPONSE_TYPE=$(printf '%s' "$INPUT" | jq -r '.tool_response | type' 2>/dev/null || echo "unknown")
-dbg "tool_response type=$TOOL_RESPONSE_TYPE keys=$(printf '%s' "$INPUT" | jq -r 'try (.tool_response | keys | join(",")) catch "n/a"' 2>/dev/null)"
+# defensive fallbacks in case the shape changes; the extractor returns empty
+# if none match. The string branch handles older/custom integrations.
+TOOL_RESPONSE_TYPE=$(jf_response_type "$INPUT")
+dbg "tool_response type=$TOOL_RESPONSE_TYPE"
 
-CONTENT=$(printf '%s' "$INPUT" | jq -r '
-  if (.tool_response | type) == "object" then
-    (.tool_response.result
-     // .tool_response.output
-     // .tool_response.text
-     // .tool_response.content
-     // .tool_response.body
-     // empty)
-  elif (.tool_response | type) == "string" then
-    .tool_response
-  else
-    empty
-  end
-' 2>/dev/null || true)
+CONTENT=$(jf_extract_response_content "$INPUT")
 
 if [ -z "$CONTENT" ]; then
   dbg "could not extract content from tool_response, exit (shape unknown)"
@@ -114,22 +106,10 @@ fi
 
 NOW=$(date +%s)
 
-TMP="${CACHE_FILE}.$$.tmp"
-if jq -n \
-  --arg url           "$URL" \
-  --arg prompt        "$PROMPT" \
-  --arg etag          "$ETAG" \
-  --arg last_modified "$LAST_MOD" \
-  --arg content       "$CONTENT" \
-  --argjson fetched_at "$NOW" \
-  '{url: $url, prompt: $prompt, etag: $etag, last_modified: $last_modified, content: $content, fetched_at: $fetched_at}' \
-  > "$TMP"
-then
-  mv "$TMP" "$CACHE_FILE"
+if jf_write_cache_file "$CACHE_FILE" "$URL" "$PROMPT" "$ETAG" "$LAST_MOD" "$CONTENT" "$NOW"; then
   dbg "wrote cache file $CACHE_FILE"
 else
-  rm -f "$TMP"
-  dbg "jq failed, temp cleaned"
+  dbg "$JSON_TOOL failed to write cache file"
 fi
 
 exit 0

--- a/hooks/sdd-cache-pre.sh
+++ b/hooks/sdd-cache-pre.sh
@@ -13,14 +13,19 @@
 # so the key is URL-only and the original prompt is surfaced in the hit
 # message so the next agent can tell if the earlier reading still applies.
 #
-# Dependencies: jq, curl, shasum (or sha256sum).
+# Dependencies: curl, shasum (or sha256sum), and one JSON tool (jq preferred,
+# falling back to python3, then node — see lib/jsonutil.sh).
 
 set -euo pipefail
 
 # Graceful degradation: if any dependency is missing, let the fetch through.
-command -v jq   >/dev/null 2>&1 || exit 0
 command -v curl >/dev/null 2>&1 || exit 0
 command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 || exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/jsonutil.sh
+source "$SCRIPT_DIR/lib/jsonutil.sh"
+[ "$JSON_TOOL" != "none" ] || exit 0
 
 if [ -t 0 ]; then INPUT="{}"; else INPUT=$(cat); fi
 
@@ -34,7 +39,7 @@ dbg() {
 }
 dbg "fired"
 
-URL=$(printf '%s' "$INPUT" | jq -r '.tool_input.url // empty' 2>/dev/null || true)
+URL=$(jf_get_input_field "$INPUT" "tool_input.url" "")
 if [ -z "$URL" ]; then dbg "no url in tool_input, exit"; exit 0; fi
 dbg "url=$URL"
 
@@ -53,10 +58,10 @@ CACHE_FILE="$CACHE_DIR/$(hash_key "$URL").json"
 if [ ! -f "$CACHE_FILE" ]; then dbg "no cache file at $CACHE_FILE, exit"; exit 0; fi
 dbg "cache file exists: $CACHE_FILE"
 
-FETCHED_AT=$(jq -r '.fetched_at // 0' "$CACHE_FILE" 2>/dev/null || echo 0)
-ORIGINAL_PROMPT=$(jq -r '.prompt // empty' "$CACHE_FILE" 2>/dev/null || true)
-ETAG=$(jq -r '.etag // empty' "$CACHE_FILE" 2>/dev/null || true)
-LAST_MOD=$(jq -r '.last_modified // empty' "$CACHE_FILE" 2>/dev/null || true)
+FETCHED_AT=$(jf_get_file "$CACHE_FILE" "fetched_at" "0")
+ORIGINAL_PROMPT=$(jf_get_file "$CACHE_FILE" "prompt" "")
+ETAG=$(jf_get_file "$CACHE_FILE" "etag" "")
+LAST_MOD=$(jf_get_file "$CACHE_FILE" "last_modified" "")
 
 # No validator means we cannot verify freshness — never serve from cache.
 if [ -z "$ETAG" ] && [ -z "$LAST_MOD" ]; then
@@ -80,9 +85,24 @@ if [ "$STATUS" != "304" ]; then
 fi
 
 # Server confirmed content unchanged. Serve cached copy to the agent.
-CONTENT=$(jq -r '.content // empty' "$CACHE_FILE" 2>/dev/null || true)
+CONTENT=$(jf_get_file "$CACHE_FILE" "content" "")
 if [ -z "$CONTENT" ]; then dbg "cache file has empty content field, bypass"; exit 0; fi
 dbg "cache HIT, blocking WebFetch with ${#CONTENT} bytes of cached content"
+
+# Record savings: a hit means WebFetch's fetch+model-postprocess round trip
+# was skipped entirely. Bytes served from cache approximate the input tokens
+# that avoided re-processing (~4 bytes/token for English prose). Best-effort:
+# a failed stats update never blocks serving the cached content.
+record_stat() {
+  local stats_file="$CACHE_DIR/.stats.json" bytes="${#CONTENT}" now hits bytes_saved since
+  now=$(date +%s)
+  hits=$(jf_get_file "$stats_file" "hits" "0")
+  bytes_saved=$(jf_get_file "$stats_file" "bytes_saved" "0")
+  since=$(jf_get_file "$stats_file" "since" "")
+  [ -n "$since" ] || since="$now"
+  jf_write_stats_file "$stats_file" "$((hits + 1))" "$((bytes_saved + bytes))" "$since" "$now"
+}
+record_stat 2>/dev/null || true
 
 VERIFIED_AT_ISO=$(date -u -r "$FETCHED_AT" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
               || date -u -d "@$FETCHED_AT" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \

--- a/hooks/sdd-cache-stats.sh
+++ b/hooks/sdd-cache-stats.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# sdd-cache-stats.sh — print accumulated sdd-cache savings.
+#
+# Reads .claude/sdd-cache/.stats.json (written by sdd-cache-pre.sh on every
+# cache hit) and prints hit count + estimated tokens saved since first use.
+#
+# Usage: bash hooks/sdd-cache-stats.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/jsonutil.sh
+source "$SCRIPT_DIR/lib/jsonutil.sh"
+if [ "$JSON_TOOL" = "none" ]; then
+  echo "No JSON tool available (need jq, python3, or node)."
+  exit 1
+fi
+
+CACHE_DIR="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
+STATS_FILE="$CACHE_DIR/.stats.json"
+
+if [ ! -f "$STATS_FILE" ]; then
+  echo "No cache hits recorded yet ($STATS_FILE not found)."
+  exit 0
+fi
+
+HITS=$(jf_get_file "$STATS_FILE" "hits" "0")
+BYTES_SAVED=$(jf_get_file "$STATS_FILE" "bytes_saved" "0")
+SINCE=$(jf_get_file "$STATS_FILE" "since" "")
+LAST_HIT=$(jf_get_file "$STATS_FILE" "last_hit" "")
+
+# ~4 bytes/token for English prose — a rough estimate, not an exact count.
+TOKENS_SAVED=$((BYTES_SAVED / 4))
+
+fmt_date() {
+  date -u -r "$1" +"%Y-%m-%d %H:%M UTC" 2>/dev/null || date -u -d "@$1" +"%Y-%m-%d %H:%M UTC" 2>/dev/null || echo "unknown"
+}
+
+echo "sdd-cache savings"
+echo "-----------------"
+echo "Cache hits:            $HITS"
+echo "Bytes served from cache: $BYTES_SAVED"
+echo "Estimated tokens saved: ~$TOKENS_SAVED (at ~4 bytes/token)"
+[ -n "$SINCE" ]    && echo "Tracking since:        $(fmt_date "$SINCE")"
+[ -n "$LAST_HIT" ] && echo "Last cache hit:         $(fmt_date "$LAST_HIT")"
+echo
+echo "Note: this counts only WebFetch calls the sdd-cache hook intercepted."
+echo "It does not include Anthropic's own prompt-cache savings, which are"
+echo "server-side and not exposed to this hook."


### PR DESCRIPTION
## Summary
- jq was a hard dependency for the sdd-cache WebFetch hook — add hooks/lib/jsonutil.sh with a jq → python3 → node fallback chain
- Track cache-hit savings in .claude/sdd-cache/.stats.json and add hooks/sdd-cache-stats.sh to view a summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)