### PR TITLE
docs: fix orchestration-patterns.md reference mapping in getting-started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,7 +136,7 @@ The `references/` directory contains supplementary checklists:
 | `accessibility-checklist.md` | frontend-ui-engineering |
 | `definition-of-done.md` | all skills / every change |
 | `observability-checklist.md` | observability-and-instrumentation |
-| `orchestration-patterns.md` | context-engineering |
+| `orchestration-patterns.md` | doubt-driven-development |
 
 Load a reference when you need detailed patterns beyond what the skill covers.
 


### PR DESCRIPTION
## Summary
- The "Using References" table in `docs/getting-started.md` mapped `references/orchestration-patterns.md` to the `context-engineering` skill, but that skill never mentions the reference.
- `references/orchestration-patterns.md` is actually cited by the `doubt-driven-development` skill (`skills/doubt-driven-development/SKILL.md` lines 46 and 229), which documents the "personas don't invoke other personas" orchestration rule.
- This PR corrects the table row so the doc matches the actual skill that consumes the reference.

## Test plan
- [x] Verified via `grep -rn "orchestration-patterns" .` that `doubt-driven-development/SKILL.md` references it explicitly, while `context-engineering/SKILL.md` has zero mentions.
- Docs-only change, no code/behavior affected.