### PR TITLE
docs: add Claude Code login troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Prefer a native integration? Pick your tool below.
 <details>
 <summary><b>Claude Code (recommended)</b></summary>
 
+> **Not logged in?** If Claude Code shows `Not logged in · Please run /login`,
+> run `/login` inside Claude Code first, then retry the install:
+>
+> ```bash
+> /plugin marketplace add addyosmani/agent-skills
+> /plugin install agent-skills@addy-agent-skills
+> ```
+>
+> Make sure you are installing `agent-skills@addy-agent-skills`; names such as
+> `everything-claude-code@everything-claude-code` are not part of this marketplace entry.
+
 **Marketplace install:**
 
 ```


### PR DESCRIPTION
## Summary

Adds a short Claude Code troubleshooting note for users who see:

`Not logged in · Please run /login`

This clarifies that users should run `/login` inside Claude Code first, then retry the documented plugin install command.

## Related issue

Fixes #343

## Verification

- Updated README.md only
- Ran `git diff --check`
- Confirmed branch was pushed to fork