### PR TITLE
fix(hooks): remove unchecked perl dependency in simplify-ignore.sh

### DIFF
--- a/hooks/simplify-ignore.sh
+++ b/hooks/simplify-ignore.sh
@@ -132,9 +132,12 @@ ${line}"
     printf '%s\n' "$buf" >> "$dest"
   fi
 
-  # Preserve trailing newline status of source
+  # Preserve trailing newline status of source. When the source has no trailing
+  # newline but $dest (built with printf '%s\n') does, strip dest's trailing
+  # newline. $(...) strips all trailing newlines, so this is a POSIX-safe
+  # replacement for `perl -pe 'chomp if eof'` and avoids a hard perl dependency.
   if [ -s "$dest" ] && [ -s "$src" ] && [ -n "$(tail -c 1 "$src")" ]; then
-    perl -pe 'chomp if eof' "$dest" > "${dest}.nnl" && \
+    printf '%s' "$(cat "$dest")" > "${dest}.nnl" && \
       cat "${dest}.nnl" > "$dest" && rm -f "${dest}.nnl"
   fi
 
@@ -264,9 +267,11 @@ if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
     ;; esac
     printf '%s\n' "$line" >> "$EXPANDED"
   done < "$FILE_PATH"
-  # Preserve trailing newline status
+  # Preserve trailing newline status. $(...) strips all trailing newlines, so
+  # this is a POSIX-safe replacement for `perl -pe 'chomp if eof'` and avoids a
+  # hard perl dependency (perl is absent on minimal CI/container images).
   if [ -s "$EXPANDED" ] && [ -s "$FILE_PATH" ] && [ -n "$(tail -c 1 "$FILE_PATH")" ]; then
-    perl -pe 'chomp if eof' "$EXPANDED" > "${EXPANDED}.nnl" && \
+    printf '%s' "$(cat "$EXPANDED")" > "${EXPANDED}.nnl" && \
       cat "${EXPANDED}.nnl" > "$EXPANDED" && rm -f "${EXPANDED}.nnl"
   fi
   # Warn if model deleted a protected block entirely


### PR DESCRIPTION
## Summary

`hooks/simplify-ignore.sh` used `perl -pe 'chomp if eof'` to preserve a file's trailing-newline status, but **perl was never dependency-checked** (unlike `jq` and `shasum`/`sha1sum`, which are validated up front) and it isn't listed in the script's `Dependencies` header.

## The bug

In the `PostToolUse` (`Edit`/`Write`) branch, the trailing-newline block runs at top level under `set -euo pipefail`:

```sh
perl -pe 'chomp if eof' "$EXPANDED" > "${EXPANDED}.nnl" && \
  cat "${EXPANDED}.nnl" > "$EXPANDED" && rm -f "${EXPANDED}.nnl"
```

On a host without perl (minimal CI images, or Alpine/busybox containers, which are common places for Claude Code hooks to run), this command fails. Because it's the last command in the `then` clause and `set -e` is active, the script aborts before the expanded content is written back to disk.

The result is not a cosmetic newline glitch. The file is left in its `BLOCK_<hash>` placeholder state and the backup is never refreshed, so the model's edits are effectively stranded, which is a data-integrity failure.

The same `perl` call is also used in `filter_file`, where it silently mishandles trailing-newline preservation on perl-less hosts.

## The fix

Replace both `perl` invocations with a POSIX-safe equivalent that removes the hidden dependency entirely:

```sh
printf '%s' "$(cat "$EXPANDED")" > "${EXPANDED}.nnl"
```

Command substitution `$(...)` strips all trailing newlines, matching the behavior of `perl -pe 'chomp if eof'`. This aligns with the script's established pattern of validating (or not depending on) every external tool.

## Testing

- `bash -n hooks/simplify-ignore.sh` passes
- `hooks/simplify-ignore-test.sh`: the trailing-newline preservation test (Test 5) passes, and results are unchanged from before this patch
