### PR TITLE
docs(skill-anatomy): explain the shared references/ design

### DIFF
--- a/docs/skill-anatomy.md
+++ b/docs/skill-anatomy.md
@@ -107,6 +107,16 @@ Keep patterns and principles inline when under 50 lines.
 
 If a skill does not need runnable helpers, do not create an empty `scripts/` directory just to mirror other skills. Empty directories add noise without changing how the skill works.
 
+## Shared References
+
+Checklists used by more than one skill — testing, security, performance, accessibility, definition-of-done — live in `references/` at the repository root, deliberately *not* inside any skill directory.
+
+This is a pack-level design choice. The Agent Skills spec describes a skill as a self-contained directory, but several skills here point at the same checklists. Colocating those would force one of two options: copy the checklist into every skill that uses it, or pick one skill to "own" it and have the others reach into that directory. Both drift over time. A single repo-root copy stays the source of truth.
+
+The tradeoff is portability: a whole-repo install (such as the Claude Code marketplace plugin) carries `references/` along, but a per-skill install that copies only `skills/<name>/` leaves the repo-root sibling behind, and those links resolve to nothing. That gap is tracked in [#361](https://github.com/addyosmani/agent-skills/issues/361).
+
+Rule of thumb: material used by exactly one skill is a supporting file inside that skill's directory; material shared across skills goes in `references/`.
+
 ## Context Efficiency
 
 Skills load on demand: only the skill name and description sit in context at startup. The full `SKILL.md` loads only when an agent decides the skill is relevant. To keep that load cheap:
@@ -142,7 +152,7 @@ When a skill ships runnable helpers under `scripts/`, each script follows these 
 - Skill directories: `lowercase-hyphen-separated`
 - Skill files: `SKILL.md` (always uppercase)
 - Supporting files: `lowercase-hyphen-separated.md`
-- References: stored in `references/` at the project root, not inside skill directories
+- References: stored in `references/` at the project root, not inside skill directories (see [Shared References](#shared-references) for why)
 
 ## Cross-Skill References
 

--- a/docs/skill-anatomy.md
+++ b/docs/skill-anatomy.md
@@ -115,7 +115,7 @@ This is a pack-level design choice. The Agent Skills spec describes a skill as a
 
 The tradeoff is portability: a whole-repo install (such as the Claude Code marketplace plugin) carries `references/` along, but a per-skill install that copies only `skills/<name>/` leaves the repo-root sibling behind, and those links resolve to nothing. That gap is tracked in [#361](https://github.com/addyosmani/agent-skills/issues/361).
 
-Rule of thumb: material used by exactly one skill is a supporting file inside that skill's directory; material shared across skills goes in `references/`.
+Current convention: material used by exactly one skill is a supporting file inside that skill's directory; material shared across skills goes in `references/`.
 
 ## Context Efficiency
 


### PR DESCRIPTION
## Summary

#329 asked why shared checklists live in repo-root `references/` instead of colocated per skill directory as the Agent Skills spec suggests, and whether that design should be documented. @addyosmani answered in the issue thread ("deliberate de-duplication... one source of truth... I may fold this rationale straight into the docs") — this PR does that folding.

- New **Shared References** section in `docs/skill-anatomy.md`: the deliberate de-duplication rationale (colocating means either copying checklists into every skill or picking an "owner" skill, and both drift), the portability tradeoff for per-skill installs with a link to #361, and a rule of thumb: used by one skill → supporting file in the skill directory; shared across skills → `references/`.
- Cross-link from the existing Naming Conventions bullet so both places that mention the convention point at the reasoning.

Deliberately narrow: this documents the design, it does not change the npx packaging behavior — that's #361/#366, where the approach is still being weighed.

## Test plan

- `node scripts/validate-skills.js` → 24 skills checked, 0 errors, 0 warnings
- `node scripts/run-evals.js` → 124 checks passed, rank-1 rate unchanged
- Docs-only change; no skill files touched

Closes #329.