### PR TITLE
fix(hooks): make simplify-ignore-test pass on machines without jq

### DIFF
--- a/hooks/simplify-ignore-test.sh
+++ b/hooks/simplify-ignore-test.sh
@@ -238,8 +238,14 @@ assert_eq "HTML suffix preserved" "1" "$(grep -c '\-\->' "$DEST")"
 # ── Test 10: JSON parsing error warning ──────────────────────────────────
 printf '\nTest 10: Malformed JSON input produces warning\n'
 
+# Without jq the hook's guard exits before parsing input. Assert whichever
+# branch this machine can exercise (same pattern as session-start-test.sh).
 warning_out=$(echo 'NOT_JSON{{{' | bash hooks/simplify-ignore.sh 2>&1) || true
-assert_eq "warning on bad JSON" "1" "$(printf '%s' "$warning_out" | grep -c 'Warning.*failed to parse')"
+if command -v jq >/dev/null 2>&1; then
+  assert_eq "warning on bad JSON" "1" "$(printf '%s' "$warning_out" | grep -c 'Warning.*failed to parse')"
+else
+  assert_eq "missing-jq guard surfaced" "1" "$(printf '%s' "$warning_out" | grep -c 'error: missing jq')"
+fi
 
 # ── Summary ──────────────────────────────────────────────────────────────
 printf '\n══════════════════════════════════════════\n'


### PR DESCRIPTION
## Problem

`bash hooks/simplify-ignore-test.sh` (the run command documented in the file header) fails on machines where `jq` is not on PATH — e.g. a default Git for Windows install:

```
Test 10: Malformed JSON input produces warning
  FAIL: warning on bad JSON
    expected: 1
    actual:   0

Results: 20 passed, 1 failed
```

Test 10 pipes malformed JSON through the real hook end-to-end, but `simplify-ignore.sh` requires jq and its guard exits with `error: missing jq` before input parsing is reached. Tests 1–9 only exercise the extracted `filter_file` (no jq needed), so contributors on jq-less machines see exactly one failure that has nothing to do with their change. CI runs the validators and evals but not the hook self-tests, so this only ever bites local contributors.

## Fix

Follow the precedent CONTRIBUTING documents for `session-start-test.sh` ("validates the hook's JSON payload — both when jq is available and when it isn't"): detect jq and assert whichever branch the machine can exercise.

- jq on PATH → assertion unchanged: malformed JSON produces the `Warning: failed to parse …` diagnostic.
- no jq → assert the hook's documented `error: missing jq` guard instead.

## Testing

On Windows (Git Bash):

- without jq: `Results: 21 passed, 0 failed` (was 20 passed, 1 failed)
- with jq 1.8.1 on PATH: `Results: 21 passed, 0 failed` (assertion identical to before)

## Not a duplicate

Checked open PRs and issues: #385 addresses the hook's unchecked perl dependency (a different defect in `simplify-ignore.sh` itself); no open PR or issue touches the test's jq assumption.
