### PR TITLE
docs(adr): match an existing ADR convention before creating one

### DIFF
--- a/skills/documentation-and-adrs/SKILL.md
+++ b/skills/documentation-and-adrs/SKILL.md
@@ -33,9 +33,19 @@ ADRs capture the reasoning behind significant technical decisions. They're the h
 - Choosing between build tools, hosting platforms, or infrastructure
 - Any decision that would be expensive to reverse
 
+### Match the existing convention first
+
+Before creating an ADR, check whether the project already has one — an established convention overrides the defaults below. Scan the repo **and**, for a GitHub org, its `.github` repo, including **open PRs** (a convention may be introduced in a not-yet-merged PR):
+
+- **Location and format** — e.g. `docs/adr/*.md`, `Documentation/Decisions/*.rst`, a MADR layout, or an `adr-tools` setup. Match the existing directory, file extension, and markup (Markdown vs reStructuredText).
+- **Numbering and naming** — continue the existing sequence and filename pattern (`ADR-004-Title.rst`, `0004-title.md`, …); don't restart at 001 or introduce a second scheme.
+- **Section headings** — reuse the project's heading set rather than imposing this template's.
+
+Only when no convention exists do you apply the default below.
+
 ### ADR Template
 
-Store ADRs in `docs/decisions/` with sequential numbering:
+Store ADRs in `docs/decisions/` with sequential numbering (unless the project already uses another location — see above):
 
 ```markdown
 # ADR-001: Use PostgreSQL for primary database

--- a/skills/documentation-and-adrs/SKILL.md
+++ b/skills/documentation-and-adrs/SKILL.md
@@ -35,13 +35,13 @@ ADRs capture the reasoning behind significant technical decisions. They're the h
 
 ### Match the existing convention first
 
-Before creating an ADR, check whether the project already has one — an established convention overrides the defaults below. Scan the repo **and**, for a GitHub org, its `.github` repo, including **open PRs** (a convention may be introduced in a not-yet-merged PR):
+Before creating an ADR, inspect the available repository context for an established convention — existing ADRs, project instructions, and ADR-related configuration or tooling (e.g. an `.adr-dir` file). An established convention overrides the defaults below. Match:
 
 - **Location and format** — e.g. `docs/adr/*.md`, `Documentation/Decisions/*.rst`, a MADR layout, or an `adr-tools` setup. Match the existing directory, file extension, and markup (Markdown vs reStructuredText).
 - **Numbering and naming** — continue the existing sequence and filename pattern (`ADR-004-Title.rst`, `0004-title.md`, …); don't restart at 001 or introduce a second scheme.
 - **Section headings** — reuse the project's heading set rather than imposing this template's.
 
-Only when no convention exists do you apply the default below.
+If the available evidence conflicts, surface the conflict rather than silently introducing another scheme. Only when no convention can be established do you apply the default below.
 
 ### ADR Template
 


### PR DESCRIPTION
## What

Adds a short "Match the existing convention first" step to the `documentation-and-adrs` skill, before the ADR Template section.

## Why

The template hard-codes `docs/decisions/` Markdown with its own numbering and headings. Many repos already have a different ADR convention — a different location or markup (e.g. `Documentation/Decisions/*.rst`, MADR, `adr-tools`), sometimes introduced in a **not-yet-merged PR** or an org-level `.github` repo. Following the template blindly then creates a second, inconsistent scheme.

The added step: detect an existing convention (location/format, numbering/naming, headings) — scanning open PRs and the org `.github` repo — and continue it; fall back to the `docs/decisions/` default only when none exists.

One line added, no restructuring. markdownlint adds no new findings (the file has pre-existing default-ruleset warnings unrelated to this change; the repo ships no markdownlint config).