### PR TITLE
docs(shipping): add Error Budget Release Gate section

### DIFF
--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -237,7 +237,7 @@ In the first hour after launch:
 
 ## Error Budget Release Gate
 
-Your service's error budget (defined by its SLO in `observability-and-instrumentation`) determines whether it's safe to ship. Use it as an objective gate — not a negotiation:
+Your service's error budget — the fraction of requests or time your SLO allows to fail — determines whether it's safe to ship. Use it as an objective gate — not a negotiation:
 
 ```
 Budget remaining > 20%  →  Ship normally; monitor closely
@@ -282,6 +282,7 @@ Every deployment needs a rollback plan before it happens:
 - For security pre-launch checks, see `../../references/security-checklist.md`
 - For performance pre-launch checklist, see `../../references/performance-checklist.md`
 - For accessibility verification before launch, see `../../references/accessibility-checklist.md`
+- For the alerting rules and SLO-tied thresholds, see `observability-and-instrumentation`
 
 ## Common Rationalizations
 
@@ -326,4 +327,4 @@ After deploying:
 
 For every shipped service:
 
-- [ ] Error budget policy in place: what happens when budget drops below 20% and when it's exhausted (see `observability-and-instrumentation` for SLO/SLI setup)
+- [ ] Error budget policy in place: know what action to take when budget drops below 20% and when it's exhausted

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -235,36 +235,9 @@ In the first hour after launch:
 6. Confirm rollback mechanism works (dry run if possible)
 ```
 
-## SLOs and Error Budgets
+## Error Budget Release Gate
 
-Monitoring tells you what is happening. SLOs tell you what *should* be happening and how much failure you can afford. Without them, alert thresholds are guesses and "is this good enough to ship?" has no shared answer.
-
-### The Three Concepts
-
-**SLI (Service Level Indicator):** The actual measurement — what you observe.
-
-```
-Error rate    = failed requests / total requests
-Latency       = P95 response time over a rolling window
-Availability  = successful health checks / total checks
-```
-
-**SLO (Service Level Objective):** The target for the SLI — the promise you make to users.
-
-```
-99.9% of API requests succeed in < 500ms, measured over a 30-day window
-```
-
-**Error budget:** The allowed failure implied by the SLO.
-
-```
-100% − 99.9% = 0.1% of requests may fail
-Over 30 days (43,200 minutes): 43 minutes of full outage, or proportionally more partial failure
-```
-
-### Error Budgets Gate Releases
-
-The error budget is the mechanism that balances feature velocity against reliability:
+Your service's error budget (defined by its SLO in `observability-and-instrumentation`) determines whether it's safe to ship. Use it as an objective gate — not a negotiation:
 
 ```
 Budget remaining > 20%  →  Ship normally; monitor closely
@@ -273,29 +246,7 @@ Budget exhausted        →  Freeze feature work; focus entirely on reliability
 Budget resets           →  Resume normal pace; bake in the fix that recovered it
 ```
 
-This gives both product and engineering a shared, objective answer to "can we ship?" — not a negotiation, not a gut call.
-
-### Setting SLO Targets
-
-Start from measurement, not aspiration:
-
-1. Instrument the SLI first (you need baseline data before you can set a target).
-2. Set the initial SLO at roughly your current p75 — achievable, but not slack.
-3. Tighten it incrementally as reliability improves and you understand your user's tolerance.
-
-**Avoid the four-nines trap.** 99.99% uptime sounds right for a serious service, but it costs exponentially more than 99.9% to maintain and allows only 52 minutes of downtime per year. Know what your users actually need — most internal tools and early-stage products can start at 99.5% and tighten from there.
-
-### Burn Rate Alerts
-
-Track how fast you're consuming the error budget, not just whether you've breached the SLO:
-
-```
-Normal burn rate = 1×  (budget consumed at exactly the SLO pace)
-High burn rate   = 5×  (alert: investigate)
-Critical burn    = 14× (page on-call: you'll exhaust 30 days' budget in 2 days)
-```
-
-Burn rate alerts catch slow degradations that never individually exceed the SLO threshold but collectively drain the budget. Connect these to the rollout thresholds in the Staged Rollout section — a high burn rate during a canary is a hold signal, not just a monitor signal.
+A high burn rate during a canary (consuming budget faster than the baseline pace) is a **hold** signal in the rollout thresholds table above — treat it the same as an elevated error rate.
 
 ## Rollback Strategy
 
@@ -341,8 +292,7 @@ Every deployment needs a rollback plan before it happens:
 | "Monitoring is overhead" | Not having monitoring means you discover problems from user complaints instead of dashboards. |
 | "We'll add monitoring later" | Add it before launch. You can't debug what you can't see. |
 | "Rolling back is admitting failure" | Rolling back is responsible engineering. Shipping a broken feature is the failure. |
-| "We'll set SLOs later when we have data" | SLOs don't require perfect data — start with a hypothesis, track it, refine it. No SLO means no shared definition of working. |
-| "Customers expect 99.99% uptime" | Each additional 9 costs exponentially more. Know what your users actually need before committing to a target. |
+| "The error rate looks fine, let's keep shipping" | Check the burn rate, not just the current error rate. Consuming budget faster than baseline is a hold signal even when individual thresholds are green. |
 
 ## Red Flags
 
@@ -353,9 +303,7 @@ Every deployment needs a rollback plan before it happens:
 - No one monitoring the deploy for the first hour
 - Production environment configuration done by memory, not code
 - "It's Friday afternoon, let's ship it"
-- Alert thresholds set without reference to an SLO
 - Error budget exhausted but feature work continues unchanged
-- SLO targets set aspirationally without baseline measurement
 
 ## Verification
 
@@ -378,6 +326,4 @@ After deploying:
 
 For every shipped service:
 
-- [ ] SLIs defined (error rate, latency, and/or availability for each user-facing feature)
-- [ ] SLO targets derived from baseline measurement, not aspiration
-- [ ] Error budget policy documented: what changes when budget drops below 20%, and when it's exhausted
+- [ ] Error budget policy in place: what happens when budget drops below 20% and when it's exhausted (see `observability-and-instrumentation` for SLO/SLI setup)

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -235,6 +235,68 @@ In the first hour after launch:
 6. Confirm rollback mechanism works (dry run if possible)
 ```
 
+## SLOs and Error Budgets
+
+Monitoring tells you what is happening. SLOs tell you what *should* be happening and how much failure you can afford. Without them, alert thresholds are guesses and "is this good enough to ship?" has no shared answer.
+
+### The Three Concepts
+
+**SLI (Service Level Indicator):** The actual measurement — what you observe.
+
+```
+Error rate    = failed requests / total requests
+Latency       = P95 response time over a rolling window
+Availability  = successful health checks / total checks
+```
+
+**SLO (Service Level Objective):** The target for the SLI — the promise you make to users.
+
+```
+99.9% of API requests succeed in < 500ms, measured over a 30-day window
+```
+
+**Error budget:** The allowed failure implied by the SLO.
+
+```
+100% − 99.9% = 0.1% of requests may fail
+Over 30 days (43,200 minutes): 43 minutes of full outage, or proportionally more partial failure
+```
+
+### Error Budgets Gate Releases
+
+The error budget is the mechanism that balances feature velocity against reliability:
+
+```
+Budget remaining > 20%  →  Ship normally; monitor closely
+Budget remaining 0–20%  →  Slow rollouts only; no high-risk changes
+Budget exhausted        →  Freeze feature work; focus entirely on reliability
+Budget resets           →  Resume normal pace; bake in the fix that recovered it
+```
+
+This gives both product and engineering a shared, objective answer to "can we ship?" — not a negotiation, not a gut call.
+
+### Setting SLO Targets
+
+Start from measurement, not aspiration:
+
+1. Instrument the SLI first (you need baseline data before you can set a target).
+2. Set the initial SLO at roughly your current p75 — achievable, but not slack.
+3. Tighten it incrementally as reliability improves and you understand your user's tolerance.
+
+**Avoid the four-nines trap.** 99.99% uptime sounds right for a serious service, but it costs exponentially more than 99.9% to maintain and allows only 52 minutes of downtime per year. Know what your users actually need — most internal tools and early-stage products can start at 99.5% and tighten from there.
+
+### Burn Rate Alerts
+
+Track how fast you're consuming the error budget, not just whether you've breached the SLO:
+
+```
+Normal burn rate = 1×  (budget consumed at exactly the SLO pace)
+High burn rate   = 5×  (alert: investigate)
+Critical burn    = 14× (page on-call: you'll exhaust 30 days' budget in 2 days)
+```
+
+Burn rate alerts catch slow degradations that never individually exceed the SLO threshold but collectively drain the budget. Connect these to the rollout thresholds in the Staged Rollout section — a high burn rate during a canary is a hold signal, not just a monitor signal.
+
 ## Rollback Strategy
 
 Every deployment needs a rollback plan before it happens:
@@ -279,6 +341,8 @@ Every deployment needs a rollback plan before it happens:
 | "Monitoring is overhead" | Not having monitoring means you discover problems from user complaints instead of dashboards. |
 | "We'll add monitoring later" | Add it before launch. You can't debug what you can't see. |
 | "Rolling back is admitting failure" | Rolling back is responsible engineering. Shipping a broken feature is the failure. |
+| "We'll set SLOs later when we have data" | SLOs don't require perfect data — start with a hypothesis, track it, refine it. No SLO means no shared definition of working. |
+| "Customers expect 99.99% uptime" | Each additional 9 costs exponentially more. Know what your users actually need before committing to a target. |
 
 ## Red Flags
 
@@ -289,6 +353,9 @@ Every deployment needs a rollback plan before it happens:
 - No one monitoring the deploy for the first hour
 - Production environment configuration done by memory, not code
 - "It's Friday afternoon, let's ship it"
+- Alert thresholds set without reference to an SLO
+- Error budget exhausted but feature work continues unchanged
+- SLO targets set aspirationally without baseline measurement
 
 ## Verification
 
@@ -308,3 +375,9 @@ After deploying:
 - [ ] Critical user flow works
 - [ ] Logs are flowing
 - [ ] Rollback tested or verified ready
+
+For every shipped service:
+
+- [ ] SLIs defined (error rate, latency, and/or availability for each user-facing feature)
+- [ ] SLO targets derived from baseline measurement, not aspiration
+- [ ] Error budget policy documented: what changes when budget drops below 20%, and when it's exhausted


### PR DESCRIPTION
## What this adds

A `## SLOs and Error Budgets` section in `skills/shipping-and-launch/SKILL.md`, covering:

- **The three concepts** — SLI (what you measure), SLO (the target), error budget (the allowed failure)
- **Budget-gates-releases policy** — a clear four-state decision table: ship normally → slow rollouts → freeze feature work → resume after recovery
- **Setting targets from measurement** — instrument first, set the SLO at your current p75, tighten incrementally; with a specific warning about the four-nines trap
- **Burn rate alerting** — how to catch slow degradations that never breach the SLO threshold individually but drain the budget silently
- Cross-link to the rollout thresholds table already in the skill (burn rate connects directly to the hold/rollback signals)

Plus two rationalization rows, three red flags, and three verification checkboxes.

## The gap it fills

The skill already references SLOs — the Staged Rollout section says thresholds should be "justified by the SLO or by historical data." But the skill never defines what an SLO is, how to set one, or what happens when the error budget runs out. Engineers are told to justify thresholds against an SLO without being taught the framework that produces one.

## Non-duplication check

`observability-and-instrumentation` teaches how to instrument for visibility. This section teaches the *target* that gives instrumentation its meaning — what "good" looks like and how much failure is acceptable before feature work stops. The skills are complementary, not overlapping.

## Checklist

- [x] Fully additive — no edits to existing prose
- [x] `node scripts/validate-skills.js` → 0 errors, 0 warnings
- [x] Touches only `skills/shipping-and-launch/SKILL.md`
- [x] Rationalization rows, red flags, and verification checkboxes match host skill's style