### PR TITLE
feat: add Test Planner handoff to TDD

### DIFF
--- a/evals/cases/test-driven-development.json
+++ b/evals/cases/test-driven-development.json
@@ -13,6 +13,10 @@
       {
         "prompt": "What tests should cover this new parsing logic before I write it?",
         "top_k": 3
+      },
+      {
+        "prompt": "The invoice rounding Test Planner is reviewed and READY; implement its case test-first without changing the oracle.",
+        "top_k": 3
       }
     ],
     "negative": [
@@ -29,14 +33,37 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Fix the reported rounding bug in the invoice totals, test-first.",
-      "expected_output": "A failing test demonstrating the bug, a minimal fix turning it green, full suite passing",
-      "expectations": [
-        "A failing test is written and shown failing before the fix",
-        "The implementation is the minimum needed to pass",
-        "The full suite is run after the fix to catch regressions"
+      "prompt": "Work in tdd-invoice-rounding. Fix the reported invoice rounding bug test-first. This is one obvious defect and no Test Planner is supplied.",
+      "expected_output": "A visible READY mini planner before any edit, followed by fixture-backed RED-GREEN evidence for the approved invoice rounding rule and the minimal fix",
+      "files": [
+        "tdd-invoice-rounding"
       ],
-      "trust_level": "provisional"
+      "expectations": [
+        "The README, package.json, implementation, and existing test are inspected before editing so the approved rounding rule is validated as the oracle and the project-owned test command is discovered",
+        "Before the first file edit, a visible compact mini planner records the oracle, one READY regression case with setup and input, action, expected result, expected RED reason, test location, and discovered command",
+        "A regression test for two 0.335 line totals expecting 0.68 is added before production code changes and is actually run",
+        "RED evidence shows the project-owned command failing because the implementation returns 0.67 instead of 0.68",
+        "The production change is limited to rounding each line before summing while preserving the CommonJS API",
+        "GREEN evidence shows the project-owned test suite passing after the fix"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Read tdd-planner-handoff/TEST-PLANNER.md from the workspace root, then work in tdd-invoice-rounding and implement only its reviewed READY case test-first. Preserve RED-GREEN evidence.",
+      "expected_output": "The reviewed planner and oracle are validated, its single READY case is implemented without changing meaning, and observed RED-GREEN command evidence is preserved",
+      "files": [
+        "tdd-invoice-rounding",
+        "tdd-planner-handoff"
+      ],
+      "expectations": [
+        "The supplied Test Planner, project README, package.json, implementation, and existing test are inspected before any file edit",
+        "Before editing, the planner and INV-ROUND-001 are confirmed READY, the README is confirmed as support for the oracle, and the absence of unresolved requirements is checked",
+        "Only INV-ROUND-001 is selected and its input, action, expected result, test level, and CommonJS boundary retain their planned meaning",
+        "A regression test for calculateInvoiceTotal([0.335, 0.335]) expecting 0.68 is added before production code changes",
+        "RED evidence shows the project-owned command failing because the current implementation returns 0.67 instead of 0.68",
+        "The implementation change is the minimum needed to round each line before summing while preserving the CommonJS API",
+        "GREEN evidence shows the project-owned test suite passing after the fix, with no unrelated cases or files added"
+      ]
     }
   ]
 }

--- a/evals/fixtures/tdd-invoice-rounding/README.md
+++ b/evals/fixtures/tdd-invoice-rounding/README.md
@@ -1,0 +1,12 @@
+# Invoice Rounding Bug
+
+Work in this project and preserve its CommonJS public API.
+
+The approved billing rule is: round each line total to the nearest cent before
+summing the invoice total. The reported reproducer is two line totals of
+`0.335`; the invoice total must be `0.68`, but the current implementation
+returns `0.67`.
+
+Use the project-owned test command from `package.json`. Add a regression test
+that fails for the reported reason before changing the implementation, make the
+smallest production change that fixes it, then run the affected required suite.

--- a/evals/fixtures/tdd-invoice-rounding/package.json
+++ b/evals/fixtures/tdd-invoice-rounding/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "tdd-invoice-rounding-fixture",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/evals/fixtures/tdd-invoice-rounding/src/invoice.js
+++ b/evals/fixtures/tdd-invoice-rounding/src/invoice.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function roundCurrency(value) {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function calculateInvoiceTotal(lineTotals) {
+  return roundCurrency(lineTotals.reduce((total, lineTotal) => total + lineTotal, 0));
+}
+
+module.exports = { calculateInvoiceTotal };

--- a/evals/fixtures/tdd-invoice-rounding/test/invoice.test.js
+++ b/evals/fixtures/tdd-invoice-rounding/test/invoice.test.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { calculateInvoiceTotal } = require('../src/invoice');
+
+test('sums invoice line totals', () => {
+  assert.equal(calculateInvoiceTotal([12.5, 7.25]), 19.75);
+});

--- a/evals/fixtures/tdd-planner-handoff/TEST-PLANNER.md
+++ b/evals/fixtures/tdd-planner-handoff/TEST-PLANNER.md
@@ -1,0 +1,35 @@
+# Reviewed Test Planner: Invoice Line Rounding
+
+- Review decision: APPROVED
+- Planner status: READY
+
+## Oracle
+
+- Source: `tdd-invoice-rounding/README.md`.
+- Approved rule: Round each line total to the nearest cent before summing the
+  invoice total.
+- Unresolved requirements: None.
+
+## Case Specification
+
+### INV-ROUND-001: Round Each Line Before Summing
+
+- Status: READY
+- Objective: Reproduce the escaped invoice rounding defect and prove the
+  approved per-line rounding rule.
+- Test level: Unit.
+- Preconditions: Keep the existing CommonJS `calculateInvoiceTotal` API.
+- Input: Line totals `[0.335, 0.335]`.
+- Action: Call `calculateInvoiceTotal([0.335, 0.335])`.
+- Expected result / oracle: Returns `0.68` under the approved billing rule.
+- Expected RED reason: The current implementation returns `0.67`.
+- Priority: Critical.
+- Existing command: Discover and use the project-owned command in
+  `tdd-invoice-rounding/package.json`.
+
+## Handoff Boundary
+
+Implement only `INV-ROUND-001`. Translate its setup, action, and assertion into
+the repository's test syntax without changing their meaning. If the oracle or
+READY status cannot be validated, block implementation and return the case to
+the design workflow.

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -21,6 +21,31 @@ Write a failing test before writing the code that makes it pass. For bug fixes, 
 
 **Related:** For browser-based changes, combine TDD with runtime verification using Chrome DevTools MCP — see the Browser Testing section below.
 
+## Planner Handoff Before RED
+
+When a reviewed Test Planner or Case Specification is supplied, consume it before editing any file:
+
+1. Read the planner and the requirement, contract, incident, or approved reference named as its oracle.
+2. Confirm that both the planner and selected case are explicitly `READY`, and that the oracle still supports the expected result.
+3. If review or `READY` status is missing, the oracle is stale, unsupported, or conflicting, or an unresolved requirement affects the expected behavior, mark the case `BLOCKED` and return it to the design workflow or user. Do not encode a guess in a test.
+4. Select one ready case and preserve its meaning. Translate its preconditions, data, action, and expected result into the repository's test syntax without silently changing the case or oracle.
+5. State which case and project-owned test command will be used before the first edit. If implementation evidence suggests the case must change, propose a planner revision rather than redesigning it in place.
+
+For a single obvious bug with no supplied planner, record this compact checkpoint in the visible response before the first file edit; do not leave it only in private reasoning:
+
+```markdown
+Mini Test Planner:
+- Oracle: [source and expected rule]
+- Case: [ID/name; preconditions and input; action; expected result]
+- Test location / command: [planned test file; discovered focused command]
+- Expected RED: [current behavior and why the assertion should fail]
+- Status: READY | BLOCKED
+```
+
+Validate the mini planner exactly as a supplied planner. If the expected result lacks an authoritative oracle or any requirement remains unresolved, use `BLOCKED` and stop before editing.
+
+For either path, preserve execution evidence through the cycle: record the focused command and observed failure that matches the planned RED reason, then the passing focused command after the minimum implementation change and the required regression run. A failure for an unexpected reason is not valid RED evidence; investigate it before proceeding to GREEN.
+
 ## The TDD Cycle
 
 ```
@@ -356,6 +381,8 @@ For detailed testing patterns, examples, and anti-patterns across frameworks, se
 | "I tested it manually" | Manual testing doesn't persist. Tomorrow's change might break it with no way to know. |
 | "The code is self-explanatory" | Tests ARE the specification. They document what the code should do, not what it does. |
 | "It's just a prototype" | Prototypes become production code. Tests from day one prevent the "test debt" crisis. |
+| "The planner already proves the behavior" | A planner records intent. RED-GREEN command evidence proves the implementation. |
+| "The bug is obvious, so I can skip planning" | Record the compact mini planner before editing so the oracle, reproducer, and expected failure stay explicit. |
 | "Let me run the tests again just to be extra sure" | After a clean test run, repeating the same command adds nothing unless the code has changed since. Run again after subsequent edits, not as reassurance. |
 
 ## Red Flags
@@ -367,6 +394,9 @@ For detailed testing patterns, examples, and anti-patterns across frameworks, se
 - Tests that test framework behavior instead of application behavior
 - Test names that don't describe the expected behavior
 - Skipping tests to make the suite pass
+- Editing before validating a supplied ready case or recording the visible mini planner
+- Silently changing a planned case or oracle during implementation
+- Turning an unresolved requirement into a test expectation instead of blocking
 - Running the same test command twice in a row without any intervening code change
 
 ## Verification
@@ -379,5 +409,8 @@ After completing any implementation:
 - [ ] Test names describe the behavior being verified
 - [ ] No tests were skipped or disabled
 - [ ] Coverage hasn't decreased (if tracked)
+- [ ] A supplied planner and selected case were reviewed, `READY`, and oracle-validated, or a visible mini planner was recorded before the first edit
+- [ ] Planned case meaning and oracle were preserved; unresolved requirements blocked implementation
+- [ ] Focused RED and GREEN commands and their observed outcomes were recorded, followed by the required regression run
 
 **Note:** Run each test command after a change that could affect the result. After a clean run, don't repeat the same command unless the code has changed since — re-running on unchanged code adds no confidence.


### PR DESCRIPTION
### TDD Test Planner Handoff

Teaches the existing test-driven-development skill to consume a reviewed READY Test Planner before writing any code:

- Validates the planner's oracle, READY status, and selected case against current requirements.
- Preserves the planned case meaning; test code translates but does not change the oracle, layer, or expected result.
- Blocks unresolved requirements instead of encoding a guess.
- For a single obvious bug with no supplied planner, records a visible mini planner checkpoint before the first file edit.
- Preserves RED-GREEN execution evidence with the discovered project command.

### Scope

7 files, +140/-6. Only modifies test-driven-development and its own evals/fixtures. Preserves the existing 80/15/5 Test Pyramid. No dependency on unmerged skills.

### Validation

- validate-skills: 24/24 passed
- run-evals: 125 checks passed, 0 warnings
- validate-commands: 8/8 passed
- Behavioral dry-run: 2 fixture-backed evals planned
- Fixture npm test: passed