### PR TITLE
docs(observability): expand runbook guidance in alerting section

### DIFF
--- a/skills/observability-and-instrumentation/SKILL.md
+++ b/skills/observability-and-instrumentation/SKILL.md
@@ -154,6 +154,23 @@ Rules for every alert you create:
 3. **It has a threshold and duration** justified by the SLO or by historical data, not by a guess.
 4. Use two severities only: **page** (user-facing, act now) and **ticket** (degradation, act this week). A third tier becomes noise that trains people to ignore everything.
 
+### Writing Runbooks
+
+A runbook is the document your alert links to. Its job is to answer three questions without requiring the reader to think: what is happening, what to check first, and who to call if that doesn't resolve it. Store in `docs/runbooks/` named after the alert.
+
+**Minimum viable runbook (three lines):**
+
+```markdown
+# Runbook: High Error Rate on /api/tasks
+**Means:** DB connection pool likely exhausted, or a bad deploy.
+**First check:** `SELECT count(*) FROM pg_stat_activity;` — if > pool limit, see Step 2.
+**Escalate to:** #db-oncall or engineering on-call rotation.
+```
+
+**When to expand beyond three lines:** add steps only when the first check alone isn't enough to decide. A five-step runbook that covers the three most common causes is better than a twenty-step document that covers every edge case and gets skimmed.
+
+**Keep runbooks current.** Update the runbook as part of closing every incident it was used in — a stale runbook builds false confidence. If a step was wrong or missing, fix it before marking the incident resolved.
+
 ### 7. Verify the telemetry itself
 
 Instrumentation is code; it can be wrong. Before calling the work done, trigger the paths and look at the actual output:

--- a/skills/observability-and-instrumentation/SKILL.md
+++ b/skills/observability-and-instrumentation/SKILL.md
@@ -154,16 +154,17 @@ Rules for every alert you create:
 3. **It has a threshold and duration** justified by the SLO or by historical data, not by a guess.
 4. Use two severities only: **page** (user-facing, act now) and **ticket** (degradation, act this week). A third tier becomes noise that trains people to ignore everything.
 
-### Writing Runbooks
+#### Writing Runbooks
 
-A runbook is the document your alert links to. Its job is to answer three questions without requiring the reader to think: what is happening, what to check first, and who to call if that doesn't resolve it. Store in `docs/runbooks/` named after the alert.
+Rule 2 above requires every alert to link to a runbook. A runbook's job is to answer three questions without requiring the reader to think: what is happening, what to check first, and who to call if that doesn't resolve it. Store in `docs/runbooks/` named after the alert.
 
 **Minimum viable runbook (three lines):**
 
 ```markdown
 # Runbook: High Error Rate on /api/tasks
 **Means:** DB connection pool likely exhausted, or a bad deploy.
-**First check:** `SELECT count(*) FROM pg_stat_activity;` — if > pool limit, see Step 2.
+**First check:** `SELECT count(*) FROM pg_stat_activity WHERE backend_type = 'client backend';`
+  — if count > pool limit, see Step 2. (Swap in the equivalent for your database.)
 **Escalate to:** #db-oncall or engineering on-call rotation.
 ```
 


### PR DESCRIPTION
## What this adds

A `### Writing Runbooks` subsection directly under the existing alerting rules in `skills/observability-and-instrumentation/SKILL.md`.

## Why here (not in documentation-and-adrs)

PR #414 tried to add runbook guidance to `documentation-and-adrs`. The review redirect was right: the skill already names runbooks as a hard requirement on every alert ("It links to a runbook — even three lines: what it means, first query to run, escalation path") and is the natural home for teaching the artifact it requires. This PR expands that one-liner into a usable guide without moving it.

## What it teaches

- The three-question format every runbook must answer: what is happening / what to check first / who to escalate to
- A minimum viable runbook template (stored in `docs/runbooks/`, named after the alert)
- When to expand beyond three lines: add steps only when the first check alone isn't enough to decide
- Keep-current discipline: update as part of closing every incident the runbook was used in

## Scope

+17 lines. One file. Fully additive — no edits to existing prose. `validate-skills.js` → 0 errors, 0 warnings.