### PR TITLE
Add fixture-backed behavioral evals

### DIFF
--- a/evals/cases/code-simplification.json
+++ b/evals/cases/code-simplification.json
@@ -28,15 +28,19 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Simplify the provided 80-line function that parses config files, preserving exact behavior.",
+      "prompt": "Simplify the provided config parser while preserving exact behavior. Run the existing npm test suite before and after the refactor, reduce the nesting in src/config-parser.js, and do not add new features.",
       "expected_output": "A simpler implementation with identical behavior and a summary of what was removed and why",
+      "files": [
+        "code-simplification/package.json",
+        "code-simplification/src/config-parser.js",
+        "code-simplification/test/config-parser.test.js"
+      ],
       "expectations": [
         "Behavior is preserved (tests unchanged and passing, or equivalence argued concretely)",
         "Complexity is reduced rather than relocated",
         "The response explains what was removed and why it was safe",
         "No new features are added during the simplification"
-      ],
-      "trust_level": "provisional"
+      ]
     }
   ]
 }

--- a/evals/cases/debugging-and-error-recovery.json
+++ b/evals/cases/debugging-and-error-recovery.json
@@ -29,15 +29,19 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "A test that passed yesterday now fails with an off-by-one error in pagination. Find and fix the root cause.",
+      "prompt": "A pagination test is failing with an off-by-one error. Run npm test to reproduce it, identify the root cause in the pagination logic, make the minimal fix, and rerun the full suite.",
       "expected_output": "A reproduced failure, an identified root cause, a minimal fix, and a guard against regression",
+      "files": [
+        "debugging-and-error-recovery/package.json",
+        "debugging-and-error-recovery/src/pagination.js",
+        "debugging-and-error-recovery/test/pagination.test.js"
+      ],
       "expectations": [
         "The failure is reproduced before any fix is attempted",
         "The root cause is identified and stated, not just the symptom patched",
         "A regression test exists after the fix",
         "The fix is minimal and scoped to the cause"
-      ],
-      "trust_level": "provisional"
+      ]
     }
   ]
 }

--- a/evals/cases/test-driven-development.json
+++ b/evals/cases/test-driven-development.json
@@ -29,14 +29,18 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Fix the reported rounding bug in the invoice totals, test-first.",
+      "prompt": "Fix the reported rounding bug in invoice totals. Use npm test, write a failing test that exposes fractional-cent floating point output first, then make the minimal code change and run the full suite.",
       "expected_output": "A failing test demonstrating the bug, a minimal fix turning it green, full suite passing",
+      "files": [
+        "test-driven-development/package.json",
+        "test-driven-development/src/invoice.js",
+        "test-driven-development/test/invoice.test.js"
+      ],
       "expectations": [
         "A failing test is written and shown failing before the fix",
         "The implementation is the minimum needed to pass",
         "The full suite is run after the fix to catch regressions"
-      ],
-      "trust_level": "provisional"
+      ]
     }
   ]
 }

--- a/evals/fixtures/code-simplification/package.json
+++ b/evals/fixtures/code-simplification/package.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "test": "node --test"
+  },
+  "type": "module"
+}

--- a/evals/fixtures/code-simplification/src/config-parser.js
+++ b/evals/fixtures/code-simplification/src/config-parser.js
@@ -1,0 +1,52 @@
+export function parseConfig(source) {
+  const result = {};
+  const lines = source.split(/\r?\n/);
+
+  for (let i = 0; i < lines.length; i += 1) {
+    let line = lines[i];
+    if (line === undefined) {
+      continue;
+    } else {
+      line = line.trim();
+      if (line.length === 0) {
+        continue;
+      } else {
+        if (line[0] === "#") {
+          continue;
+        } else {
+          const equalsIndex = line.indexOf("=");
+          if (equalsIndex === -1) {
+            continue;
+          } else {
+            const rawKey = line.slice(0, equalsIndex);
+            const rawValue = line.slice(equalsIndex + 1);
+            const key = rawKey.trim();
+            let value = rawValue.trim();
+            if (value === "true") {
+              result[key] = true;
+            } else {
+              if (value === "false") {
+                result[key] = false;
+              } else {
+                const maybeNumber = Number(value);
+                if (value !== "" && Number.isFinite(maybeNumber)) {
+                  result[key] = maybeNumber;
+                } else {
+                  if (
+                    (value.startsWith('"') && value.endsWith('"')) ||
+                    (value.startsWith("'") && value.endsWith("'"))
+                  ) {
+                    value = value.slice(1, -1);
+                  }
+                  result[key] = value;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return result;
+}

--- a/evals/fixtures/code-simplification/test/config-parser.test.js
+++ b/evals/fixtures/code-simplification/test/config-parser.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseConfig } from "../src/config-parser.js";
+
+test("parses strings, booleans, and numbers", () => {
+  assert.deepEqual(
+    parseConfig(`
+      # ignored
+      host = "localhost"
+      port = 3000
+      debug = true
+      dryRun = false
+    `),
+    {
+      host: "localhost",
+      port: 3000,
+      debug: true,
+      dryRun: false
+    }
+  );
+});
+
+test("ignores blank lines and malformed lines", () => {
+  assert.deepEqual(
+    parseConfig(`
+      enabled = true
+
+      no equals here
+      retries = 2
+    `),
+    {
+      enabled: true,
+      retries: 2
+    }
+  );
+});

--- a/evals/fixtures/debugging-and-error-recovery/package.json
+++ b/evals/fixtures/debugging-and-error-recovery/package.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "test": "node --test"
+  },
+  "type": "module"
+}

--- a/evals/fixtures/debugging-and-error-recovery/src/pagination.js
+++ b/evals/fixtures/debugging-and-error-recovery/src/pagination.js
@@ -1,0 +1,8 @@
+export function pageItems(items, page, perPage) {
+  if (page < 1) throw new RangeError("page must be 1 or greater");
+  if (perPage < 1) throw new RangeError("perPage must be 1 or greater");
+
+  const start = (page - 1) * perPage;
+  const end = page * perPage - 1;
+  return items.slice(start, end);
+}

--- a/evals/fixtures/debugging-and-error-recovery/test/pagination.test.js
+++ b/evals/fixtures/debugging-and-error-recovery/test/pagination.test.js
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { pageItems } from "../src/pagination.js";
+
+const items = ["a", "b", "c", "d", "e"];
+
+test("returns the first page", () => {
+  assert.deepEqual(pageItems(items, 1, 2), ["a", "b"]);
+});
+
+test("returns the second page", () => {
+  assert.deepEqual(pageItems(items, 2, 2), ["c", "d"]);
+});
+
+test("keeps the final partial page", () => {
+  assert.deepEqual(pageItems(items, 3, 2), ["e"]);
+});

--- a/evals/fixtures/test-driven-development/package.json
+++ b/evals/fixtures/test-driven-development/package.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "test": "node --test"
+  },
+  "type": "module"
+}

--- a/evals/fixtures/test-driven-development/src/invoice.js
+++ b/evals/fixtures/test-driven-development/src/invoice.js
@@ -1,0 +1,4 @@
+export function invoiceTotal(items, taxRate = 0) {
+  const subtotal = items.reduce((sum, item) => sum + item.quantity * item.unitPrice, 0);
+  return subtotal + subtotal * taxRate;
+}

--- a/evals/fixtures/test-driven-development/test/invoice.test.js
+++ b/evals/fixtures/test-driven-development/test/invoice.test.js
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { invoiceTotal } from "../src/invoice.js";
+
+test("totals whole-dollar line items", () => {
+  assert.equal(
+    invoiceTotal([
+      { quantity: 2, unitPrice: 10 },
+      { quantity: 1, unitPrice: 5 }
+    ]),
+    25
+  );
+});
+
+test("applies tax to the subtotal", () => {
+  assert.equal(invoiceTotal([{ quantity: 1, unitPrice: 100 }], 0.075), 107.5);
+});


### PR DESCRIPTION
## What changed

- Added fixture workspaces for three behavioral evals: test-driven-development, debugging-and-error-recovery, and code-simplification.
- Updated the corresponding eval case files to reference real files via files[].
- Removed provisional trust markers from these three evals because they now run against concrete fixture workspaces.

## Why

Behavioral evals without fixtures are useful as sanity checks, but they do not prove that an agent can operate on real code. These fixtures let the Tier 3 runner materialize small Node.js projects so graders can inspect actual tool calls, edits, and test runs instead of relying on narration.

## What was implemented

- test-driven-development: a small invoice total module and passing test suite. The eval asks the agent to add a failing fractional-cent rounding test before making the minimal fix.
- debugging-and-error-recovery: a pagination module with an intentional off-by-one bug. The eval requires reproducing the failure, identifying the root cause, fixing it minimally, and rerunning tests.
- code-simplification: a deliberately nested config parser with passing coverage. The eval asks the agent to simplify the parser while preserving behavior and avoiding feature creep.

## Validation

- node scripts/validate-skills.js
- node scripts/run-evals.js
- npm test in evals/fixtures/test-driven-development
- npm test in evals/fixtures/code-simplification
- npm test in evals/fixtures/debugging-and-error-recovery fails intentionally before the agent fix, showing the seeded pagination bug is present