### PR TITLE
fix(validator): reject fenced-block headings and negated triggers

### DIFF
--- a/scripts/lib/skill-lint.js
+++ b/scripts/lib/skill-lint.js
@@ -34,7 +34,10 @@ const KEBAB_CASE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 // A description must state WHEN to use the skill, not just what it does
 // (docs/skill-anatomy.md → Required). Accept the canonical "Use when …"
 // plus the equivalent "Use before/after/during …" phrasings in use today.
-const DESCRIPTION_TRIGGER = /\buse (this )?when\b|\buse (before|after|during)\b/i;
+// Reject negated forms ("Do not use when …", "Don't use when …") — those
+// describe exclusions, not trigger conditions.
+const DESCRIPTION_TRIGGER        = /\buse (this )?when\b|\buse (before|after|during)\b/i;
+const DESCRIPTION_TRIGGER_NEGATE = /\b(do not|don't|never) use (this )?(when|before|after|during)\b/i;
 
 // Sections every standard SKILL.md must contain.
 // Each entry is an array of acceptable heading strings — the first
@@ -73,6 +76,14 @@ const SKILL_REF_PATTERNS = [
 ];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Strip fenced code blocks from markdown content so that headings, references,
+ * and trigger phrases inside examples or templates are not matched by lint rules.
+ */
+function stripFencedCodeBlocks(content) {
+  return content.replace(/^(`{3,})[^\n]*\n[\s\S]*?^\1\s*$/gm, '');
+}
 
 /**
  * Parse YAML-style frontmatter from the top of a markdown file.
@@ -150,7 +161,10 @@ function lintSkillContent(dirName, content, knownSkills) {
         ` (agents inject this into the system prompt)`
       );
     }
-    if (!DESCRIPTION_TRIGGER.test(fm.description)) {
+    const hasTrigger       = DESCRIPTION_TRIGGER.test(fm.description);
+    const onlyNegated      = hasTrigger && DESCRIPTION_TRIGGER_NEGATE.test(fm.description)
+      && !fm.description.replace(DESCRIPTION_TRIGGER_NEGATE, '').match(DESCRIPTION_TRIGGER);
+    if (!hasTrigger || onlyNegated) {
       errors.push(
         `Description has no 'when to use' trigger — add a "Use when …" clause ` +
         `(skill-anatomy.md: Required — the description must say both what the skill does and when to use it)`
@@ -176,8 +190,15 @@ function lintSkillContent(dirName, content, knownSkills) {
   exempt = dirName in SECTION_EXEMPT_SKILLS;
 
   if (!exempt) {
+    // Strip fenced code blocks so headings inside examples/templates don't
+    // satisfy the check, and match headings at the start of a line so
+    // `### Verification` inside a block doesn't satisfy `## Verification`.
+    const proseContent = stripFencedCodeBlocks(content);
     for (const aliases of REQUIRED_SECTIONS) {
-      const found = aliases.some(heading => content.includes(heading));
+      const found = aliases.some(heading => {
+        const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        return new RegExp(`^${escaped}\\s*$`, 'm').test(proseContent);
+      });
       if (!found) {
         errors.push(`Missing required section: ${aliases[0]}`);
       }


### PR DESCRIPTION
## Summary

Fixes the two validator heuristic bugs I [claimed on #387](https://github.com/addyosmani/agent-skills/issues/387#issuecomment-4971842600), now that #379 has landed:

**Section check** (`scripts/lib/skill-lint.js`): the old check used `content.includes('## Overview')`, which matches headings inside fenced code blocks (a `## Overview` in a template example would satisfy the real section requirement) and sub-headings (`### Verification` contains the substring `## Verification`). Replaced with a line-anchored regex match against content that has had fenced code blocks stripped via a new `stripFencedCodeBlocks()` helper. Only real `##`-level headings in prose now satisfy the check.

**Trigger check**: a description like "Does stuff. Do not use when testing." satisfied `DESCRIPTION_TRIGGER` because it contains "use … when". Added `DESCRIPTION_TRIGGER_NEGATE` to catch "do not / don't / never use when" and reject descriptions where the only trigger match is a negated form. Descriptions with both a positive and negated trigger still pass (the positive is what matters; the negated describes exclusions, which is fine).

The remaining two items from #387 — frontmatter YAML-subset parsing and cross-reference patterns matching inside fences — are unclaimed and available for follow-up.

## Test plan

- `node scripts/validate-skills.js` → 24 skills, 0 errors, 0 warnings — output is **byte-identical** to the pre-change run (no current skill hits either bug pattern, so these are purely defensive fixes)
- Crafted edge cases exercised against `lintSkillContent` directly:
  - Headings only inside fenced blocks → 5 missing-section errors (previously: 0 — they were silently satisfied)
  - `### Verification` outside a fence → missing `## Verification` error (previously: passed via substring match)
  - Description with only "Do not use when …" → missing-trigger error (previously: passed)
  - Description with both "Use when …" and "Do not use when …" → passes (the positive trigger counts)
- `node scripts/run-evals.js` → 124 checks passed, rank-1 rate 86% — unchanged

Partial fix for #387 (section check + trigger negation).