### PR TITLE
feat: add test case design skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Skills also activate automatically based on what you're doing — designing an A
 **Fastest path — any agent, one command.** The open [skills CLI](https://github.com/vercel-labs/skills) installs into 70+ agents (Claude Code, Cursor, Codex, Copilot, Cline, and more):
 
 ```bash
-npx skills add addyosmani/agent-skills            # install all 24 skills
+npx skills add addyosmani/agent-skills            # install all 25 skills
 npx skills add addyosmani/agent-skills --list     # browse before installing
 ```
 
@@ -193,9 +193,9 @@ Already installed? How you roll the pack out depends on your codebase. The **[Ad
 
 ---
 
-## All 24 Skills
+## All 25 Skills
 
-The commands above are entry points. The pack includes 24 skills total — 23 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
+The commands above are entry points. The pack includes 25 skills total — 24 lifecycle skills plus the `using-agent-skills` meta-skill. Each skill is a structured workflow with steps, verification gates, and anti-rationalization tables. You can also reference any skill directly.
 
 ### Meta - Discover which skill applies
 
@@ -216,6 +216,7 @@ The commands above are entry points. The pack includes 24 skills total — 23 li
 | Skill | What It Does | Use When |
 |-------|-------------|----------|
 | [planning-and-task-breakdown](skills/planning-and-task-breakdown/SKILL.md) | Decompose specs into small, verifiable tasks with acceptance criteria and dependency ordering | You have a spec and need implementable units |
+| [test-case-design](skills/test-case-design/SKILL.md) | Analyze test basis and risk, apply the 80/15/5 cost guideline, and produce a Test Planner with concrete Case Specifications | Deciding what to test, reviewing coverage gaps, or preparing cases for TDD |
 
 ### Build - Write the code
 
@@ -324,7 +325,7 @@ Every skill follows a consistent anatomy:
 
 ```
 agent-skills/
-├── skills/                            # 24 skills (23 lifecycle + 1 meta)
+├── skills/                            # 25 skills (24 lifecycle + 1 meta)
 │   ├── interview-me/                  #   Define
 │   ├── idea-refine/                   #   Define
 │   ├── spec-driven-development/       #   Define

--- a/evals/cases/test-case-design.json
+++ b/evals/cases/test-case-design.json
@@ -1,0 +1,159 @@
+{
+  "skill_name": "test-case-design",
+  "trigger": {
+    "positive": [
+      {
+        "prompt": "Before we change checkout, tell me which tests are actually necessary and which layers would just duplicate coverage",
+        "top_k": 1
+      },
+      {
+        "prompt": "I have requirements for a quantity field but no test list. Give me implementable cases with setup, input, action, and exact expected results",
+        "top_k": 1
+      },
+      {
+        "prompt": "What values should we test around the minimum and maximum for this quantity validator?",
+        "top_k": 1
+      },
+      {
+        "prompt": "Map these discount conditions and precedence rules to the smallest set of tests that covers every outcome",
+        "top_k": 1
+      },
+      {
+        "prompt": "Which test cases cover the legal and illegal event sequences for this order workflow, including retries?",
+        "top_k": 1
+      },
+      {
+        "prompt": "We cannot run every browser, locale, plan, and login combination. Give me a defensible reduced test matrix",
+        "top_k": 2
+      }
+    ],
+    "negative": [
+      {
+        "prompt": "Write a failing test for this bug and then implement the fix",
+        "owner": "test-driven-development"
+      },
+      {
+        "prompt": "This previously passing test now fails intermittently; diagnose and fix the root cause",
+        "owner": "debugging-and-error-recovery"
+      }
+    ]
+  },
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Use the Inventory Reservation API requirements in the fixture. Produce only a Test Planner and concrete test-case model that efficiently covers quantity validation; do not implement anything.",
+      "expected_output": "An API-layer plan whose equivalence partitions and boundary model derive explicit representatives below, at, and above both inclusive limits",
+      "files": [
+        "test-design-methods"
+      ],
+      "expectations": [
+        "The fixture requirements are the test basis; API is primary while the unchanged contract is kept separate",
+        "Valid and invalid partitions include missing, null, wrong-type, fractional, and out-of-range inputs",
+        "Boundary cases include 0, 1, 2, 99, 100, and 101 with exact expected outcomes",
+        "Each concrete case is derived from a named partition or boundary rather than merely naming a technique",
+        "Each case is reconstructable from a complete Case Specification or shared procedure plus data row, including stable ID and name, objective, layer, setup and data, action, expected result and oracle, coverage point, priority, and READY or BLOCKED status"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Use the Discount Rules in the fixture. Produce only a Test Planner and a compact concrete case model covering every reachable outcome and precedence rule; do not implement anything.",
+      "expected_output": "A unit-layer decision table that represents the conditions, discount precedence, non-stacking behavior, and every reachable outcome",
+      "files": [
+        "test-design-methods"
+      ],
+      "expectations": [
+        "Unit is selected as the lowest sufficient layer for the pure discount-selection rules",
+        "The decision table models membership, subtotal threshold, valid coupon, and resulting discount",
+        "Loyalty-over-coupon precedence and the no-stacking rule are explicit",
+        "Every reachable rule has a concrete case or justified collapse; boundary values around $100 may supplement but do not replace the table"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Use the Order State Machine in the fixture. Produce only a Test Planner and a concrete case model for valid and invalid event sequences, retries, and side effects; do not implement anything.",
+      "expected_output": "A state-transition model covering valid transitions, important invalid transitions, and idempotent repeated payment without duplicate side effects",
+      "files": [
+        "test-design-methods"
+      ],
+      "expectations": [
+        "The model names states, events, next states, and charge or rejection outcomes",
+        "Draft-to-Paid, Paid-to-Shipped, and Draft-to-Cancelled transitions are covered",
+        "Shipping Draft, paying Cancelled, and cancelling Shipped are covered as invalid transitions",
+        "Repeated payment in Paid proves idempotency and no duplicate charge",
+        "The layer choice is separate from the technique, and every multi-step case pairs each action with its expected observation"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Use the Deployment Matrix in the fixture. Produce only a Test Planner and a reduced concrete case model that covers the documented combinations efficiently; do not implement anything.",
+      "expected_output": "A bounded pairwise plan with a factor/value model, generated case set, pair-coverage evidence, and the known high-risk four-factor combination",
+      "files": [
+        "test-design-methods"
+      ],
+      "expectations": [
+        "Browser, locale, plan, and authentication are listed with all documented values",
+        "A concrete reduced case set and a way to generate or verify pair coverage are provided",
+        "Safari + ja-JP + Enterprise + SSO is included explicitly as a high-risk combination",
+        "The plan does not claim pairwise coverage handles every three-way or four-way interaction"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Use the Refund Eligibility Sources in the test-planner-advanced fixture. Produce only a Test Planner and the cases that can be specified responsibly; do not implement anything.",
+      "expected_output": "A plan that exposes the unresolved oracle conflict, avoids inventing deadline behavior, and separates blocked boundary expectations from undisputed coverage",
+      "files": [
+        "test-planner-advanced"
+      ],
+      "expectations": [
+        "The calendar-day criterion and 720-hour API example are both named as conflicting test-basis sources",
+        "The plan does not choose an oracle or encode current implementation behavior as the expected result",
+        "Timezone and daylight-saving boundary cases are BLOCKED while undisputed cases may remain READY with explicit expected results",
+        "The next action names the product or API owner needed to resolve the conflict"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Use the Checkout Client Migration in the test-planner-advanced fixture. Produce only the smallest sufficient Test Planner for the release; do not implement anything.",
+      "expected_output": "A cross-stack plan led by consumer/provider contract evidence, with adjacent frontend and API checks plus one bounded critical E2E journey",
+      "files": [
+        "test-planner-advanced"
+      ],
+      "expectations": [
+        "The approved OpenAPI migration and one-release mobile compatibility requirement form the test basis",
+        "Contract is primary for old and regenerated consumer/provider compatibility rather than being conflated with API behavior",
+        "API checks cover provider endpoint behavior without claiming to prove both consumers remain compatible",
+        "Frontend Integration covers the generated web client and confirmation page with a mocked backend",
+        "One critical real checkout journey is justified at E2E while alternate compatibility and error cases stay lower"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Use the Order Commit Workflow in the test-planner-advanced fixture. Produce only a Test Planner and focused case model; do not implement anything.",
+      "expected_output": "A backend-integration-led plan for transaction atomicity, retry idempotency, and duplicate delivery without unnecessary contract or browser coverage",
+      "files": [
+        "test-planner-advanced"
+      ],
+      "expectations": [
+        "The transaction, rollback, idempotency, and duplicate-delivery requirements form the test basis",
+        "Backend Integration is primary because the behavior depends on the real database transaction and outbox persistence",
+        "Focused Unit cases may cover pure rules, while API is adjacent only when endpoint orchestration needs evidence",
+        "Contract is skipped because request and response schemas are unchanged",
+        "Failure, retry, and duplicate-delivery cases assert observable stock, order, and outbox outcomes rather than internal calls"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Use the Bulk Import Discovery scenario in the test-planner-advanced fixture. Produce only a risk-aware Test Planner for the two-hour session and release decision; do not implement anything.",
+      "expected_output": "An adaptive plan combining stable scripted evidence with a time-boxed exploratory charter, historical defect heuristics, explicit exit criteria, and residual-risk ownership",
+      "files": [
+        "test-planner-advanced"
+      ],
+      "expectations": [
+        "Settled UTF-8 examples are separated from unresolved duplicate, encoding, partial-failure, cancellation, and retry oracles",
+        "Stable scripted checks are combined with a time-boxed exploratory charter, while historical incidents remain risk heuristics rather than case-design techniques",
+        "The two-hour limit is a forced stop rather than proof that exit criteria were satisfied",
+        "The report names coverage, discoveries, blocked areas, residual risk, and acceptance by the customer-data product lead"
+      ]
+    }
+  ]
+}

--- a/evals/fixtures/test-design-methods/README.md
+++ b/evals/fixtures/test-design-methods/README.md
@@ -1,0 +1,38 @@
+# Test Design Planning Fixture
+
+This fixture contains requirements for test-planning evals. Produce a Test Planner and concrete test-case model only; there is no implementation to edit or execute.
+
+## Inventory Reservation API
+
+`POST /inventory/reserve` accepts a required `quantity` field. It must be an integer from 1 through 100 inclusive. Missing, null, string, fractional, zero, negative, and values above 100 are rejected with status 422. Authentication behavior and the request/response schema are unchanged.
+
+## Discount Rules
+
+Discount selection depends on three conditions:
+
+- the customer is a member;
+- the cart subtotal is at least $100;
+- a campaign coupon is valid.
+
+A member with a qualifying subtotal receives a 10% loyalty discount, even when a valid coupon is present. Otherwise, a valid coupon gives 5%. All other carts receive no discount. Discounts never stack.
+
+## Order State Machine
+
+Orders start in `Draft`.
+
+- `pay` moves `Draft` to `Paid` and charges once.
+- repeating `pay` in `Paid` is idempotent and must not charge again.
+- `ship` moves `Paid` to `Shipped`.
+- `cancel` moves `Draft` to `Cancelled`.
+- shipping a `Draft` order, paying a `Cancelled` order, and cancelling a `Shipped` order are invalid transitions.
+
+## Deployment Matrix
+
+The supported factors are:
+
+- Browser: Chrome, Firefox, Safari
+- Locale: en-US, fr-FR, ja-JP
+- Plan: Free, Pro, Enterprise
+- Authentication: Password, SSO
+
+The full Cartesian set is too expensive. Safari + ja-JP + Enterprise + SSO is a known high-risk combination that must be included even if a pairwise generator omits it.

--- a/evals/fixtures/test-planner-advanced/README.md
+++ b/evals/fixtures/test-planner-advanced/README.md
@@ -1,0 +1,41 @@
+# Advanced Test Planner Scenarios
+
+This fixture contains four independent planning scenarios. Produce plans and
+case models only; there is no implementation to edit or execute.
+
+## Refund Eligibility Sources
+
+Two approved sources disagree at the refund deadline:
+
+- The product acceptance criterion says a purchase remains refundable through
+  the end of the 30th calendar day in the merchant's configured timezone.
+- The public API example says a refund is accepted while
+  `now <= purchasedAt + 720 hours`.
+
+The difference is observable across daylight-saving changes and when merchant
+and purchaser timezones differ. No owner has resolved which source controls.
+
+## Checkout Client Migration
+
+The approved migration changes the checkout response field `total` to
+`grandTotal` in OpenAPI and regenerates the web client. The React confirmation
+page is updated in the same release. Validation, authorization, and persistence
+behavior are unchanged. A mobile consumer remains on the old response shape for
+one release and must continue working. Checkout is a critical revenue journey.
+
+## Order Commit Workflow
+
+The order service now reserves stock, inserts the order, and writes an outbox
+event in one database transaction. The HTTP request and response schemas are
+unchanged. A database error must roll back all three effects. Retrying the same
+idempotency key must not reserve stock or emit an event twice. Delivery workers
+may receive the outbox event more than once.
+
+## Bulk Import Discovery
+
+A new CSV customer import has examples for UTF-8 comma-separated files, but
+requirements for duplicate rows, mixed encodings, partial failure, cancellation,
+and retry are not settled. Previous import incidents involved duplicate records,
+silent row loss, and files that passed validation but failed after several
+minutes. The team has a two-hour test session before the release decision. The
+release owner is the customer-data product lead.

--- a/references/test-design-techniques.md
+++ b/references/test-design-techniques.md
@@ -1,0 +1,385 @@
+# Test Design Techniques
+
+Operational reference for choosing test cases when coverage matters. This is a compact, paraphrased field guide inspired by Lee Copeland's *A Practitioner's Guide to Software Test Design*.
+
+Use this reference from `test-case-design` when reviewing coverage gaps or deciding which behaviors deserve tests. It complements `testing-patterns.md`: this file chooses *what cases to test*; `testing-patterns.md` shows *how to write the tests* in common frameworks.
+
+## Contents
+
+- [Planning Decision Model](#planning-decision-model)
+- [Case-Design Technique Selector](#case-design-technique-selector)
+- [Basic Selection Patterns](#basic-selection-patterns)
+- [Black Box Techniques](#black-box-techniques)
+- [White Box Techniques](#white-box-techniques)
+- [Operating Mode](#operating-mode)
+- [Risk Heuristics](#risk-heuristics)
+- [Exit Criteria](#exit-criteria)
+- [Applying This To Test Planner](#applying-this-to-test-planner)
+
+## Planning Decision Model
+
+Keep four decisions separate:
+
+| Decision | Question | Examples |
+|---|---|---|
+| Case-design technique | How will representative cases be derived? | boundary values, decision table, pairwise |
+| Operating mode | How will learning and execution proceed? | scripted, exploratory, adaptive |
+| Risk heuristic | What defect ideas might be missing? | taxonomy, historical defects, production incidents |
+| Exit criteria | What evidence is enough to stop, and who accepts residual risk? | required gates, risk coverage, explicit owner acceptance |
+
+These are orthogonal planning dimensions: they answer different questions, and a plan may use several of them together. Individual case-design techniques can also combine when each exposes a distinct risk; record the artifact produced by each one.
+
+## Case-Design Technique Selector
+
+| Testing need | Prefer | Good fit |
+|---|---|---|
+| One concrete behavior has no meaningful partitions or combinations | Direct example | a focused example, simple mapping, one invariant |
+| A known defect must never recur | Regression reproduction | bug fixes, incident follow-up, escaped defects |
+| Inputs can be grouped by expected behavior | Equivalence class testing | validators, parsers, form fields, API inputs |
+| Defects likely near thresholds | Boundary value testing | min/max, dates, pagination, limits, feature flags |
+| Many business rules combine conditions and outcomes | Decision table testing | pricing, eligibility, routing, permissions |
+| Too many independent configuration combinations | Pairwise testing | browsers, devices, plans, locales, feature toggles |
+| Behavior depends on current state and events | State-transition testing | workflows, protocols, auth/session, lifecycle states |
+| Multiple numeric variables interact | Domain analysis testing | ranges constrained by other ranges, geometry, finance |
+| A user or actor completes a goal | Use case testing | checkout, signup, onboarding, CRUD transaction paths |
+| Code paths are complex | Control flow testing | branch-heavy logic, loops, exception paths |
+| Variable lifecycle matters | Data flow testing | initialization, mutation, cleanup, cached values |
+
+### Required Technique Artifacts
+
+| Technique | Evidence that the technique was actually applied |
+|---|---|
+| Direct example | Concrete input/precondition, action, and expected result |
+| Regression reproduction | Minimal reproducer and the expected RED failure reason |
+| Equivalence classes | Named valid/invalid partitions and a representative from each |
+| Boundary values | Named boundaries with below/at/above cases where meaningful |
+| Decision table | Conditions, outcomes, reachable rules, and one case per rule |
+| Pairwise | Factor/value model, generated case set, and pair-coverage evidence |
+| State transition | States, events, transitions, actions, and important invalid transitions |
+| Domain analysis | Dimensions, boundaries, inside/outside points, and intersections |
+| Use case | Actor, goal, main path, and selected alternate/error paths |
+| Control flow | Decisions/loops covered and observable outcomes asserted |
+| Data flow | Important define-use paths and stale/uninitialized/cleanup risks |
+
+Naming a technique without its artifact is not evidence that the technique shaped the tests.
+
+## Basic Selection Patterns
+
+### Direct Example
+
+Use for one concrete behavior that has no useful partition, threshold, combination, or state model. Record the precondition or input, action, and expected observable result. Do not apply a more formal label merely to fill a planner field.
+
+### Regression Reproduction
+
+Use for a known defect. Preserve the smallest input and setup that reproduce it, state why the test must fail before the fix, then keep the case as permanent regression coverage. Add another technique only when it reveals additional cases beyond the reported defect.
+
+## Black Box Techniques
+
+### Equivalence Class Testing
+
+Use when many inputs should be handled identically.
+
+Steps:
+1. Identify one input, field, API parameter, or condition.
+2. Partition values into valid and invalid classes.
+3. Pick at least one representative from each class.
+4. Add explicit invalid-class cases; do not only test happy paths.
+5. Re-check classes whenever validation rules change.
+
+Watch for:
+- Empty, missing, null, malformed, unsupported, duplicate, and unauthorized inputs.
+- Hidden classes created by business policy, not just type constraints.
+- Classes that look equivalent to users but are different to the system.
+
+Layer mapping:
+- Unit for pure validation or parsing.
+- API for request validation, auth, status code, and error shape.
+- Component/frontend integration for form behavior and visible error states.
+
+### Boundary Value Testing
+
+Use when behavior changes at edges.
+
+Steps:
+1. Identify each ordered range or threshold.
+2. Test values just below, exactly at, and just above each boundary.
+3. Include minimum, maximum, first, last, zero, negative, empty, and overflow cases where relevant.
+4. For dates and times, test timezone, daylight saving, inclusive/exclusive end dates, and precision.
+
+Watch for:
+- Off-by-one errors.
+- Inclusive vs exclusive boundaries.
+- Boundary rules that differ between frontend and backend.
+
+Layer mapping:
+- Unit for algorithms and domain rules.
+- API for backend validation boundaries.
+- Contract when a boundary is part of a public schema or generated client.
+
+### Decision Table Testing
+
+Use when outcomes depend on combinations of conditions.
+
+Steps:
+1. List conditions as rows.
+2. List actions or expected outcomes as rows.
+3. Enumerate meaningful rules as columns.
+4. Collapse impossible or irrelevant combinations only after naming why.
+5. Create at least one test per rule that can fire.
+
+Watch for:
+- Default or fallback rule missing.
+- Two rules overlap but produce different outcomes.
+- Impossible combinations that become possible after a product change.
+
+Layer mapping:
+- Unit for pure business rule functions.
+- API for endpoint-level policy decisions.
+- Backend integration when the rule depends on persistence or external state.
+
+### Pairwise Testing
+
+Use when full Cartesian coverage is too expensive but independent factors may interact.
+
+Steps:
+1. Identify factors and values.
+2. Remove values that are impossible or out of scope.
+3. Generate a set that covers every pair of factor values.
+4. Add extra high-risk triples or known-bad combinations manually.
+5. Keep the factor/value model with the tests so future changes can update it.
+
+Use a project-approved pairwise generator when available, or mechanically enumerate expected pairs and verify the proposed set covers them. Do not claim pair coverage from visual inspection alone; report an unverified proposal when no generator or coverage check was run.
+
+Watch for:
+- Pairwise is not enough when defects require three or more interacting factors.
+- Invalid combinations can pollute the generated set.
+- Risky combinations should be added even if pairwise generation omits them.
+
+Layer mapping:
+- Component/frontend integration for UI state matrices.
+- API for endpoint parameter matrices.
+- E2E only for a small number of critical cross-system combinations.
+
+### State-Transition Testing
+
+Use when the system remembers state and events must occur in valid order.
+
+Steps:
+1. Name all states.
+2. Name events that trigger transitions.
+3. Name actions or side effects for each transition.
+4. Test each valid transition at least once.
+5. Test invalid transitions from important states.
+6. Add reset, retry, cancellation, timeout, and idempotency cases.
+
+Watch for:
+- Missing invalid-transition tests.
+- State leakage between tests.
+- Tests that start from impossible states without setup justification.
+
+Layer mapping:
+- Unit for reducers/state machines.
+- Backend integration for persisted lifecycle state.
+- E2E for critical user journeys through multiple states.
+
+### Domain Analysis Testing
+
+Use when multiple ordered variables interact and one variable constrains another.
+
+Steps:
+1. Identify dimensions and their valid ranges.
+2. Identify boundaries across multiple dimensions.
+3. Test on the boundary, just inside, and just outside each region.
+4. Include intersections where two or more boundaries meet.
+
+Watch for:
+- Testing each variable alone when the bug is in the interaction.
+- Missing precision and rounding issues.
+- Validity regions that shift when configuration changes.
+
+Layer mapping:
+- Unit for mathematical/domain calculations.
+- API for request combinations with cross-field validation.
+- Backend integration when valid regions depend on stored data.
+
+### Use Case Testing
+
+Use when a user, actor, or system completes a goal through a transaction.
+
+Steps:
+1. Name the actor and goal.
+2. Write the main success scenario.
+3. Add alternate, error, cancel, timeout, and retry paths.
+4. Identify required test data for each scenario.
+5. Keep end-to-end coverage focused on critical paths; push smaller checks down to lower layers.
+
+Watch for:
+- Only testing the happy path.
+- Ignoring test data setup cost.
+- Putting every alternate path into E2E when API, frontend integration, or backend integration tests would prove it faster.
+
+Layer mapping:
+- Frontend integration for UI flow with mocked backend.
+- API/backend integration for transaction rules and persistence.
+- E2E for must-not-break business journeys.
+
+## White Box Techniques
+
+### Control Flow Testing
+
+Use when code structure has meaningful branches, loops, or exception paths.
+
+Steps:
+1. Sketch the major branches and loops.
+2. Cover each decision outcome.
+3. Cover loop zero, one, many, and boundary iteration cases when relevant.
+4. Use complexity as a signal: high branch count needs either more tests or simpler code.
+
+Watch for:
+- Chasing path exhaustiveness in complex code instead of refactoring.
+- Missing error/exception paths.
+- Tests coupled to internal structure rather than observable behavior.
+
+### Data Flow Testing
+
+Use when variable lifecycle can break behavior.
+
+Steps:
+1. Identify where important values are defined, updated, used, and cleared.
+2. Test define-use paths that affect observable behavior.
+3. Add cases for uninitialized, stale, overwritten, cached, or destroyed values.
+
+Watch for:
+- Shared mutable state between tests.
+- Cache invalidation and cleanup paths.
+- Variables that are set in one branch and read in another.
+
+## Operating Mode
+
+Operating mode describes how testing proceeds; it is not a case-design technique.
+
+| Mode | Required artifact |
+|---|---|
+| Scripted | Repeatable cases, expected results, and traceability required by the project |
+| Exploratory | Time-boxed charter, observations, defects, coverage notes, and follow-up candidates |
+| Adaptive | Initial scripted scope plus recorded changes made from evidence discovered during testing |
+
+### Scripted Testing
+
+Use when predictability, auditability, and repeatability matter.
+
+Good for:
+- Compliance and regulated workflows.
+- Regression suites with stable behavior.
+- Teams that need handoff, traceability, or documented procedures.
+
+Risk:
+- Scripts can become stale and blind to new information.
+
+### Exploratory Testing
+
+Use when learning and test design must happen together.
+
+Good for:
+- New features with unknown risks.
+- UI behavior, usability, and odd flows.
+- Investigating suspicious behavior before writing permanent tests.
+
+Rule:
+- Preserve what you learn. Convert important discoveries into automated tests, bug reports, or updated charters.
+
+### Adaptive Test Planning
+
+Use scripted and exploratory testing together. Plan enough to guide effort, but update the plan as new information arrives.
+
+Practical split:
+- Scripted tests protect known critical behavior.
+- Exploratory sessions discover unknown risks.
+- Automated regression tests preserve important findings.
+
+## Risk Heuristics
+
+Risk heuristics suggest missing defect ideas; they do not select representative cases by themselves.
+
+### Defect Taxonomies
+
+Use taxonomies as idea generators and coverage audits, not as paperwork.
+
+Ask:
+- What input defects are common here?
+- What state, timing, permission, data, environment, or integration defects are plausible?
+- What defects has this team historically created?
+- Which defect classes have no tests?
+
+Typical categories:
+- Interface/API contract
+- Validation and boundary
+- State and workflow
+- Data persistence and migration
+- Concurrency and timing
+- Configuration and environment
+- Security and authorization
+- Performance and resource use
+- Observability and diagnosability
+
+## Exit Criteria
+
+There is no universal stopping rule. Define required evidence and the owner who can accept residual risk before testing starts.
+
+Evidence-based exit criteria can include:
+- Required coverage goals are met.
+- Critical and high-risk scenarios have passed.
+- Defect discovery rate has dropped below an agreed threshold across comparable, sufficiently broad sessions.
+- Remaining known risks are accepted by the right owner.
+- The cost of more testing exceeds the likely value for this release.
+
+Time or budget exhaustion is a forced stop, not a satisfied exit criterion. Report the result as `INCOMPLETE`, name what was not covered, document residual risk, and do not claim release readiness.
+
+Never use "we ran a lot of tests" as an exit criterion. Name what was covered, what was not covered, and what risk remains.
+
+## Applying This To Test Planner
+
+Use the Test Planner to separate decisions:
+
+- Test basis / oracle: the requirement, contract, incident evidence, invariant, or approved reference that determines the expected result; unresolved conflicts stay explicit.
+- Changed surfaces: what code/data/API/UI changed.
+- Affected contracts: public schemas, clients, events, or none.
+- Primary layer: the lowest layer that provides sufficient evidence for the behavior.
+- Case design technique: direct example, regression reproduction, equivalence, boundary, decision table, pairwise, state-transition, domain, use case, control flow, or data flow.
+- Quality concerns: security, performance, visual regression, observability, migration safety, or none.
+- Skipped layers and why: explicit risk tradeoff.
+- Commands to run: existing project scripts.
+
+The coverage model selects cases; a **Case Specification** makes each selected case implementable. Record a stable ID and name, description/objective, source/risk, layer, preconditions, exact test data, action or ordered steps, expected result/oracle, technique/coverage point, priority, and `READY` or `BLOCKED` status. Pair each meaningful step with its expected observation. Add cleanup for stateful cases. For equivalent data rows, share setup and actions once rather than duplicating prose, but ensure the shared procedure plus each row reconstructs a complete case.
+
+For larger or release-oriented plans, add these only when they affect the decision:
+
+- Operating mode: scripted, exploratory, or adaptive.
+- Risk heuristics: defect taxonomy, historical defects, incidents, or none.
+- Exit criteria: required evidence, forced-stop behavior, and residual-risk owner.
+
+Example:
+
+```markdown
+Test Planner:
+- Test basis / oracle: Checkout validation requirements and the unchanged public request contract
+- Changed surfaces: Backend endpoint POST /checkout validation
+- Affected contracts: Request schema unchanged
+- Primary layer: API
+- Case design technique: Equivalence classes + boundary values
+- Quality concerns: Security/authorization
+- Skipped layers and why: Contract unchanged; E2E too broad for validation rules
+- Commands to run: npm run test:api -- checkout
+
+Case Specification:
+- ID / name: CHECKOUT-QTY-001 — Reject quantity below the minimum
+- Description / objective: Prove the API rejects the first invalid lower-boundary value
+- Source / risk: Checkout quantity requirement; off-by-one validation risk
+- Layer: API
+- Preconditions: Authenticated checkout request
+- Test data: quantity = 0
+- Action: POST /checkout with quantity 0
+- Expected result / oracle: 422 validation response required by the checkout contract
+- Technique / coverage: Boundary value, min - 1
+- Priority / status: High / READY
+```

--- a/skills/test-case-design/SKILL.md
+++ b/skills/test-case-design/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: test-case-design
+description: Designs a traceable Test Planner and concrete Case Specifications without writing or running tests. Use when planning or reviewing what to test, choosing the smallest sufficient layer, turning coverage models into named cases with preconditions, test data, steps, and expected results, applying boundary values, equivalence classes, decision tables, state transitions, or pairwise reduction, resolving test oracles, reducing a test matrix, or reviewing coverage gaps. Its output is design guidance, not implementation or execution.
+---
+
+# Test Case Design
+
+## Overview
+
+Perform **Test Analysis** and **Test Design** before test implementation:
+
+- Test Analysis decides **what must be proven** from requirements, contracts, risks, changed surfaces, and authoritative oracles.
+- Test Design decides **how to prove it** by selecting layers, techniques, coverage models, data, and concrete cases.
+- Case Specification makes each selected case **implementable without inventing intent** by naming its purpose, setup, actions, and observable expected results.
+
+The output is a `Test Planner` that `test-driven-development` can consume case by case. This skill may inspect code, requirements, tests, and project commands, but it does not write test code, change product code, or execute tests.
+
+## When to Use
+
+Use this skill when:
+
+- Planning tests before implementing a non-trivial change
+- Deciding the smallest sufficient set of test layers
+- Turning requirements, contracts, incidents, or risks into concrete test cases
+- Choosing a case-design technique or reviewing whether it was applied correctly
+- Reducing a large input, state, rule, or configuration matrix
+- Reviewing existing coverage for gaps, redundancy, weak oracles, or misplaced E2E tests
+
+Do not use it to write tests, execute suites, or change behavior; continue with `test-driven-development` after the planner is ready. Use `debugging-and-error-recovery` to diagnose unexplained failures and `browser-testing-with-devtools` for live browser evidence.
+
+## Test Design Workflow
+
+### 1. Establish the Test Basis and Oracle
+
+Collect authoritative sources for expected behavior:
+
+- Requirement or acceptance criterion
+- API, schema, event, or interface contract
+- Business invariant or approved example
+- Incident evidence or a confirmed defect report
+- Existing behavior only when explicitly accepted as the specification
+
+For each expected result, cite its oracle. For each case, cite the requirement or risk that justifies it. If sources conflict or omit an expected result, mark that case `BLOCKED` and name the owner who must decide. Never turn an assumption or current implementation into an executable requirement silently.
+
+Then identify:
+
+- Changed surfaces: UI, frontend state/router, endpoint, domain service, shared schema/client, persistence, queue, cache, filesystem, or external integration
+- Affected contracts: request/response schema, generated client, public API, event, or none
+- Quality concerns: security, performance, visual regression, observability, migration safety, reliability, or none
+
+At trust boundaries, treat input validation, authentication, authorization, sensitive-data handling, and abuse resistance as security quality concerns even when their public contract is unchanged. A quality concern does not automatically require another test layer; it records the risk the selected cases must address.
+
+### 2. Choose the Smallest Sufficient Layer
+
+Use the familiar ~80/15/5 pyramid as a cost and confidence guideline, not a universal quota:
+
+```text
+          /\
+         /  \         E2E / System (~5%)
+        /----\        Critical real journeys
+       /      \       Boundary / Collaboration (~15%)
+      /--------\      Component, Frontend Integration, API,
+     /          \     Contract, Backend Integration
+    /------------\    Unit (~80%)
+                        Pure logic and isolated modules
+```
+
+The pyramid answers how much expensive coverage to keep. The layer decision answers where each behavior is best proven.
+
+| What must be proven | Prefer this layer |
+|---|---|
+| Pure logic with no side effects | Unit |
+| One rendered UI unit behaves correctly | Component |
+| Frontend modules cooperate with a mocked backend | Frontend Integration |
+| A backend HTTP endpoint behaves correctly | API |
+| Consumers and providers agree on shared shapes | Contract |
+| Backend dependencies cooperate | Backend Integration |
+| A critical journey works through the real system | E2E / System |
+
+Use the lowest layer that proves the behavior. API tests are backend-owned endpoint behavior; contract tests are consumer/provider compatibility. Frontend Integration and Backend Integration protect different boundaries. Size is a separate execution-cost model:
+
+| Size | Constraint | Typical layer |
+|---|---|---|
+| Small | Single process, no I/O or network | Unit, focused component |
+| Medium | Localhost or local dependencies allowed | API, contract, integration |
+| Large | External services or multi-system environment | E2E, system, performance |
+
+### 3. Derive Cases with an Explicit Technique
+
+Select the lightest technique that exposes the risk:
+
+| Behavior shape | Prefer | Required artifact |
+|---|---|---|
+| One concrete behavior | Direct example | Input/precondition, action, expected result |
+| Known defect | Regression reproduction | Minimal reproducer and expected RED reason |
+| Values form valid and invalid groups | Equivalence classes | Named partitions and representatives |
+| Behavior changes at a threshold | Boundary values | Below, at, and above meaningful boundaries |
+| Conditions combine into outcomes | Decision table | Conditions, outcomes, reachable rules, precedence |
+| Behavior depends on state and event order | State transition | States, events, valid and important invalid transitions |
+| Configuration matrix is too large | Pairwise | Factors, values, constraints, generated set, coverage evidence |
+| Multiple ordered variables interact | Domain analysis | Dimensions, regions, boundaries, intersections |
+| An actor completes a goal | Use case | Actor, goal, main path, selected alternate/error paths |
+| Code paths or value lifecycles matter | Control/data flow | Covered decisions or define-use paths and observable outcomes |
+
+For an inclusive discrete range `[L, U]`, the default boundary model is `L-1, L, L+1, U-1, U, U+1`. Deduplicate overlapping points and adapt the step for the domain, but do not replace just-inside points with an arbitrary interior representative. For a single threshold, cover just below, at, and just above it unless one point is impossible by definition.
+
+Read `references/test-design-techniques.md` when the choice is non-obvious or when applying white-box, exploratory, adaptive, risk-based, or exit-criteria guidance. Keep these dimensions separate:
+
+- Case-design technique: how representative cases are derived
+- Operating mode: scripted, exploratory, or adaptive
+- Risk heuristic: what additional failure ideas deserve attention
+- Exit criteria: what evidence is enough and who accepts residual risk
+- Quality concern: which non-functional failure matters
+- Test layer: where the future test runs
+
+Naming a technique without its required artifact is not evidence that the technique shaped the cases.
+
+### 4. Produce a Minimal, Diagnostic Case Set
+
+1. Start with the critical successful behavior.
+2. Add every case required by the selected coverage model.
+3. Add high-impact negative, authorization, retry, idempotency, timing, concurrency, or recovery cases only when supported by the model or risk.
+4. Remove cases that repeat the same rule without adding a partition, boundary, transition, combination, or outcome.
+5. Keep one primary objective per case so failures remain diagnosable.
+6. Add known high-risk combinations even when pairwise generation omits them.
+7. Mark impossible combinations and excluded layers explicitly.
+
+Prioritize by impact, likelihood, and recent change. Case count is not a quality target; distinct risk coverage is.
+
+### 5. Match Quality Claims to Evidence
+
+Apply quality concerns at the selected layer first. Add broader evidence only when the claim cannot be proven lower down.
+
+For every quality claim, state the observable evidence, the selected layer or tool, and any limitation. Do not infer security, performance, reliability, or compatibility from a functional assertion that does not measure it. Record manual verification or specialist review as an explicit handoff instead of claiming unavailable evidence.
+
+### 6. Specify Concrete Cases
+
+A coverage model or list of test ideas is not yet a Case Specification. Every case must provide enough information for TDD to implement it without choosing a new oracle, action, or scope.
+
+| Field | Required content |
+|---|---|
+| ID | Stable unique identifier used by the planner and implementation handoff |
+| Name | Short behavior statement that distinguishes the case |
+| Description / objective | The single behavior or risk this case proves |
+| Source / risk | Requirement, contract, incident, invariant, or risk that justifies the case |
+| Layer | Unit, Component, Frontend Integration, API, Contract, Backend Integration, or E2E / System |
+| Preconditions | Required state, actor, environment, or `None` |
+| Test data | Exact values, fixtures, identities, or generated-data constraints |
+| Action / steps | One action for an atomic case or an ordered sequence for a workflow |
+| Expected result / oracle | Observable result paired with the action or relevant step, plus its authoritative source |
+| Technique / coverage | The partition, boundary, rule, transition, pair, path, or risk represented |
+| Priority | Critical, High, Medium, or Low based on risk and implementation order |
+| Status | `READY` when executable, or `BLOCKED` with the unresolved owner and question |
+
+Add postconditions or cleanup when a case changes persistent or shared state. Do not add `Actual Result`, pass/fail execution status, duration, or evidence during design; those belong to test execution.
+
+Use an expanded specification for workflows, E2E journeys, retries, state transitions, or any case with multiple observation points:
+
+```markdown
+#### CASE-ID — Case name
+- Description / objective:
+- Source / risk:
+- Layer:
+- Preconditions:
+- Test data:
+
+| Step | Action | Expected observation / oracle |
+|---:|---|---|
+| 1 | | |
+
+- Technique / coverage:
+- Priority:
+- Status: READY | BLOCKED — owner / question
+- Postconditions / cleanup: # when stateful
+```
+
+For equivalent data-driven cases, define setup and actions once, then use a case matrix. Never emit a matrix without an explicit shared action or steps: preconditions and test data do not say what the test performs. Every row still needs a stable ID and name, exact data, expected result/oracle, coverage point, priority, and status. Shared fields plus the shared steps plus one row must reconstruct a complete Case Specification.
+
+```markdown
+#### Shared Case Specification — Parameterized behavior
+- Description / objective:
+- Source / risk:
+- Layer:
+- Preconditions:
+
+| Step | Shared action | Expected observation |
+|---:|---|---|
+| 1 | Perform the operation using the row's test data | Use the row-specific expected result / oracle |
+
+| ID | Name | Test data | Expected result / oracle | Technique / coverage | Priority | Status |
+|---|---|---|---|---|---|---|
+```
+
+### 7. Write the Test Planner Handoff
+
+Use the repository's established format when one exists; otherwise produce:
+
+```markdown
+## Test Planner
+
+### Test Analysis
+- Test basis / oracle:
+- Changed surfaces:
+- Affected contracts:
+- Quality concerns:
+- Assumptions or blocked questions:
+
+### Test Design
+- Primary layer:
+- Adjacent layers:
+- Case-design technique(s):
+- Coverage model / required artifacts:
+- Skipped layers and why:
+
+### Case Specifications
+#### CASE-ID — Case name
+- Description / objective:
+- Source / risk:
+- Layer:
+- Preconditions:
+- Test data:
+
+| Step | Action | Expected observation / oracle |
+|---:|---|---|
+| 1 | | |
+
+- Technique / coverage:
+- Priority:
+- Status: READY | BLOCKED — owner / question
+- Postconditions / cleanup: # when stateful
+
+### Implementation Handoff
+- First RED case:
+- Existing command(s) discovered:
+- Planner status: READY | BLOCKED
+- Residual risk / owner:
+```
+
+A planner is `READY` only when its first case has a complete Case Specification with an authoritative oracle and the handoff has a real project command or a clearly identified command-discovery step.
+
+For a single obvious behavior or confirmed bug, the handoff may collapse to a four-field mini planner: basis/oracle, layer, command, and one compact Case Specification containing ID/name/objective, setup/data, action, expected result and RED reason, technique/coverage, priority, and `READY` status. The basis/oracle supplies its source/risk. Do not require a large document for a one-case change.
+
+## TDD Handoff Contract
+
+After design:
+
+1. `test-driven-development` reads and validates the planner against current sources.
+2. It selects the highest-priority unimplemented case and performs RED-GREEN-REFACTOR.
+3. It does not silently redesign cases, change the oracle, or broaden layers while implementing.
+4. New implementation evidence may trigger a planner revision, but the change and rationale must be explicit.
+5. A `BLOCKED` oracle stops TDD for that case; code must not decide an unresolved product rule.
+
+## Design Rules
+
+1. No expected result without an oracle.
+2. No case without traceability to a requirement or risk.
+3. No technique claim without its coverage artifact.
+4. No test-layer label used as a case-design technique.
+5. No full Cartesian matrix when constraints or combinatorial coverage can reduce it.
+6. No duplicate cases that add no distinct coverage.
+7. No case handed to TDD without a concrete action and observable expected result.
+8. No test or product implementation during the design activity.
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "TDD can decide the cases while coding" | Non-trivial case selection and product oracles should be reviewable before implementation encodes them. |
+| "Happy path plus edge cases is enough" | "Edge case" is not a coverage model. Name partitions, boundaries, rules, or transitions. |
+| "The expected result is obvious" | An uncited expected result can turn an assumption into permanent executable behavior. |
+| "We should test every layer" | Use the lowest sufficient layer and add broader evidence only for a distinct risk. |
+| "We should test every combination" | Apply constraints, pairwise reduction, and explicit high-risk combinations. |
+| "Calling it E2E makes it comprehensive" | An execution layer does not prove systematic case coverage. |
+| "A one-line fix does not need planning" | Use a four-field mini planner; small does not mean oracle-free. |
+| "The test name explains the case" | A name cannot replace setup, data, action, and an authoritative expected result. |
+
+## Red Flags
+
+- TDD begins a non-trivial change without a planner or explicit mini planner
+- The planner mixes unit, API, contract, integration, and E2E into one generic bucket
+- Expected results use phrases such as "works" or "fails correctly"
+- Recommended tests are only names or one-line ideas rather than Case Specifications
+- A multi-step case has no expected observation at the step where behavior should be visible
+- A data matrix provides values and expected results but no explicit shared action or steps
+- A range boundary model omits a just-inside or just-outside point without explaining why
+- A decision table ignores precedence or impossible combinations
+- A state model covers only valid transitions
+- Pairwise coverage is claimed without factors, constraints, or verification
+- The design writes test code, changes production code, or claims execution results
+
+## Verification
+
+Before handing the planner to TDD, verify:
+
+- [ ] Test Analysis and Test Design are both present and not conflated
+- [ ] Every expected result cites an authoritative oracle
+- [ ] Layers, techniques, quality concerns, operating mode, and exit criteria remain distinct
+- [ ] Every technique has its required coverage artifact
+- [ ] Boundary models include just-outside, at, and just-inside points where meaningful
+- [ ] Every case adds distinct, traceable coverage
+- [ ] Every case has ID, name, objective, source/risk, layer, setup/data, action, expected result/oracle, technique/coverage, priority, and status
+- [ ] Multi-step cases pair actions with expected observations; stateful cases define cleanup when needed
+- [ ] Every data-driven matrix defines explicit shared steps before its row-specific data and expected results
+- [ ] API, Contract, Frontend Integration, Backend Integration, and E2E are named precisely
+- [ ] Assumptions, blocked cases, skipped layers, and residual risks are visible
+- [ ] The first RED case and command handoff are actionable
+- [ ] No test implementation or execution occurred during design


### PR DESCRIPTION
### Test Case Design

- Separates Test Analysis, Test Design, and Case Specification.
- Builds a Test Planner from the test basis/oracle, changed surfaces, affected contracts, risks, quality concerns, and exit criteria.
- Selects the smallest sufficient layer across Unit, Component, Frontend Integration, API, Contract, Backend Integration, and E2E/System testing.
- Distinguishes backend API behavior from consumer/provider contract compatibility.
- Applies boundary values, equivalence partitions, decision tables, state transitions, pairwise reduction, and regression reproduction.
- Produces concrete Case Specifications with names, objectives, preconditions, test data, actions, expected results/oracles, coverage traceability, priority, and readiness status.
- Retains the familiar 80/15/5 pyramid as a cost guideline rather than a universal quota.
- Prevents disputed, incomplete, or unsupported assumptions from becoming executable tests.
- Hands READY cases to TDD without allowing implementation to silently change their layer, scope, or oracle.

### Scope

6 files, +935/-4. New skill only; no edits to existing skills, commands, agents, or unrelated docs.

### Validation

- validate-skills: 25/25 passed
- run-evals: 132 checks passed, 0 warnings
- validate-commands: 8/8 passed
- Behavioral dry-run: 8 fixture-backed evals planned

Note: If the standalone `tests` skill PR also lands, update README skill count from 25 to 26.