### PR TITLE
docs(copilot): clarify skill and persona installation

### DIFF
--- a/docs/copilot-setup.md
+++ b/docs/copilot-setup.md
@@ -2,27 +2,19 @@
 
 ## Setup
 
-### Agent Skills
+### Copilot Instructions
 
 Copilot supports creating agent skills using a `.github/skills`, `.claude/skills`, or `.agents/skills` directory in your repository.
 
-Install all skills from the root of the repository where you use Copilot:
-
 ```bash
-npx skills add addyosmani/agent-skills --agent github-copilot --skill '*' --copy --yes
+mkdir -p .github/skills/test-driven-development .github/skills/code-review-and-quality
+
+# Create files for essential skills
+cat /path/to/agent-skills/skills/test-driven-development/SKILL.md > .github/skills/test-driven-development/SKILL.md
+cat /path/to/agent-skills/skills/code-review-and-quality/SKILL.md > .github/skills/code-review-and-quality/SKILL.md
 ```
 
-This installs the skills in `.agents/skills/`, one of Copilot's supported project locations. To start with only the three essential skills:
-
-```bash
-npx skills add addyosmani/agent-skills --agent github-copilot --skill spec-driven-development --skill test-driven-development --skill code-review-and-quality --copy --yes
-```
-
-Agent skills work in Copilot cloud agent, code review, Copilot CLI, the Copilot app, and VS Code agent mode.
-
-> **Skills and agents are separate.** The skills CLI installs the workflows in `skills/`; it does not install the personas in `agents/`. Follow the next section if you also want selectable custom agents.
-
-For more details, refer [Adding agent skills for GitHub Copilot](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills).
+For more details, refer [Creating agent skills for GitHub Copilot](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-skills).
 
 ### Agent Personas (*.agent.md)
 
@@ -32,31 +24,49 @@ Copilot supports specialized agent personas. Use the agent-skills agents:
 > VS Code also detects plain `*.md` files in `.github/agents`, but other Copilot surfaces may not.
 > See [VS Code custom agents docs](https://code.visualstudio.com/docs/agent-customization/custom-agents#_custom-agent-file-structure) for details.
 
-If you installed only the skills with `npx`, clone the source once outside your project so the persona files are available:
+Skills and personas are separate customizations. Installing or copying skills does not install the personas.
+
+Run this from the target repository root. The source repository is cloned to a temporary directory and removed after the four persona files are copied:
 
 ```bash
-git clone --depth 1 https://github.com/addyosmani/agent-skills.git ../agent-skills-source
-```
+source_dir="$(mktemp -d)"
+git clone --depth 1 https://github.com/addyosmani/agent-skills.git "$source_dir"
 
-```bash
-# Create the agents directory and copy agent definitions
 mkdir -p .github/agents
-cp ../agent-skills-source/agents/code-reviewer.md .github/agents/code-reviewer.agent.md
-cp ../agent-skills-source/agents/test-engineer.md .github/agents/test-engineer.agent.md
-cp ../agent-skills-source/agents/security-auditor.md .github/agents/security-auditor.agent.md
-cp ../agent-skills-source/agents/web-performance-auditor.md .github/agents/web-performance-auditor.agent.md
+for agent in code-reviewer test-engineer security-auditor web-performance-auditor; do
+  cp "$source_dir/agents/$agent.md" ".github/agents/$agent.agent.md"
+done
+
+rm -rf "$source_dir"
 ```
 
 PowerShell:
 
 ```powershell
-$source = "..\agent-skills-source\agents"
-$destination = ".github\agents"
+$source = Join-Path ([IO.Path]::GetTempPath()) "agent-skills-$([guid]::NewGuid())"
 
-New-Item -ItemType Directory -Force -Path $destination | Out-Null
-Get-ChildItem -LiteralPath $source -Filter "*.md" | ForEach-Object {
-  $name = [IO.Path]::GetFileNameWithoutExtension($_.Name)
-  Copy-Item -LiteralPath $_.FullName -Destination "$destination\$name.agent.md"
+try {
+  git clone --depth 1 https://github.com/addyosmani/agent-skills.git $source
+  if ($LASTEXITCODE -ne 0) {
+    throw "Unable to clone agent-skills."
+  }
+
+  $destination = ".github\agents"
+  New-Item -ItemType Directory -Force -Path $destination | Out-Null
+
+  foreach ($agent in @(
+    "code-reviewer",
+    "test-engineer",
+    "security-auditor",
+    "web-performance-auditor"
+  )) {
+    Copy-Item `
+      -LiteralPath (Join-Path $source "agents\$agent.md") `
+      -Destination (Join-Path $destination "$agent.agent.md")
+  }
+}
+finally {
+  Remove-Item -LiteralPath $source -Recurse -Force -ErrorAction SilentlyContinue
 }
 ```
 
@@ -131,5 +141,5 @@ Use the agents for targeted review workflows in Copilot Chat.
 
 1. **Keep instructions concise** — Copilot instructions work best when focused. Summarize the key rules rather than including full skill files.
 2. **Use agents for review** — The code-reviewer, test-engineer, and security-auditor agents are designed for Copilot's agent model.
-3. **Reference in chat** — Skills load automatically when their descriptions match the task. You can also ask Copilot to use a skill explicitly, such as "Use the test-driven-development skill for this change."
+3. **Reference in chat** — When working on a specific phase, paste the relevant skill content into Copilot Chat for context.
 4. **Combine with PR reviews** — Set up Copilot to review PRs using the code-reviewer agent persona.

--- a/docs/copilot-setup.md
+++ b/docs/copilot-setup.md
@@ -18,6 +18,8 @@ This installs the skills in `.agents/skills/`, one of Copilot's supported projec
 npx skills add addyosmani/agent-skills --agent github-copilot --skill spec-driven-development --skill test-driven-development --skill code-review-and-quality --copy --yes
 ```
 
+Agent skills work in Copilot cloud agent, code review, Copilot CLI, the Copilot app, and VS Code agent mode.
+
 > **Skills and agents are separate.** The skills CLI installs the workflows in `skills/`; it does not install the personas in `agents/`. Follow the next section if you also want selectable custom agents.
 
 For more details, refer [Adding agent skills for GitHub Copilot](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills).
@@ -26,23 +28,29 @@ For more details, refer [Adding agent skills for GitHub Copilot](https://docs.gi
 
 Copilot supports specialized agent personas. Use the agent-skills agents:
 
-> **Important:** GitHub Copilot requires custom agent files to be named `*.agent.md`.
-> Files named `*.md` are silently ignored by Copilot.
+> **Important:** Use the `*.agent.md` extension for compatibility across VS Code and GitHub Copilot coding agent.
+> VS Code also detects plain `*.md` files in `.github/agents`, but other Copilot surfaces may not.
 > See [VS Code custom agents docs](https://code.visualstudio.com/docs/agent-customization/custom-agents#_custom-agent-file-structure) for details.
+
+If you installed only the skills with `npx`, clone the source once outside your project so the persona files are available:
+
+```bash
+git clone --depth 1 https://github.com/addyosmani/agent-skills.git ../agent-skills-source
+```
 
 ```bash
 # Create the agents directory and copy agent definitions
 mkdir -p .github/agents
-cp /path/to/agent-skills/agents/code-reviewer.md .github/agents/code-reviewer.agent.md
-cp /path/to/agent-skills/agents/test-engineer.md .github/agents/test-engineer.agent.md
-cp /path/to/agent-skills/agents/security-auditor.md .github/agents/security-auditor.agent.md
-cp /path/to/agent-skills/agents/web-performance-auditor.md .github/agents/web-performance-auditor.agent.md
+cp ../agent-skills-source/agents/code-reviewer.md .github/agents/code-reviewer.agent.md
+cp ../agent-skills-source/agents/test-engineer.md .github/agents/test-engineer.agent.md
+cp ../agent-skills-source/agents/security-auditor.md .github/agents/security-auditor.agent.md
+cp ../agent-skills-source/agents/web-performance-auditor.md .github/agents/web-performance-auditor.agent.md
 ```
 
 PowerShell:
 
 ```powershell
-$source = "C:\path\to\agent-skills\agents"
+$source = "..\agent-skills-source\agents"
 $destination = ".github\agents"
 
 New-Item -ItemType Directory -Force -Path $destination | Out-Null

--- a/docs/copilot-setup.md
+++ b/docs/copilot-setup.md
@@ -2,19 +2,25 @@
 
 ## Setup
 
-### Copilot Instructions
+### Agent Skills
 
 Copilot supports creating agent skills using a `.github/skills`, `.claude/skills`, or `.agents/skills` directory in your repository.
 
-```bash
-mkdir -p .github/skills/test-driven-development .github/skills/code-review-and-quality
+Install all skills from the root of the repository where you use Copilot:
 
-# Create files for essential skills
-cat /path/to/agent-skills/skills/test-driven-development/SKILL.md > .github/skills/test-driven-development/SKILL.md
-cat /path/to/agent-skills/skills/code-review-and-quality/SKILL.md > .github/skills/code-review-and-quality/SKILL.md
+```bash
+npx skills add addyosmani/agent-skills --agent github-copilot --skill '*' --copy --yes
 ```
 
-For more details, refer [Creating agent skills for GitHub Copilot](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-skills).
+This installs the skills in `.agents/skills/`, one of Copilot's supported project locations. To start with only the three essential skills:
+
+```bash
+npx skills add addyosmani/agent-skills --agent github-copilot --skill spec-driven-development --skill test-driven-development --skill code-review-and-quality --copy --yes
+```
+
+> **Skills and agents are separate.** The skills CLI installs the workflows in `skills/`; it does not install the personas in `agents/`. Follow the next section if you also want selectable custom agents.
+
+For more details, refer [Adding agent skills for GitHub Copilot](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills).
 
 ### Agent Personas (*.agent.md)
 
@@ -22,7 +28,7 @@ Copilot supports specialized agent personas. Use the agent-skills agents:
 
 > **Important:** GitHub Copilot requires custom agent files to be named `*.agent.md`.
 > Files named `*.md` are silently ignored by Copilot.
-> See [VS Code custom agents docs](https://code.visualstudio.com/docs/copilot/customization/custom-agents#_custom-agent-file-structure) for details.
+> See [VS Code custom agents docs](https://code.visualstudio.com/docs/agent-customization/custom-agents#_custom-agent-file-structure) for details.
 
 ```bash
 # Create the agents directory and copy agent definitions
@@ -30,12 +36,30 @@ mkdir -p .github/agents
 cp /path/to/agent-skills/agents/code-reviewer.md .github/agents/code-reviewer.agent.md
 cp /path/to/agent-skills/agents/test-engineer.md .github/agents/test-engineer.agent.md
 cp /path/to/agent-skills/agents/security-auditor.md .github/agents/security-auditor.agent.md
+cp /path/to/agent-skills/agents/web-performance-auditor.md .github/agents/web-performance-auditor.agent.md
 ```
 
-Invoke agents in Copilot Chat:
-- `@code-reviewer Review this PR`
-- `@test-engineer Analyze test coverage for this module`
-- `@security-auditor Check this endpoint for vulnerabilities`
+PowerShell:
+
+```powershell
+$source = "C:\path\to\agent-skills\agents"
+$destination = ".github\agents"
+
+New-Item -ItemType Directory -Force -Path $destination | Out-Null
+Get-ChildItem -LiteralPath $source -Filter "*.md" | ForEach-Object {
+  $name = [IO.Path]::GetFileNameWithoutExtension($_.Name)
+  Copy-Item -LiteralPath $_.FullName -Destination "$destination\$name.agent.md"
+}
+```
+
+In VS Code, select the persona from the agent picker in Copilot Chat, then enter the task:
+
+- Select `code-reviewer`, then enter `Review this PR`.
+- Select `test-engineer`, then enter `Analyze test coverage for this module`.
+- Select `security-auditor`, then enter `Check this endpoint for vulnerabilities`.
+- Select `web-performance-auditor`, then enter `Audit this web application`.
+
+Custom agents are modes in current VS Code releases, not agent skills. If they do not appear, run **Chat: Open Customizations** to inspect discovery, then run **Developer: Reload Window** after adding the files.
 
 ### Custom Instructions (User Level)
 
@@ -83,5 +107,5 @@ Use the agents for targeted review workflows in Copilot Chat.
 
 1. **Keep instructions concise** — Copilot instructions work best when focused. Summarize the key rules rather than including full skill files.
 2. **Use agents for review** — The code-reviewer, test-engineer, and security-auditor agents are designed for Copilot's agent model.
-3. **Reference in chat** — When working on a specific phase, paste the relevant skill content into Copilot Chat for context.
+3. **Reference in chat** — Skills load automatically when their descriptions match the task. You can also ask Copilot to use a skill explicitly, such as "Use the test-driven-development skill for this change."
 4. **Combine with PR reviews** — Set up Copilot to review PRs using the code-reviewer agent persona.

--- a/docs/copilot-setup.md
+++ b/docs/copilot-setup.md
@@ -60,14 +60,30 @@ Get-ChildItem -LiteralPath $source -Filter "*.md" | ForEach-Object {
 }
 ```
 
-In VS Code, select the persona from the agent picker in Copilot Chat, then enter the task:
+Open the target repository root in VS Code. In Copilot Chat, select the persona from the agent picker, then enter the task:
 
 - Select `code-reviewer`, then enter `Review this PR`.
 - Select `test-engineer`, then enter `Analyze test coverage for this module`.
 - Select `security-auditor`, then enter `Check this endpoint for vulnerabilities`.
 - Select `web-performance-auditor`, then enter `Audit this web application`.
 
-Custom agents are modes in current VS Code releases, not agent skills. If they do not appear, run **Chat: Open Customizations** to inspect discovery, then run **Developer: Reload Window** after adding the files.
+Custom agents are modes in current VS Code releases, not agent skills or `@` mentions. If they do not appear, run **Chat: Open Customizations** to inspect discovery, then run **Developer: Reload Window** after adding the files.
+
+In GitHub Copilot CLI, run from the target repository root:
+
+```bash
+copilot --agent code-reviewer
+```
+
+To target a repository without changing directories:
+
+```bash
+copilot -C "/path/to/repository" --agent code-reviewer
+```
+
+In an interactive CLI session, use `/agent` to switch personas.
+
+For Copilot cloud agent, commit the `.github/agents/*.agent.md` files and merge them into the repository's default branch. The personas then appear in the custom-agent dropdown on GitHub.
 
 ### Custom Instructions (User Level)
 

--- a/docs/copilot-setup.md
+++ b/docs/copilot-setup.md
@@ -24,50 +24,15 @@ Copilot supports specialized agent personas. Use the agent-skills agents:
 > VS Code also detects plain `*.md` files in `.github/agents`, but other Copilot surfaces may not.
 > See [VS Code custom agents docs](https://code.visualstudio.com/docs/agent-customization/custom-agents#_custom-agent-file-structure) for details.
 
-Skills and personas are separate customizations. Installing or copying skills does not install the personas.
-
-Run this from the target repository root. The source repository is cloned to a temporary directory and removed after the four persona files are copied:
+Skills and personas are separate customizations. Installing or copying skills does not install the personas. The commands below assume this repository is already cloned; replace `/path/to/agent-skills` with the path to that clone.
 
 ```bash
-source_dir="$(mktemp -d)"
-git clone --depth 1 https://github.com/addyosmani/agent-skills.git "$source_dir"
-
+# Create the agents directory and copy agent definitions
 mkdir -p .github/agents
-for agent in code-reviewer test-engineer security-auditor web-performance-auditor; do
-  cp "$source_dir/agents/$agent.md" ".github/agents/$agent.agent.md"
-done
-
-rm -rf "$source_dir"
-```
-
-PowerShell:
-
-```powershell
-$source = Join-Path ([IO.Path]::GetTempPath()) "agent-skills-$([guid]::NewGuid())"
-
-try {
-  git clone --depth 1 https://github.com/addyosmani/agent-skills.git $source
-  if ($LASTEXITCODE -ne 0) {
-    throw "Unable to clone agent-skills."
-  }
-
-  $destination = ".github\agents"
-  New-Item -ItemType Directory -Force -Path $destination | Out-Null
-
-  foreach ($agent in @(
-    "code-reviewer",
-    "test-engineer",
-    "security-auditor",
-    "web-performance-auditor"
-  )) {
-    Copy-Item `
-      -LiteralPath (Join-Path $source "agents\$agent.md") `
-      -Destination (Join-Path $destination "$agent.agent.md")
-  }
-}
-finally {
-  Remove-Item -LiteralPath $source -Recurse -Force -ErrorAction SilentlyContinue
-}
+cp /path/to/agent-skills/agents/code-reviewer.md .github/agents/code-reviewer.agent.md
+cp /path/to/agent-skills/agents/test-engineer.md .github/agents/test-engineer.agent.md
+cp /path/to/agent-skills/agents/security-auditor.md .github/agents/security-auditor.agent.md
+cp /path/to/agent-skills/agents/web-performance-auditor.md .github/agents/web-performance-auditor.agent.md
 ```
 
 Open the target repository root in VS Code. In Copilot Chat, select the persona from the agent picker, then enter the task:


### PR DESCRIPTION
## Summary
- keep the existing GitHub Copilot skill-installation guidance unchanged
- clarify that skills and custom-agent personas are separate customizations
- retain the existing copy pattern and add the fourth `web-performance-auditor` persona
- document current VS Code agent-picker, Copilot CLI, and cloud-agent usage

## Why
The existing skill setup works, but it does not install the repository's `agents/` personas. Users can therefore have working skills and still see no selectable custom agents. The previous guide also described `@` invocation rather than the current agent-picker flow.

## Scope
Documentation only. This PR changes only the Agent Personas section in `docs/copilot-setup.md`. It does not change skill installation, lifecycle slash commands, plugin manifests, or runtime behavior.

## Verification
- original-style copy commands tested in a fresh temporary repository: four valid `.agent.md` files created
- `copilot --agent code-reviewer` verified with GitHub Copilot CLI 1.0.72-1
- `node scripts/validate-skills.js`
- `node scripts/validate-commands.js`
- `git diff --check`