### PR TITLE
Add grounding-and-abstention skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ The commands above are entry points. The pack includes 24 skills total — 23 li
 | [test-driven-development](skills/test-driven-development/SKILL.md) | Red-Green-Refactor, test pyramid (80/15/5), test sizes, DAMP over DRY, Beyonce Rule, browser testing | Implementing logic, fixing bugs, or changing behavior |
 | [context-engineering](skills/context-engineering/SKILL.md) | Feed agents the right information at the right time - rules files, context packing, MCP integrations | Starting a session, switching tasks, or when output quality drops |
 | [source-driven-development](skills/source-driven-development/SKILL.md) | Ground every framework decision in official documentation - verify, cite sources, flag what's unverified | You want authoritative, source-cited code for any framework or library |
+| [grounding-and-abstention](skills/grounding-and-abstention/SKILL.md) | Ground LLM/RAG answers in retrieved evidence and abstain - refuse, say "I don't know", or escalate to a human - instead of hallucinating; test the unanswerable cases, not just the hits | Building any feature where an LLM answers from documents, data, or tools and a confident wrong answer is costly |
 | [doubt-driven-development](skills/doubt-driven-development/SKILL.md) | Adversarial fresh-context review of every non-trivial decision in-flight - CLAIM → EXTRACT → DOUBT → RECONCILE → STOP, with optional user-authorized cross-model escalation | Stakes are high (production, security, irreversible), working in unfamiliar code, or a confident output is cheaper to verify now than to debug later |
 | [frontend-ui-engineering](skills/frontend-ui-engineering/SKILL.md) | Component architecture, design systems, state management, responsive design, WCAG 2.1 AA accessibility | Building or modifying user-facing interfaces |
 | [api-and-interface-design](skills/api-and-interface-design/SKILL.md) | Contract-first design, Hyrum's Law, One-Version Rule, error semantics, boundary validation | Designing APIs, module boundaries, or public interfaces |
@@ -321,6 +322,7 @@ agent-skills/
 │   ├── incremental-implementation/    #   Build
 │   ├── context-engineering/           #   Build
 │   ├── source-driven-development/     #   Build
+│   ├── grounding-and-abstention/      #   Build
 │   ├── doubt-driven-development/      #   Build
 │   ├── frontend-ui-engineering/       #   Build
 │   ├── test-driven-development/       #   Build

--- a/evals/cases/grounding-and-abstention.json
+++ b/evals/cases/grounding-and-abstention.json
@@ -1,0 +1,47 @@
+{
+  "skill_name": "grounding-and-abstention",
+  "trigger": {
+    "positive": [
+      {
+        "prompt": "Build a support assistant that answers from our help-center docs and never makes things up",
+        "top_k": 3
+      },
+      {
+        "prompt": "Our RAG bot invents answers when the docs don't cover a question. How should it behave instead?",
+        "top_k": 3
+      },
+      {
+        "prompt": "Design an AI feature that cites its sources and says 'I don't know' or escalates to a human when it's unsure",
+        "top_k": 3
+      }
+    ],
+    "negative": [
+      {
+        "prompt": "Write a failing test for this rounding bug before I fix it",
+        "owner": "test-driven-development"
+      },
+      {
+        "prompt": "Which React 19 hook should I use for form state, per the official docs?",
+        "owner": "source-driven-development"
+      },
+      {
+        "prompt": "Set up CI to run our LLM evals and gate the PR on a pass-rate threshold",
+        "owner": "evaluating-llm-output"
+      }
+    ]
+  },
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Build a RAG assistant over our internal policy docs. Users will sometimes ask things the docs don't cover.",
+      "expected_output": "A design that grounds answers in retrieved policy chunks with per-claim citations, abstains (states it doesn't have the information) when retrieval is weak or out of scope, escalates high-stakes cases to a human, and an eval set that includes unanswerable / out-of-scope questions.",
+      "expectations": [
+        "Answers are constrained to retrieved evidence, with each non-trivial claim citing a source",
+        "A relevance floor triggers abstention instead of answering from the model's general knowledge",
+        "Abstention is a designed, gracefully-rendered response rather than an error",
+        "The proposed eval set includes unanswerable / out-of-scope inputs and measures abstention accuracy, over-refusal rate, and hallucination-on-unanswerable"
+      ],
+      "trust_level": "provisional"
+    }
+  ]
+}

--- a/skills/grounding-and-abstention/SKILL.md
+++ b/skills/grounding-and-abstention/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: grounding-and-abstention
+description: Designs LLM and RAG features that ground every claim in retrieved evidence and abstain — say "I don't know", refuse, or escalate to a human — instead of hallucinating a confident wrong answer. Use when building any feature where an LLM answers from documents, data, or tools (RAG, support assistants, search, agents); when the cost of a confident wrong answer is high (regulated or user-facing domains); or when answers must be traceable to a source. Use when the system needs to know what it does not know.
+---
+
+# Grounding and Abstention
+
+## Overview
+
+The most common — and most damaging — production LLM failure is a **confident wrong answer**. The model is equally fluent when it is right and when it is fabricating, so a plausible-sounding hallucination ships straight past a casual reviewer and into a user's hands.
+
+This skill is the **design discipline** for the opposite behavior: every claim is grounded in retrieved evidence, and when the feature cannot answer reliably it **abstains** — says "I don't have that," refuses, asks a clarifying question, or escalates to a human — rather than guessing. A feature that grounds and abstains is trusted; one that confabulates fluently is a liability.
+
+This is a build-time skill. *Measuring* output quality and catching regressions is the `evaluating-llm-output` skill's job; *designing the grounding and abstention behavior it measures* is this skill's.
+
+## When to Use
+
+- Building any feature where an LLM answers from documents, a knowledge base, tools, or retrieved data (RAG, support assistants, internal search, doc Q&A, agents that report findings)
+- The cost of a confident wrong answer is high — regulated domains (legal, medical, financial), or anything user-facing where trust matters
+- Answers must be **traceable** to a source the user or an SME can check
+- Users can ask things that are out of scope or not in the knowledge base
+
+**When NOT to use:**
+
+- Pure-creative or ideation output where there is no ground truth (fiction, brainstorming, naming)
+- Deterministic code paths — use [`test-driven-development`](../test-driven-development/SKILL.md)
+- Throwaway prototypes with no real users and no cost to being wrong
+
+## The Process
+
+```
+BOUND ──→ GROUND ──→ ABSTAIN ──→ ESCALATE ──→ TEST THE GAPS ──→ TUNE
+  │         │           │            │              │             │
+  ▼         ▼           ▼            ▼              ▼             ▼
+what can  answer only  make "I     route low-    eval on the   pick the
+it answer from cited   don't know" confidence &  UNANSWERABLE  refuse↔halluc
+vs must   evidence,    a designed  high-stakes   inputs, not   operating
+abstain?  or refuse    output      to a human    just the hits point
+```
+
+### Step 1: Bound the question space
+
+Before the first prompt, write down what the feature **can** answer and what **must** trigger abstention or escalation:
+
+```
+IN SCOPE (answer from sources):   product/policy questions covered by the KB
+MUST ABSTAIN (no confident answer): topics not in the KB, missing/weak evidence
+MUST ESCALATE (needs a human):    personalized/high-stakes decisions,
+                                   anything requiring a licensed professional
+```
+
+These boundaries are not documentation — they become your eval cases (Step 5). If you cannot name what the feature must refuse, you have not designed it yet.
+
+### Step 2: Ground every claim
+
+Retrieve first, then generate **only from what was retrieved**. Each non-trivial claim cites the source it came from (chunk id, doc + section, or URL).
+
+```
+System prompt (the load-bearing instruction):
+"Answer ONLY using the provided sources. Cite the source for each claim.
+ If the sources do not contain the answer, say you don't have that
+ information — do NOT answer from general knowledge."
+```
+
+**Relevance gates the answer, not presence.** Retrieval always returns *something*; ranking by cosine similarity will hand back the "least irrelevant" chunk for a question the corpus never covered. Set a **relevance floor** — below it, there is effectively no evidence, so abstain instead of answering from parametric memory. That memory path is exactly where hallucinations come from.
+
+### Step 3: Make abstention a first-class output
+
+Refusal is a **designed response**, not an error or an afterthought bolted on later. Structure the output so "I can't answer this" is a normal, typed result the application renders gracefully:
+
+```json
+{ "answer": null, "reason": "no_supporting_evidence",
+  "message": "I don't have that in my sources.", "sources": [] }
+```
+
+A system built to *always* produce an answer cannot be retrofitted to abstain without a rewrite of its prompts and output contract. Design the abstain path from day one.
+
+### Step 4: Confidence and escalation
+
+Set thresholds (retrieval score, self-consistency across samples, or a judge's confidence). Below the threshold, don't just abstain silently — **escalate**: hand off to a human, open a review ticket, or ask a clarifying question.
+
+Some categories **always escalate** regardless of confidence. In a mortgage assistant, *"Am I approved?"* or *"What rate can I get?"* route to a licensed loan officer every time — the model must never answer them even if it "sounds sure." Encode these as hard rules, not soft preferences.
+
+When escalating, hand the human a **review package**, not just the raw question: the question + the retrieved evidence + the draft answer + why it was flagged. That is what makes a human-in-the-loop gate fast instead of a bottleneck.
+
+### Step 5: Test the gaps, not just the hits
+
+The most-skipped, highest-value step. Evaluate with **unanswerable and out-of-scope inputs**, not only questions the KB covers. An eval set of only answerable questions gives a model that *never abstains* a perfect score — while it hallucinates on every real out-of-scope query. Measure three numbers, not one:
+
+| Metric | What it catches | Where it lives |
+|---|---|---|
+| **Abstention accuracy** | Does it refuse when it should? | unanswerable + out-of-scope cases |
+| **Hallucination rate** | Does it invent answers to unanswerables? | must-abstain cases that got a confident answer |
+| **Over-refusal rate** | Does it refuse things it *could* have answered? | answerable cases that got refused |
+
+Build the harness with the `evaluating-llm-output` skill; this skill defines *which cases must exist* (the unanswerables) and *which behaviors count as pass/fail*.
+
+### Step 6: Tune the tradeoff
+
+Over-refusal (useless) and hallucination (dangerous) are two ends of one dial — you cannot maximize helpfulness and safety independently; pushing one down pushes the other up.
+
+```
+  more abstention                          more answering
+  ◄─────────────────────────┼─────────────────────────►
+  over-refusal              │              hallucination
+  (safe but unhelpful)   operating point   (helpful but unsafe)
+                         chosen by stakes
+```
+
+Pick the operating point deliberately for the domain: high-stakes (legal/medical/financial) → bias toward abstain; low-stakes internal search → bias toward answer. Track **both** rates over time; never tune one blind to the other.
+
+## Grounding Techniques
+
+| Technique | What it does | Use when |
+|---|---|---|
+| Retrieve-then-generate | Answer is built from retrieved chunks, not memory | Any RAG / doc-Q&A feature |
+| Cite-per-claim | Each claim carries its source (id/anchor/URL) | Answers must be verifiable by a user or SME |
+| Relevance floor | Below a similarity/rerank threshold → treat as no evidence | Corpus doesn't cover everything users ask |
+| Constrain to context | System prompt forbids answering beyond the sources | Preventing parametric-memory leakage |
+| Structured output + sources array | `{answer, sources[], reason}` typed contract | The app must render/verify sources and refusals |
+| Quote-and-attribute | Quote the supporting passage when a claim is non-obvious | High-stakes or disputed claims |
+
+## Abstention Triggers → Responses
+
+| Trigger | Right response |
+|---|---|
+| No / low-relevance retrieval | Refuse + say it's not in your sources |
+| Conflicting sources | Surface the conflict; don't silently pick one |
+| Out-of-scope topic | Refuse + point to where the answer lives |
+| Needs real-time/data you don't have | Say so; offer the freshest thing you *do* have |
+| Requires a licensed/authorized human | Escalate — always, regardless of confidence |
+| Asks for a guarantee/decision you can't make | Explain the limit; route to a human |
+| Ambiguous question | Ask one clarifying question before answering |
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "A plausible answer is more helpful than 'I don't know'" | In any domain with real stakes, a confident wrong answer is worse than an honest gap — it breaks trust and can cause harm. When you don't know, abstention *is* the helpful answer. |
+| "The model sounds confident, so it's probably right" | Fluency is not accuracy. An LLM is equally fluent when correct and when fabricating. Ground the claim in a source or flag it — tone is not evidence. |
+| "Refusing makes the product look dumb" | Refusing *wrong* answers makes it trustworthy. Users forgive "I don't have that"; they do not forgive being confidently misled. |
+| "We'll add grounding and abstention later" | Retrofitting refusal onto a system designed to always answer is a rewrite of its prompts and output contract. Design the abstain path from the first prompt. |
+| "Our eval pass rate is high" | If the eval set only contains answerable questions, a model that never abstains scores 100% and still hallucinates on every out-of-scope real query. Test the gaps. |
+| "Retrieval returned chunks, so answer from them" | Retrieval always returns something. Relevance, not presence, gates the answer — below the floor there is no evidence, so abstain. |
+| "Adding a source citation is extra work" | The citation is the proof. Without it, neither the user nor an SME can tell a grounded answer from a fluent guess. |
+
+## Red Flags
+
+- The feature never says "I don't know" anywhere in testing
+- Answers carry no citations, or a claim can't be traced to a source
+- The eval set contains only answerable questions — no unanswerables or out-of-scope inputs
+- Abstention is implemented as an error/exception instead of a designed response
+- The model answers from general knowledge when retrieval was empty or weak
+- Every query gets an answer — there is no confidence threshold
+- High-stakes decisions are answered directly instead of escalated to a human
+- Only accuracy-on-answerable is measured; over-refusal and hallucination-on-unanswerable are not
+
+## Interaction with Other Skills
+
+- **the `evaluating-llm-output` skill**: complementary. That skill *measures* output quality and guards against regressions; this one *designs* the grounding and abstention behavior it measures. Build with this, verify with that.
+- **[`source-driven-development`](../source-driven-development/SKILL.md)**: SDD grounds *your framework code* in official documentation. This grounds *the product's LLM answers* in retrieved data. Same principle — cite, don't guess — applied at runtime to what the feature says, not to how you write it.
+- **[`doubt-driven-development`](../doubt-driven-development/SKILL.md)**: doubt-driven verifies *your reasoning* about an artifact before it stands. This makes the shipped feature apply the same "don't assert what you can't support" discipline to its own outputs at runtime.
+- **[`context-engineering`](../context-engineering/SKILL.md)**: context-engineering feeds the right information in; this skill decides what to do when that information is insufficient — abstain rather than fill the gap with invention.
+
+## Verification
+
+After designing a feature with this skill:
+
+- [ ] In-scope, must-abstain, and must-escalate boundaries are written down
+- [ ] Answers are built only from retrieved evidence, and each non-trivial claim cites a source
+- [ ] Retrieval below a relevance floor triggers abstention, not a parametric-memory answer
+- [ ] Abstention is a first-class, gracefully-rendered response — not an error
+- [ ] A confidence threshold routes low-confidence and high-stakes cases to a human, with a review package
+- [ ] The eval set includes unanswerable and out-of-scope inputs, and you measure abstention accuracy, over-refusal rate, and hallucination-on-unanswerable
+- [ ] The over-refusal ↔ hallucination operating point was chosen deliberately for the domain's stakes


### PR DESCRIPTION
## What

Adds a `grounding-and-abstention` skill (Build phase): the design discipline for LLM/RAG features that **ground every claim in retrieved evidence and abstain** (refuse, say "I don't know", or escalate to a human) instead of hallucinating a confident wrong answer.

## Why / the gap

Confident hallucination is the #1 production LLM failure, and it is a **design** problem, not only an eval one. The pack covers deterministic engineering well, and `context-engineering` covers feeding context *in* - but nothing covers what a feature should do when that context is **insufficient**: ground and refuse rather than invent.

Per CONTRIBUTING, I checked the catalog and open PRs. This is deliberately **complementary to, not a duplicate of, #286 (`evaluating-llm-output`)**:

- **#286 *measures* output quality and guards regressions.** This skill is the **build-time discipline** for the grounding + abstention behavior it measures, and it points at an eval skill for the harness rather than re-implementing one.
- Distinct from **`source-driven-development`** (grounds *your code* in framework docs) and **`doubt-driven-development`** (verifies *your reasoning*): this grounds **the product's runtime answers** in retrieved data.

It references the eval skill by name only, so it carries **no hard dependency on the unmerged #286**.

## What's in it

- `skills/grounding-and-abstention/SKILL.md` - standard anatomy (Overview, When to Use, a 6-step design process, grounding + abstention technique tables, the over-refusal <-> hallucination tradeoff, Common Rationalizations, Red Flags, Interaction with Other Skills, Verification).
- `evals/cases/grounding-and-abstention.json` - 3 positive triggers, 3 negative (owned by `test-driven-development` / `source-driven-development` / `evaluating-llm-output`), 1 behavioral eval.
- README Build-section table row + directory-tree entry.

## Conventions

Frontmatter is `name` + `description` (what, then Use-when). Standard section anatomy, under 130 lines, references other skills by name.
