### PR TITLE
docs(skills): extend ecosystem-neutral commands catalog-wide (#404 Phase 2)

### DIFF
--- a/evals/cases/test-driven-development.json
+++ b/evals/cases/test-driven-development.json
@@ -55,7 +55,7 @@
     },
     {
       "id": 3,
-      "prompt": "Add debit entries to the ledger, test-first. A debit subtracts its amount from the balance and must not drive the balance below zero.",
+      "prompt": "Add debit entries to the ledger, test-first. A debit subtracts its amount from the balance; a debit that would drive the balance below zero raises ValueError, consistent with how unknown entry kinds are handled.",
       "expected_output": "A failing unittest written and shown failing first, a minimal implementation, and the full suite run with the repository's own Python test command",
       "files": [
         "test-driven-development-ecosystem"

--- a/references/security-checklist.md
+++ b/references/security-checklist.md
@@ -181,7 +181,7 @@ res.status(500).json({
 | 3 | Injection | Parameterized queries, input validation |
 | 4 | Insecure Design | Threat modeling, spec-driven development |
 | 5 | Security Misconfiguration | Security headers, minimal permissions, audit deps |
-| 6 | Vulnerable Components | Native dependency audit (`npm audit`, `pip-audit`, ...), keep deps updated, minimal deps |
+| 6 | Vulnerable Components | The ecosystem's dependency audit (`npm audit`, `pip-audit`, ...), keep deps updated, minimal deps |
 | 7 | Auth Failures | Strong passwords, rate limiting, session management |
 | 8 | Data Integrity Failures | Verify updates/dependencies, signed artifacts |
 | 9 | Logging Failures | Log security events, don't log secrets |

--- a/references/security-checklist.md
+++ b/references/security-checklist.md
@@ -181,7 +181,7 @@ res.status(500).json({
 | 3 | Injection | Parameterized queries, input validation |
 | 4 | Insecure Design | Threat modeling, spec-driven development |
 | 5 | Security Misconfiguration | Security headers, minimal permissions, audit deps |
-| 6 | Vulnerable Components | `npm audit`, keep deps updated, minimal deps |
+| 6 | Vulnerable Components | Native dependency audit (`npm audit`, `pip-audit`, ...), keep deps updated, minimal deps |
 | 7 | Auth Failures | Strong passwords, rate limiting, session management |
 | 8 | Data Integrity Failures | Verify updates/dependencies, signed artifacts |
 | 9 | Logging Failures | Log security events, don't log secrets |

--- a/skills/debugging-and-error-recovery/SKILL.md
+++ b/skills/debugging-and-error-recovery/SKILL.md
@@ -72,7 +72,7 @@ Cannot reproduce on demand:
     └── Document the conditions observed and revisit when it recurs
 ```
 
-For test failures:
+For test failures (npm shown — substitute the repository's own test command, per the test-driven-development skill's Discover the Stack First section):
 ```bash
 # Run the specific failing test
 npm test -- --grep "test name"
@@ -105,7 +105,7 @@ git bisect start
 git bisect bad                    # Current commit is broken
 git bisect good <known-good-sha> # This commit worked
 # Git will checkout midpoint commits; run your test at each
-git bisect run npm test -- --grep "failing test"
+git bisect run npm test -- --grep "failing test"  # substitute the repository's focused-test command
 ```
 
 ### Step 3: Reduce
@@ -153,7 +153,7 @@ This test will prevent the same bug from recurring. It should fail without the f
 
 ### Step 6: Verify End-to-End
 
-After fixing, verify the complete scenario:
+After fixing, verify the complete scenario with the repository's own commands (npm shown):
 
 ```bash
 # Run the specific test

--- a/skills/incremental-implementation/SKILL.md
+++ b/skills/incremental-implementation/SKILL.md
@@ -190,21 +190,21 @@ When directing an agent to implement incrementally:
 Start with just the database schema change and the API endpoint.
 Don't touch the UI yet — we'll do that in the next increment.
 
-After implementing, run `npm test` and `npm run build` to verify
-nothing is broken."
+After implementing, run the repository's test and build commands to
+verify nothing is broken."
 ```
 
 Be explicit about what's in scope and what's NOT in scope for each increment.
 
 ## Increment Checklist
 
-After each increment, verify:
+After each increment, verify with the repository's own commands (see the test-driven-development skill's Discover the Stack First section):
 
 - [ ] The change does one thing and does it completely
-- [ ] All existing tests still pass (`npm test`)
-- [ ] The build succeeds (`npm run build`)
-- [ ] Type checking passes (`npx tsc --noEmit`)
-- [ ] Linting passes (`npm run lint`)
+- [ ] All existing tests still pass (the repository's test command: `npm test`, `./gradlew test`, `pytest`, ...)
+- [ ] The build succeeds (the repository's build command)
+- [ ] Type checking passes, where the stack has one (`npx tsc --noEmit`, `mypy`, ...)
+- [ ] Linting passes (the repository's lint command)
 - [ ] The new functionality works as expected
 - [ ] The change is committed with a descriptive message
 

--- a/skills/planning-and-task-breakdown/SKILL.md
+++ b/skills/planning-and-task-breakdown/SKILL.md
@@ -90,8 +90,8 @@ Each task follows this structure:
 - [ ] [Specific, testable condition]
 
 **Verification:**
-- [ ] Tests pass: `npm test -- --grep "feature-name"`
-- [ ] Build succeeds: `npm run build`
+- [ ] Tests pass: [the repository's focused-test command]
+- [ ] Build succeeds: [the repository's build command]
 - [ ] Manual check: [description of what to verify]
 
 **Dependencies:** [Task numbers this depends on, or "None"]

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -32,7 +32,7 @@ Ship with confidence. The goal is not just to deploy — it's to deploy safely, 
 ### Security
 
 - [ ] No secrets in code or version control
-- [ ] `npm audit` shows no critical or high vulnerabilities
+- [ ] The ecosystem's dependency audit (`npm audit`, `pip-audit`, `cargo audit`, ...) shows no critical or high vulnerabilities
 - [ ] Input validation on all user-facing endpoints
 - [ ] Authentication and authorization checks in place
 - [ ] Security headers configured (CSP, HSTS, etc.)


### PR DESCRIPTION
Follow-up to #419, which addyosmani asked to treat as Phase 1 of a catalog-wide pass. This addresses the remaining normative npm-family commands from @federicobartoli's grep on #404: incremental-implementation's four exit criteria, planning-and-task-breakdown's task-template verification lines, shipping-and-launch's `npm audit` checkbox, and the imperative command blocks in debugging-and-error-recovery — each now uses or points to the repository's own commands, referencing the TDD skill's Discover the Stack First section instead of duplicating it. `references/security-checklist.md`'s OWASP row generalizes likewise. security-and-hardening needed no change: its SKILL.md was already neutralized by the supply-chain work. Ride-along: pins the below-zero debit behavior (ValueError) in TDD eval case 3, per @nucliweb's non-blocking note on #419.

Illustrative-only material (CI pipeline YAML, example CLAUDE.md/README snippets in context-engineering, documentation-and-adrs, spec-driven-development) is deliberately untouched — those depict concrete example projects, not universal exit criteria.

Validation: `validate-skills.js`, `validate-commands.js`, and `run-evals.js` all pass (rank-1 86%).

Rebase notes: #415 adds an SLO section to shipping-and-launch (different section, trivial rebase for whoever lands second), and #383 touches planning-and-task-breakdown's plan template header (adjacent to, not overlapping, the lines changed here).
