### PR TITLE
Make shared skill workflows agent-agnostic

### DIFF
--- a/skills/browser-testing-with-devtools/SKILL.md
+++ b/skills/browser-testing-with-devtools/SKILL.md
@@ -25,7 +25,11 @@ Use Chrome DevTools MCP to give your agent eyes into the browser. This bridges t
 
 ### Installation
 
-Add the following to your project's `.mcp.json` or Claude Code settings:
+Your MCP-capable agent harness must launch `npx -y chrome-devtools-mcp@latest --isolated` as a local STDIO MCP server.
+
+#### Claude Code and compatible clients
+
+For Claude Code and compatible clients, `.mcp.json` is one harness-specific representation of that server configuration:
 
 ```json
 {
@@ -37,6 +41,24 @@ Add the following to your project's `.mcp.json` or Claude Code settings:
   }
 }
 ```
+
+#### Codex
+
+Add the server from the command line:
+
+```bash
+codex mcp add chrome-devtools -- npx -y chrome-devtools-mcp@latest --isolated
+```
+
+Or use the equivalent project-scoped `.codex/config.toml` configuration:
+
+```toml
+[mcp_servers.chrome_devtools]
+command = "npx"
+args = ["-y", "chrome-devtools-mcp@latest", "--isolated"]
+```
+
+Codex loads project configuration only for trusted projects.
 
 `-y` skips the npx install confirmation. By default the server launches Chrome with its own dedicated profile (under `~/.cache/chrome-devtools-mcp/`), separate from your personal browser; `--isolated` goes one step further and uses a temporary profile that is wiped when the browser closes. This is the right setup for most testing.
 

--- a/skills/idea-refine/SKILL.md
+++ b/skills/idea-refine/SKILL.md
@@ -66,7 +66,7 @@ When the user invokes this skill with an idea (`$ARGUMENTS`), guide them through
    - What's been tried before?
    - Why now?
 
-   Use the `AskUserQuestion` tool to gather this input. Do NOT proceed until you understand who this is for and what success looks like.
+   Ask the user these questions using the interaction mechanism available in the current agent. Do NOT proceed until you understand who this is for and what success looks like.
 
 3. **Generate 5-8 idea variations** using these lenses:
    - **Inversion:** "What if we did the opposite?"
@@ -79,7 +79,7 @@ When the user invokes this skill with an idea (`$ARGUMENTS`), guide them through
 
    Push beyond what the user initially asked for. Create products people don't know they need yet.
 
-**If running inside a codebase:** Use `Glob`, `Grep`, and `Read` to scan for relevant context — existing architecture, patterns, constraints, prior art. Ground your variations in what actually exists. Reference specific files and patterns when relevant.
+**If running inside a codebase:** Discover relevant files, search for related concepts, and read only the context needed to understand existing architecture, patterns, constraints, and prior art. Use the codebase exploration capabilities available in the current agent. Ground your variations in what actually exists and reference specific files and patterns when relevant.
 
 Read `frameworks.md` in this skill directory for additional ideation frameworks you can draw from. Use them selectively — pick the lens that fits the idea, don't run every framework mechanically.
 


### PR DESCRIPTION
## Summary

Two shared skills currently instruct the agent in Claude Code's tool vocabulary, which reads as a hard requirement on harnesses that have the same capability under a different name.

- `idea-refine`: replace `AskUserQuestion` and `` `Glob`/`Grep`/`Read` `` with the capability each one stands for — ask focused questions; discover, search, and read relevant files. Workflow and stopping conditions unchanged.
- `browser-testing-with-devtools`: lead with the transport-neutral requirement (launch `chrome-devtools-mcp` as a local STDIO MCP server), then give the existing `.mcp.json` under a labeled **Claude Code and compatible clients** heading and add a **Codex** equivalent (`codex mcp add` plus project-scoped `.codex/config.toml`).

Scoped down from the original submission per review on #424:

- the `superpowers/` plan and spec docs are removed — working artifacts against an external framework, and `docs/` carries no `plans/`/`specs/` convention;
- the portability lint rule is removed — a blocking catalog-wide gate is a policy decision that deserves its own thread, and it overlaps #428's rework of the same file;
- the `doubt-driven-development` edit is removed — #380 rewrites the same paragraph and has been open longer. It can be re-cut on top of #380 if still wanted.

No overlap with the #404 ecosystem-neutrality track (#419, #425): different axis, no shared files.

## Verification

- `node scripts/validate-skills.js` — 24 skills, 0 errors, 0 warnings
- `node scripts/validate-commands.js` — 8 commands, 0 errors
- `node scripts/run-evals.js` — 124 checks passed, 0 errors, 0 warnings; rank-1 86% (65/76)
- `git diff --check origin/main...HEAD` — clean
- Rebased onto `main` at 7829ffd (post-#425)
