### PR TITLE
docs: decline documentation and skill translations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,10 @@ The frontmatter fields above are required. The section anatomy is a recommended 
 
 `AGENTS.md` and `CLAUDE.md` at the repo root configure agents working on the [`addyosmani/agent-skills`](https://github.com/addyosmani/agent-skills) repository itself. When writing setup guides or docs, do not instruct users to copy these files into their own projects or into a global agent configuration; the reusable assets are the skills in `skills/`.
 
+## Translations
+
+We don't accept translations of the documentation (README, `docs/`) or of skills and their content. Translated copies drift out of sync as skills and docs evolve, and we have no way to maintain them long-term without leaning on agent translations plus community corrections, which adds maintenance cost for limited value. Keep all skills, docs, and contributions in English.
+
 ## Testing Hooks
 
 The session-start hook (`hooks/session-start.sh`) injects the `using-agent-skills` meta-skill into every new Claude Code session. A regression test at `hooks/session-start-test.sh` validates the hook's JSON payload — both when `jq` is available and when it isn't.


### PR DESCRIPTION
## Why

Maintainers have decided not to accept translations of the documentation or skills. Translated copies drift out of sync as skills and docs evolve, and there is no sustainable way to maintain them long-term (it would mean relying on agent translations plus community corrections, for limited value).

## What

Add a **Translations** section to CONTRIBUTING.md stating the policy, keeping all skills, docs, and contributions in English.

Docs only.