### PR TITLE
docs: clarify AGENTS.md and CLAUDE.md are repo-scoped, not for user projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to AI coding agents (Claude Code, Cursor, Copilot, Antigravity, etc.) when working with code in this repository.
 
+> **Scope:** This file configures agents working on the [`addyosmani/agent-skills`](https://github.com/addyosmani/agent-skills) repository itself. It is not meant to be copied into other projects or into a global agent configuration; the reusable assets are the skills in `skills/`, not this file.
+
 ## Repository Overview
 
 A collection of skills for Claude.ai and Claude Code for senior software engineers. Skills are packaged instructions and scripts that extend Claude and your coding agents capabilities.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This is the agent-skills project — a collection of production-grade engineering skills for AI coding agents.
 
+> **Scope:** This file configures agents working on the [`addyosmani/agent-skills`](https://github.com/addyosmani/agent-skills) repository itself, not other projects. Don't copy it into another project or a global agent configuration; the reusable assets are the skills in `skills/`.
+
 ## Project Structure
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,10 @@ The frontmatter fields above are required. The section anatomy is a recommended 
 - Preserve the existing structure and tone
 - Test that YAML frontmatter remains valid after edits
 
+## Repo-scoped files
+
+`AGENTS.md` and `CLAUDE.md` at the repo root configure agents working on the [`addyosmani/agent-skills`](https://github.com/addyosmani/agent-skills) repository itself. When writing setup guides or docs, do not instruct users to copy these files into their own projects or into a global agent configuration; the reusable assets are the skills in `skills/`.
+
 ## Testing Hooks
 
 The session-start hook (`hooks/session-start.sh`) injects the `using-agent-skills` meta-skill into every new Claude Code session. A regression test at `hooks/session-start-test.sh` validates the hook's JSON payload — both when `jq` is available and when it isn't.


### PR DESCRIPTION
## Why

`AGENTS.md` and `CLAUDE.md` at the repo root configure agents working on this repository. They can be mistaken for files to copy into a user's own project or global agent configuration; copying them injects this repo's identity and orchestration rules into unrelated projects, mis-framing them and potentially misdirecting the agent.

## What

- Add a **Scope** banner to the top of `AGENTS.md` and `CLAUDE.md` stating they configure agents working on the `addyosmani/agent-skills` repository itself and are not meant to be copied into other projects or a global config. The banner references the repo by its canonical GitHub URL so the scope stays unambiguous even when the file is read out of context (for example by an LLM).
- Add a **Repo-scoped files** note to `CONTRIBUTING.md` so setup-guide authors don't instruct users to copy these files.

Docs only; no skill or code changes.