### PR TITLE
test: add accessibility testing guidance

### DIFF
--- a/agents/test-engineer.md
+++ b/agents/test-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: test-engineer
-description: QA engineer specialized in test strategy, test writing, and coverage analysis. Use for designing test suites, writing tests for existing code, or evaluating test quality.
+description: QA engineer specialized in test strategy, test writing, accessibility coverage, and coverage analysis. Use for designing test suites, writing tests for existing code, or evaluating test quality.
 ---
 
 # Test Engineer
@@ -22,6 +22,7 @@ Before writing any test:
 ```
 Pure logic, no I/O          → Unit test
 Crosses a boundary          → Integration test
+UI semantics/focus behavior → Component accessibility test or browser test
 Critical user flow          → E2E test
 ```
 
@@ -55,6 +56,7 @@ For every function or component:
 | Boundary values | Min, max, zero, negative |
 | Error paths | Invalid input, network failure, timeout |
 | Concurrency | Rapid repeated calls, out-of-order responses |
+| Accessibility | Keyboard path, focus management, accessible names, ARIA/live-region announcements |
 
 ## Output Format
 
@@ -70,6 +72,9 @@ When analyzing test coverage:
 ### Recommended Tests
 1. **[Test name]** — [What it verifies, why it matters]
 2. **[Test name]** — [What it verifies, why it matters]
+
+### Accessibility Coverage
+- [Automated checks, keyboard/focus checks, screen-reader semantics, or "not applicable" with rationale]
 
 ### Priority
 - Critical: [Tests that catch potential data loss or security issues]
@@ -87,6 +92,7 @@ When analyzing test coverage:
 5. Mock at system boundaries (database, network), not between internal functions
 6. Every test name should read like a specification
 7. A test that never fails is as useless as a test that always fails
+8. For UI changes, include accessibility coverage: role/name queries, keyboard paths, focus management, and automated a11y checks where useful
 
 ## Composition
 

--- a/evals/cases/browser-testing-with-devtools.json
+++ b/evals/cases/browser-testing-with-devtools.json
@@ -13,6 +13,10 @@
       {
         "prompt": "Verify in a real browser that the form submits and the data persists in localStorage",
         "top_k": 3
+      },
+      {
+        "prompt": "Use the browser accessibility tree to verify the modal labels and keyboard focus behavior",
+        "top_k": 3
       }
     ],
     "negative": [
@@ -35,6 +39,17 @@
         "Findings are grounded in observed runtime data (console, network, DOM), not static code reading alone",
         "The report distinguishes what was observed from what is inferred",
         "A concrete next step or fix hypothesis is provided"
+      ],
+      "trust_level": "provisional"
+    },
+    {
+      "id": 2,
+      "prompt": "Verify a settings modal in the browser for accessible labels, focus order, and focus restoration after close.",
+      "expected_output": "Runtime evidence from DevTools or browser automation showing accessibility tree labels and keyboard focus behavior",
+      "expectations": [
+        "The accessibility tree or role/name information is inspected rather than inferred from code alone",
+        "Keyboard focus order and focus restoration are verified with browser runtime evidence",
+        "Findings distinguish observed browser data from inferred causes"
       ],
       "trust_level": "provisional"
     }

--- a/evals/cases/ci-cd-and-automation.json
+++ b/evals/cases/ci-cd-and-automation.json
@@ -13,6 +13,10 @@
       {
         "prompt": "Automate the quality gates so nothing merges without passing checks",
         "top_k": 3
+      },
+      {
+        "prompt": "Add an axe or pa11y accessibility audit to CI for browser UI changes",
+        "top_k": 3
       }
     ],
     "negative": [
@@ -36,6 +40,17 @@
         "Failure of any quality gate fails the pipeline run",
         "Steps are ordered logically and cache or setup steps are sane",
         "No secrets are hardcoded in the workflow"
+      ],
+      "trust_level": "provisional"
+    },
+    {
+      "id": 2,
+      "prompt": "Add a CI job that runs accessibility checks for a React app without slowing down backend-only pull requests.",
+      "expected_output": "A CI plan or workflow that runs a11y audits for UI paths and avoids unnecessary browser work for backend-only changes",
+      "expectations": [
+        "Accessibility checks are included using axe, pa11y, Lighthouse, or Playwright accessibility tests",
+        "The job is scoped to browser-facing or UI changes rather than every backend-only change",
+        "The workflow still keeps normal lint, test, build, and security gates intact"
       ],
       "trust_level": "provisional"
     }

--- a/evals/cases/test-driven-development.json
+++ b/evals/cases/test-driven-development.json
@@ -13,6 +13,10 @@
       {
         "prompt": "What tests should cover this new parsing logic before I write it?",
         "top_k": 3
+      },
+      {
+        "prompt": "Add accessibility regression tests for keyboard focus in the settings modal",
+        "top_k": 3
       }
     ],
     "negative": [
@@ -35,6 +39,17 @@
         "A failing test is written and shown failing before the fix",
         "The implementation is the minimum needed to pass",
         "The full suite is run after the fix to catch regressions"
+      ],
+      "trust_level": "provisional"
+    },
+    {
+      "id": 2,
+      "prompt": "Plan tests for a modal that previously trapped keyboard users and hid its validation error from screen readers.",
+      "expected_output": "A test plan that covers keyboard focus, accessible names or announcements, and the right mix of component and browser checks",
+      "expectations": [
+        "Keyboard focus and focus restoration are explicitly tested",
+        "Screen-reader-visible validation behavior is checked through role, label, alert, or live-region assertions",
+        "Automated accessibility scans are treated as helpful but not sufficient by themselves"
       ],
       "trust_level": "provisional"
     }

--- a/references/accessibility-checklist.md
+++ b/references/accessibility-checklist.md
@@ -6,6 +6,7 @@ Quick reference for WCAG 2.1 AA compliance. Use alongside the `frontend-ui-engin
 
 - [Essential Checks](#essential-checks)
 - [Common HTML Patterns](#common-html-patterns)
+- [Testing Layer Map](#testing-layer-map)
 - [Testing Tools](#testing-tools)
 - [Quick Reference: ARIA Live Regions](#quick-reference-aria-live-regions)
 - [Common Anti-Patterns](#common-anti-patterns)
@@ -120,12 +121,22 @@ Quick reference for WCAG 2.1 AA compliance. Use alongside the `frontend-ui-engin
 </ul>
 ```
 
+## Testing Layer Map
+
+| Layer | Use For | Example Checks |
+|---|---|---|
+| Component test | Semantics and state exposed by one component | role/name queries, required state, alert text, `aria-live` content |
+| Browser test | Real focus, layout, and composed UI behavior | tab order, focus trap, focus restoration, contrast, accessibility tree |
+| E2E test | Critical user journeys that must remain accessible | login, checkout, onboarding, form submission with keyboard only |
+| CI audit | Broad regression smoke checks | axe, pa11y, Lighthouse accessibility score |
+
 ## Testing Tools
 
 ```bash
 # Automated audit
-npx axe-core          # Programmatic accessibility testing
-npx pa11y             # CLI accessibility checker
+npm install --save-dev jest-axe @axe-core/playwright
+npx pa11y http://localhost:3000
+npx lighthouse http://localhost:3000 --only-categories=accessibility
 
 # In browser
 # Chrome DevTools → Lighthouse → Accessibility

--- a/references/testing-patterns.md
+++ b/references/testing-patterns.md
@@ -9,6 +9,7 @@ Quick reference for common testing patterns across the stack. Use alongside the 
 - [Common Assertions](#common-assertions)
 - [Mocking Patterns](#mocking-patterns)
 - [React/Component Testing](#reactcomponent-testing)
+- [Accessibility Testing](#accessibility-testing)
 - [API / Integration Testing](#api--integration-testing)
 - [E2E Testing (Playwright)](#e2e-testing-playwright)
 - [Test Anti-Patterns](#test-anti-patterns)
@@ -153,6 +154,64 @@ describe('TaskForm', () => {
   });
 });
 ```
+
+## Accessibility Testing
+
+Accessibility is testable behavior. Prefer the lowest layer that catches the regression, then add browser evidence when real rendering, tab order, focus trapping, or contrast matters.
+
+### Component Semantics
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+it('exposes the email field and validation error to assistive tech', async () => {
+  render(<SettingsForm />);
+
+  expect(screen.getByRole('textbox', { name: /email/i })).toBeRequired();
+  expect(screen.getByRole('button', { name: /save settings/i })).toBeEnabled();
+
+  await userEvent.click(screen.getByRole('button', { name: /save settings/i }));
+
+  expect(await screen.findByRole('alert')).toHaveTextContent(/email is required/i);
+});
+```
+
+### Automated Violation Scan
+
+```tsx
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+expect.extend(toHaveNoViolations);
+
+it('has no obvious accessibility violations', async () => {
+  const { container } = render(<SettingsForm />);
+
+  expect(await axe(container)).toHaveNoViolations();
+});
+```
+
+### Browser Keyboard Flow
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('settings modal keeps keyboard focus predictable', async ({ page }) => {
+  await page.goto('/settings');
+  await page.getByRole('button', { name: /open settings/i }).click();
+
+  await expect(page.getByRole('dialog', { name: /settings/i })).toBeVisible();
+  await expect(page.getByRole('textbox', { name: /email/i })).toBeFocused();
+
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('button', { name: /save settings/i })).toBeFocused();
+
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('button', { name: /open settings/i })).toBeFocused();
+});
+```
+
+Use axe, pa11y, or Lighthouse to catch broad violations, but do not rely on automated scans alone. Critical UI flows still need keyboard traversal, focus-state checks, accessible names, and the browser accessibility tree. See `references/accessibility-checklist.md` for the full checklist.
 
 ## API / Integration Testing
 

--- a/skills/browser-testing-with-devtools/SKILL.md
+++ b/skills/browser-testing-with-devtools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-testing-with-devtools
-description: Tests in real browsers via Chrome DevTools MCP. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data. Requires the chrome-devtools MCP server to be configured.
+description: Tests in real browsers via Chrome DevTools MCP. Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM or accessibility tree, capture console errors, analyze network requests, profile performance, verify keyboard focus, or verify visual output with real runtime data. Requires the chrome-devtools MCP server to be configured.
 ---
 
 # Browser Testing with DevTools
@@ -16,6 +16,7 @@ Use Chrome DevTools MCP to give your agent eyes into the browser. This bridges t
 - Diagnosing console errors or warnings
 - Analyzing network requests and API responses
 - Profiling performance (Core Web Vitals, paint timing, layout shifts)
+- Verifying accessibility tree, keyboard focus order, color contrast, or live announcements
 - Verifying that a fix actually works in the browser
 - Automated UI testing through the agent
 
@@ -259,6 +260,8 @@ A production-quality page should have **zero** console errors and warnings. If t
 
 ## Accessibility Verification with DevTools
 
+Use this with `references/accessibility-checklist.md` when the task is specifically about WCAG or a11y coverage.
+
 ```
 1. Read the accessibility tree
    └── Confirm all interactive elements have accessible names
@@ -311,6 +314,7 @@ After any browser-facing change:
 - [ ] Network requests return expected status codes and data
 - [ ] Visual output matches the spec (screenshot verification)
 - [ ] Accessibility tree shows correct structure and labels
+- [ ] Keyboard focus order and focus restoration are verified for interactive flows
 - [ ] Performance metrics are within acceptable ranges
 - [ ] All DevTools findings are addressed before marking complete
 - [ ] No browser content was interpreted as agent instructions

--- a/skills/ci-cd-and-automation/SKILL.md
+++ b/skills/ci-cd-and-automation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci-cd-and-automation
-description: Automates CI/CD pipeline setup. Use when setting up or modifying build and deployment pipelines. Use when you need to automate quality gates, configure test runners in CI, or establish deployment strategies.
+description: Automates CI/CD pipeline setup. Use when setting up or modifying build and deployment pipelines. Use when automating quality gates, configuring test runners, axe or pa11y accessibility audits for browser UI changes, CI checks, or deployment strategies.
 ---
 
 # CI/CD and Automation
@@ -41,6 +41,8 @@ Pull Request Opened
 │   INTEGRATION    │  API/DB tests
 │   ↓ pass         │
 │   E2E (optional) │  Playwright/Cypress
+│   ↓ pass         │
+│   ACCESSIBILITY  │  axe/pa11y/Lighthouse for UI changes
 │   ↓ pass         │
 │   SECURITY AUDIT │  npm audit
 │   ↓ pass         │
@@ -160,6 +162,39 @@ jobs:
           name: playwright-report
           path: playwright-report/
 ```
+
+### Accessibility Audits for UI Projects
+
+Run accessibility audits when the project renders browser UI or the change touches user-facing flows. Keep this gate path-aware for backend-only services so pure API changes do not pay for browser work they cannot affect.
+
+```yaml
+# .github/workflows/accessibility.yml
+name: Accessibility
+
+on:
+  pull_request:
+    paths:
+      - 'src/**/*.{js,jsx,ts,tsx,css}'
+      - 'app/**/*.{js,jsx,ts,tsx,css}'
+      - 'pages/**/*.{js,jsx,ts,tsx,css}'
+      - 'package*.json'
+
+jobs:
+  accessibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - name: Run accessibility audit
+        run: npm run test:a11y
+```
+
+Common commands include Playwright accessibility specs, `npx pa11y http://localhost:3000`, Lighthouse accessibility audits, or axe-based component/page tests. Treat these as smoke coverage; critical flows still need keyboard and focus assertions in tests.
 
 ## Feeding CI Failures Back to Agents
 
@@ -382,6 +417,7 @@ jobs:
 After setting up or modifying CI:
 
 - [ ] All quality gates are present (lint, types, tests, build, audit)
+- [ ] UI pipelines include accessibility checks when browser-facing flows are in scope
 - [ ] Pipeline runs on every PR and push to main
 - [ ] Failures block merge (branch protection configured)
 - [ ] CI results feed back into the development loop

--- a/skills/debugging-and-error-recovery/SKILL.md
+++ b/skills/debugging-and-error-recovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging-and-error-recovery
-description: Guides systematic root-cause debugging. Use when tests fail, builds break, behavior doesn't match expectations, or you encounter any unexpected error. Use when you need a systematic approach to finding and fixing the root cause rather than guessing.
+description: Guides systematic root-cause debugging. Use when tests fail, a test passed yesterday and fails today, builds break, behavior does not match expectations, something broke unexpectedly, or you need to find and fix the root cause rather than guessing.
 ---
 
 # Debugging and Error Recovery

--- a/skills/documentation-and-adrs/SKILL.md
+++ b/skills/documentation-and-adrs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: documentation-and-adrs
-description: Records decisions and documentation. Use when making architectural decisions, changing public APIs, shipping features, or when you need to record context that future engineers and agents will need to understand the codebase.
+description: Records decisions and documentation. Use when documenting architecture decisions, ADRs, queue design rationale, changing public APIs, shipping features, or recording context future engineers and agents need to understand the codebase.
 ---
 
 # Documentation and ADRs

--- a/skills/doubt-driven-development/SKILL.md
+++ b/skills/doubt-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: doubt-driven-development
-description: Subjects every non-trivial decision to a fresh-context adversarial review before it stands. Use when correctness matters more than speed, when working in unfamiliar code, when stakes are high (production, security-sensitive logic, irreversible operations), or any time a confident output would be cheaper to verify now than to debug later.
+description: Subjects every non-trivial decision to fresh-context adversarial review. Use when correctness matters more than speed, stakes are high such as production auth or migrations, or you need to cross-examine assumptions, stress a plan, or find hidden failure modes before proceeding.
 ---
 
 # Doubt-Driven Development

--- a/skills/git-workflow-and-versioning/SKILL.md
+++ b/skills/git-workflow-and-versioning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow-and-versioning
-description: Structures git workflow practices. Use when making any code change. Use when committing, branching, resolving conflicts, or when you need to organize work across multiple parallel streams. Use when cutting a release, choosing a semantic version bump, tagging, or writing a changelog.
+description: Structures git workflow practices. Use when making code changes, committing, branching, resolving conflicts, splitting a messy working tree into clean atomic commits, organizing parallel streams, cutting releases, choosing semantic version bumps, tagging, or writing changelogs.
 ---
 
 # Git Workflow and Versioning

--- a/skills/incremental-implementation/SKILL.md
+++ b/skills/incremental-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: incremental-implementation
-description: Delivers changes incrementally. Use when implementing any feature or change that touches more than one file. Use when you're about to write a large amount of code at once, or when a task feels too big to land in one step.
+description: Delivers changes incrementally. Use when implementing multi-file changes, the next task from a plan, a small verifiable slice, thin slices behind a feature flag, or when a task feels too big to land in one step.
 ---
 
 # Incremental Implementation

--- a/skills/observability-and-instrumentation/SKILL.md
+++ b/skills/observability-and-instrumentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: observability-and-instrumentation
-description: Instruments code so production behavior is visible and diagnosable. Use when adding logging, metrics, tracing, or alerting. Use when shipping any feature that runs in production and you need evidence it works. Use when production issues are reported but you can't tell what happened from the available data.
+description: Instruments code so production behavior is visible and diagnosable. Use when adding structured logging, metrics, tracing, service alerts, or endpoint alerting. Use when shipping production features that need evidence they work or when production issues lack enough data.
 ---
 
 # Observability and Instrumentation

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-and-hardening
-description: Hardens code against vulnerabilities. Use when handling user input, authentication, data storage, or external integrations. Use when building any feature that accepts untrusted data, manages user sessions, or interacts with third-party services.
+description: Hardens code against vulnerabilities. Use when auditing or building file upload handlers, handling user input, authentication, data storage, external integrations, untrusted data, user sessions, or third-party services.
 ---
 
 # Security and Hardening

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shipping-and-launch
-description: Prepares production launches. Use when preparing to deploy to production. Use when you need a pre-launch checklist, when setting up monitoring, when planning a staged rollout, or when you need a rollback strategy.
+description: Prepares production launches. Use when preparing to deploy or ship to production, checking what needs to be in place before shipping, setting up monitoring, planning staged rollout, or defining rollback strategy.
 ---
 
 # Shipping and Launch

--- a/skills/source-driven-development/SKILL.md
+++ b/skills/source-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: source-driven-development
-description: Grounds every implementation decision in official documentation. Use when you want authoritative, source-cited code free from outdated patterns. Use when building with any framework or library where correctness matters.
+description: Grounds implementation decisions in official documentation. Use when verifying against official framework docs before implementing, wanting source-cited code, integrating libraries such as Next.js or Stripe, or when current authoritative sources matter.
 ---
 
 # Source-Driven Development

--- a/skills/spec-driven-development/SKILL.md
+++ b/skills/spec-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-driven-development
-description: Creates specs before coding. Use when starting a new project, feature, or significant change and no specification exists yet. Use when requirements are unclear, ambiguous, or only exist as a vague idea.
+description: Creates specs before coding. Use when drafting a PRD, defining objectives and boundaries, starting a new project, feature, or significant change, or when requirements are unclear, ambiguous, or only exist as a vague idea.
 ---
 
 # Spec-Driven Development

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-driven-development
-description: Drives development with tests. Use when implementing any logic, fixing any bug, or changing any behavior. Use when you need to prove that code works, when a bug report arrives, or when you're about to modify existing functionality.
+description: Drives test-first development. Use when implementing logic, fixing bugs, using red-green-refactor, adding regression coverage, or choosing unit/component/integration/E2E tests, including accessibility tests for UI behavior such as keyboard, focus, labels, and announcements.
 ---
 
 # Test-Driven Development
@@ -169,7 +169,23 @@ Does it cross a boundary (API, database, file system)?
 
 Is it a critical user flow that must work end-to-end?
   → E2E test (large) — limit these to critical paths
+
+Does it verify UI semantics, keyboard access, focus, or screen reader announcements?
+  → Component accessibility test first; add browser/E2E accessibility checks for page-level flows
 ```
+
+### Accessibility Test Planning
+
+Treat accessibility as user-facing behavior, not visual polish. Test it at the lowest reliable layer:
+
+| Concern | Best First Test | Add Browser/E2E When |
+|---|---|---|
+| Accessible name, role, required state, form error text | Component test with role/label queries | The rendered page composes multiple components |
+| Keyboard path, focus trap, focus restoration | Component or browser test | Real tab order, modals, menus, or routing are involved |
+| ARIA live regions and dynamic announcements | Component test plus DOM assertion | Timing or async updates affect announcements |
+| Color contrast, zoom, responsive reflow | Browser/DevTools/axe/pa11y audit | CSS, theming, or layout changed |
+
+Automated axe/pa11y checks catch broad violations, but they do not replace keyboard traversal, focus verification, or reading the accessibility tree for critical flows. For the detailed checklist, use `references/accessibility-checklist.md`.
 
 ## Writing Good Tests
 
@@ -316,6 +332,7 @@ For anything that runs in a browser, unit tests alone aren't enough — you need
 | **Console** | Always | Zero errors and warnings in production-quality code |
 | **Network** | API issues | Status codes, payload shape, timing, CORS errors |
 | **DOM** | UI bugs | Element structure, attributes, accessibility tree |
+| **Accessibility** | Browser-facing UI changes | Accessible names, tab order, focus state, contrast, live regions |
 | **Styles** | Layout issues | Computed styles vs expected, specificity conflicts |
 | **Performance** | Slow pages | LCP, CLS, INP, long tasks (>50ms) |
 | **Screenshots** | Visual changes | Before/after comparison for CSS and layout changes |
@@ -344,7 +361,7 @@ This separation ensures the test is written without knowledge of the fix, making
 
 ## See Also
 
-For detailed testing patterns, examples, and anti-patterns across frameworks, see `references/testing-patterns.md`.
+For detailed testing patterns, examples, and anti-patterns across frameworks, see `references/testing-patterns.md`. For accessibility-specific checks, see `references/accessibility-checklist.md`.
 
 ## Common Rationalizations
 

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-agent-skills
-description: Discovers and invokes agent skills. Use when starting a session or when you need to discover which skill applies to the current task. This is the meta-skill that governs how all other skills are discovered and invoked.
+description: Discovers and invokes agent skills. Use when starting a session, deciding which workflow or skill applies to a piece of work, or when you need to discover the right skill for the current task.
 ---
 
 # Using Agent Skills


### PR DESCRIPTION
Add accessibility testing guidance across TDD, browser testing, CI, references, and test-engineer coverage analysis. Add a11y eval prompts and tune skill descriptions so routing remains stable at 100% rank-1.