### PR TITLE
ci: validate repository-local Markdown links and anchors

### DIFF
--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -40,9 +40,26 @@ jobs:
       - name: Validate commands across all tool directories
         run: node scripts/validate-commands.js
 
+  validate-links:
+    name: Validate repository-local Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Test Markdown link validator
+        run: node --test scripts/validate-links-test.js
+
+      - name: Validate repository-local Markdown links
+        run: node scripts/validate-links.js
+
   validate:
     name: Validate plugin structure
-    needs: [validate-skills, validate-commands]
+    needs: [validate-skills, validate-commands, validate-links]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/scripts/lib/markdown-link-lint.js
+++ b/scripts/lib/markdown-link-lint.js
@@ -1,0 +1,427 @@
+'use strict';
+
+const path = require('node:path');
+
+function stripFencedCodeBlocks(markdown) {
+  const lines = markdown.split('\n');
+  let fence = null;
+
+  return lines.map((line) => {
+    if (fence !== null) {
+      const closingFence = new RegExp(
+        `^ {0,3}\\${fence.character}{${fence.length},}[ \\t]*$`,
+      );
+      if (closingFence.test(line)) fence = null;
+      return '';
+    }
+
+    const openingFence = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+    if (
+      openingFence
+      && !(openingFence[1][0] === '`' && openingFence[2].includes('`'))
+    ) {
+      fence = {
+        character: openingFence[1][0],
+        length: openingFence[1].length,
+      };
+      return '';
+    }
+
+    return line;
+  }).join('\n');
+}
+
+function stripCodeSpans(markdown) {
+  const characters = [...markdown];
+  let cursor = 0;
+
+  while (cursor < characters.length) {
+    if (characters[cursor] !== '`') {
+      cursor++;
+      continue;
+    }
+
+    const openingStart = cursor;
+    while (characters[cursor] === '`') cursor++;
+    const openingLength = cursor - openingStart;
+    let search = cursor;
+    let closingEnd = null;
+
+    while (search < characters.length) {
+      if (characters[search] !== '`') {
+        search++;
+        continue;
+      }
+      const runStart = search;
+      while (characters[search] === '`') search++;
+      if (search - runStart === openingLength) {
+        closingEnd = search;
+        break;
+      }
+    }
+
+    if (closingEnd === null) continue;
+    for (let index = openingStart; index < closingEnd; index++) {
+      if (characters[index] !== '\n' && characters[index] !== '\r') {
+        characters[index] = ' ';
+      }
+    }
+    cursor = closingEnd;
+  }
+
+  return characters.join('');
+}
+
+function stripCode(markdown) {
+  return stripCodeSpans(stripFencedCodeBlocks(markdown));
+}
+
+function unescapeMarkdown(value) {
+  return value.replace(
+    /\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g,
+    '$1',
+  );
+}
+
+function isIgnoredDestination(destination) {
+  const unescaped = unescapeMarkdown(destination);
+  return (
+    unescaped.length === 0
+    || /^[a-z][a-z0-9+.-]*:/i.test(unescaped)
+    || unescaped.startsWith('//')
+    || unescaped.startsWith('/')
+  );
+}
+
+function isEscaped(value, index) {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === '\\'; cursor--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+function openingBracketFor(line, closeBracket) {
+  for (let index = closeBracket - 1; index >= 0; index--) {
+    if (line[index] === ']' && !isEscaped(line, index)) return -1;
+    if (line[index] === '[' && !isEscaped(line, index)) return index;
+  }
+  return -1;
+}
+
+function inlineDestinations(line, lineNumber) {
+  const destinations = [];
+  let cursor = 0;
+
+  while (cursor < line.length) {
+    const closeBracket = line.indexOf('](', cursor);
+    if (closeBracket === -1) break;
+
+    const openBracket = isEscaped(line, closeBracket)
+      ? -1
+      : openingBracketFor(line, closeBracket);
+    if (openBracket === -1) {
+      cursor = closeBracket + 2;
+      continue;
+    }
+
+    const isImage = openBracket > 0 && line[openBracket - 1] === '!';
+    let start = closeBracket + 2;
+    while (/\s/.test(line[start] ?? '')) start++;
+
+    let destination = '';
+    let destinationEnd = start;
+    let closingParenthesis = null;
+    if (line[start] === '<') {
+      const closingAngle = line.indexOf('>', start + 1);
+      if (closingAngle !== -1) {
+        destination = line.slice(start + 1, closingAngle);
+        const candidate = line.indexOf(')', closingAngle + 1);
+        if (candidate !== -1) closingParenthesis = candidate;
+      }
+    } else {
+      let depth = 0;
+      let escaped = false;
+      let destinationComplete = false;
+      for (let index = start; index < line.length; index++) {
+        const character = line[index];
+        if (escaped) {
+          escaped = false;
+          if (!destinationComplete) destinationEnd = index + 1;
+          continue;
+        }
+        if (character === '\\') {
+          escaped = true;
+          if (!destinationComplete) destinationEnd = index + 1;
+          continue;
+        }
+        if (character === '(') {
+          depth++;
+        } else if (character === ')') {
+          if (depth === 0) {
+            closingParenthesis = index;
+            if (!destinationComplete) destinationEnd = index;
+            break;
+          }
+          depth--;
+        } else if (/\s/.test(character) && depth === 0) {
+          destinationComplete = true;
+          continue;
+        }
+        if (!destinationComplete) destinationEnd = index + 1;
+      }
+      destination = line.slice(start, destinationEnd);
+    }
+
+    if (
+      closingParenthesis !== null
+      && !isImage
+      && !isIgnoredDestination(destination)
+    ) {
+      destinations.push({ destination, line: lineNumber });
+    }
+    cursor = closingParenthesis === null
+      ? closeBracket + 2
+      : closingParenthesis + 1;
+  }
+
+  return destinations;
+}
+
+function extractDestinations(markdown) {
+  const prose = stripCode(markdown);
+  const destinations = [];
+  const definitions = new Map();
+  const definitionLines = new Set();
+  const lines = prose.split('\n');
+
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1;
+    destinations.push(...inlineDestinations(line, lineNumber));
+
+    const definition = line.match(
+      /^\s{0,3}\[([^\]]+)\]:\s*(?:<([^>]+)>|(\S+))/,
+    );
+    const destination = definition?.[2] ?? definition?.[3];
+    if (definition && destination && !isIgnoredDestination(destination)) {
+      const label = definition[1].trim().replace(/\s+/g, ' ').toLowerCase();
+      if (!definitions.has(label)) {
+        definitions.set(label, { destination, line: lineNumber });
+      }
+      definitionLines.add(index);
+    }
+  });
+
+  const usedLabels = new Set();
+  lines.forEach((line, index) => {
+    if (definitionLines.has(index)) return;
+
+    const reference = /(!?)\[([^\]]+)\](?:\[([^\]]*)\])?/g;
+    let match;
+    while ((match = reference.exec(line)) !== null) {
+      if (
+        match[1] === '!'
+        || isEscaped(line, match.index)
+        || line[reference.lastIndex] === '('
+      ) {
+        continue;
+      }
+      const label = (match[3] || match[2]).trim().replace(/\s+/g, ' ').toLowerCase();
+      if (definitions.has(label)) usedLabels.add(label);
+    }
+  });
+
+  for (const [label, definition] of definitions) {
+    if (usedLabels.has(label)) destinations.push(definition);
+  }
+
+  destinations.sort((left, right) => left.line - right.line);
+  return destinations;
+}
+
+function githubSlug(text) {
+  return text
+    .trim()
+    .toLowerCase()
+    .replace(/<[^>]*>/g, '')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[*~`]/g, '')
+    .replace(/[^\p{L}\p{N}\s_-]/gu, '')
+    .replace(/\s/g, '-');
+}
+
+function buildAnchorSet(markdown) {
+  const prose = stripFencedCodeBlocks(markdown);
+  const anchors = new Set();
+  const usedHeadingSlugs = new Set();
+  const lines = prose.split('\n');
+
+  function addHeading(headingText) {
+    const baseSlug = githubSlug(headingText);
+    if (!baseSlug) return;
+
+    let slug = baseSlug;
+    let suffix = 1;
+    while (usedHeadingSlugs.has(slug)) {
+      slug = `${baseSlug}-${suffix}`;
+      suffix++;
+    }
+    usedHeadingSlugs.add(slug);
+    anchors.add(slug);
+  }
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    const atxHeading = line.match(/^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$/);
+    if (atxHeading) addHeading(atxHeading[1]);
+
+    const setextUnderline = lines[index + 1]?.match(/^\s{0,3}(?:=+|-+)\s*$/);
+    if (!atxHeading && setextUnderline && line.trim()) addHeading(line.trim());
+
+    const explicitAnchor = /\b(?:id|name)\s*=\s*["']([^"']+)["']/gi;
+    let match;
+    while ((match = explicitAnchor.exec(line)) !== null) {
+      anchors.add(match[1]);
+    }
+  }
+
+  return anchors;
+}
+
+function toPosix(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function defaultExistingPaths(documents) {
+  const existingPaths = new Set(['.']);
+  for (const documentPath of documents.keys()) {
+    const normalized = toPosix(path.normalize(documentPath));
+    existingPaths.add(normalized);
+
+    let parent = path.posix.dirname(normalized);
+    while (parent !== '.') {
+      existingPaths.add(parent);
+      parent = path.posix.dirname(parent);
+    }
+  }
+  return existingPaths;
+}
+
+function decodePart(value) {
+  try {
+    return { value: decodeURIComponent(value) };
+  } catch {
+    return { error: 'invalid percent encoding' };
+  }
+}
+
+function targetForDestination(_root, source, destination) {
+  const logicalDestination = unescapeMarkdown(destination);
+  const hashIndex = logicalDestination.indexOf('#');
+  const pathAndQuery = hashIndex === -1
+    ? logicalDestination
+    : logicalDestination.slice(0, hashIndex);
+  const queryIndex = pathAndQuery.indexOf('?');
+  const rawPath = queryIndex === -1
+    ? pathAndQuery
+    : pathAndQuery.slice(0, queryIndex);
+  const rawFragment = hashIndex === -1
+    ? null
+    : logicalDestination.slice(hashIndex + 1);
+  const decodedPath = decodePart(rawPath);
+  if (decodedPath.error) return { error: decodedPath.error };
+
+  const decodedFragment = rawFragment === null ? { value: null } : decodePart(rawFragment);
+  if (decodedFragment.error) return { error: decodedFragment.error };
+
+  const unresolvedTarget = rawPath === ''
+    ? source
+    : path.posix.normalize(
+      path.posix.join(path.posix.dirname(source), decodedPath.value),
+    );
+  const relativeTarget = unresolvedTarget.replace(/\/+$/, '') || '.';
+  if (
+    relativeTarget === '..'
+    || relativeTarget.startsWith('../')
+    || path.posix.isAbsolute(relativeTarget)
+  ) {
+    return { error: 'target escapes repository root' };
+  }
+
+  return {
+    fragment: decodedFragment.value,
+    target: relativeTarget,
+  };
+}
+
+function validateDocuments(root, documents, existingPaths = defaultExistingPaths(documents)) {
+  const normalizedDocuments = new Map(
+    [...documents].map(([documentPath, content]) => [
+      toPosix(path.normalize(documentPath)),
+      content,
+    ]),
+  );
+  const normalizedExistingPaths = new Set(
+    [...existingPaths].map((filePath) => toPosix(path.normalize(filePath))),
+  );
+  const anchorsByDocument = new Map();
+  const diagnostics = [];
+
+  for (const [source, markdown] of normalizedDocuments) {
+    for (const { destination, line } of extractDestinations(markdown)) {
+      const resolved = targetForDestination(root, source, destination);
+      if (resolved.error) {
+        diagnostics.push({ destination, line, reason: resolved.error, source });
+        continue;
+      }
+
+      if (!normalizedExistingPaths.has(resolved.target)) {
+        diagnostics.push({
+          destination,
+          line,
+          reason: `target does not exist: ${resolved.target}`,
+          source,
+        });
+        continue;
+      }
+
+      if (resolved.fragment === null || resolved.fragment === '') continue;
+      if (!/\.md$/i.test(resolved.target)) {
+        diagnostics.push({
+          destination,
+          line,
+          reason: `cannot validate fragment on non-Markdown target: ${resolved.target}`,
+          source,
+        });
+        continue;
+      }
+
+      if (!anchorsByDocument.has(resolved.target)) {
+        const targetMarkdown = normalizedDocuments.get(resolved.target);
+        anchorsByDocument.set(
+          resolved.target,
+          targetMarkdown === undefined ? new Set() : buildAnchorSet(targetMarkdown),
+        );
+      }
+      if (!anchorsByDocument.get(resolved.target).has(resolved.fragment)) {
+        diagnostics.push({
+          destination,
+          line,
+          reason: `fragment not found in ${resolved.target}: #${resolved.fragment}`,
+          source,
+        });
+      }
+    }
+  }
+
+  return diagnostics;
+}
+
+module.exports = {
+  buildAnchorSet,
+  extractDestinations,
+  githubSlug,
+  stripCode,
+  validateDocuments,
+};

--- a/scripts/validate-links-test.js
+++ b/scripts/validate-links-test.js
@@ -1,0 +1,355 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const { execFileSync, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  buildAnchorSet,
+  extractDestinations,
+  githubSlug,
+  stripCode,
+  validateDocuments,
+} = require('./lib/markdown-link-lint');
+
+const CLI_PATH = path.join(__dirname, 'validate-links.js');
+
+function makeRepository(t, files, tracked = Object.keys(files)) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-skills-link-test-'));
+  t.after(() => fs.rmSync(root, { force: true, recursive: true }));
+
+  execFileSync('git', ['init', '--quiet'], { cwd: root });
+  execFileSync('git', ['config', 'core.autocrlf', 'false'], { cwd: root });
+  for (const [filePath, content] of Object.entries(files)) {
+    const absolutePath = path.join(root, filePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, content, 'utf8');
+  }
+  if (tracked.length > 0) {
+    execFileSync('git', ['add', '--', ...tracked], { cwd: root });
+  }
+  return root;
+}
+
+function runCli(cwd) {
+  return spawnSync(process.execPath, [CLI_PATH], {
+    cwd,
+    encoding: 'utf8',
+  });
+}
+
+test('extracts inline and reference destinations with source lines', () => {
+  const markdown = [
+    '# Install & Run',
+    '## Repeat',
+    '## Repeat',
+    '[guide](docs/guide.md#usage)',
+    '[reference][guide]',
+    '[guide]: docs/guide.md#usage',
+    '![ignored](missing.png)',
+    '`[inline](missing.md)`',
+  ].join('\n');
+
+  assert.deepEqual(extractDestinations(markdown), [
+    { destination: 'docs/guide.md#usage', line: 4 },
+    { destination: 'docs/guide.md#usage', line: 6 },
+  ]);
+});
+
+test('ignores links inside fenced and inline code', () => {
+  const markdown = [
+    '[kept](docs/guide.md)',
+    '```markdown',
+    '[fenced](missing.md)',
+    '```',
+    '~~~',
+    '[also-fenced](missing.md)',
+    '~~~',
+    '`[inline](missing.md)`',
+  ].join('\n');
+
+  assert.deepEqual(extractDestinations(markdown), [
+    { destination: 'docs/guide.md', line: 1 },
+  ]);
+  assert.equal(stripCode(markdown).split('\n').length, markdown.split('\n').length);
+});
+
+test('ignores multiline code spans, shorter backticks, and fence-like content', () => {
+  const markdown = [
+    '```markdown',
+    '```still code',
+    '[fenced](missing.md)',
+    '```',
+    '`multiline',
+    '[single](missing.md)',
+    'code`',
+    '``multiline with ` inner',
+    '[double](missing.md)',
+    'code``',
+    '[kept](docs/guide.md)',
+  ].join('\n');
+
+  assert.deepEqual(extractDestinations(markdown), [
+    { destination: 'docs/guide.md', line: 11 },
+  ]);
+});
+
+test('ignores reference definitions used only by images', () => {
+  const markdown = [
+    '![logo][brand]',
+    '[brand]: missing.png',
+    '[guide][docs]',
+    '[docs]: docs/guide.md',
+  ].join('\n');
+
+  assert.deepEqual(extractDestinations(markdown), [
+    { destination: 'docs/guide.md', line: 4 },
+  ]);
+});
+
+test('ignores escaped and unbalanced link-like text', () => {
+  const markdown = [
+    'not a link](missing.md)',
+    '\\[literal](missing.md)',
+    '[unfinished](missing.md',
+    '[unfinished](<missing.md>',
+    '[kept](docs/guide.md)',
+  ].join('\n');
+
+  assert.deepEqual(extractDestinations(markdown), [
+    { destination: 'docs/guide.md', line: 5 },
+  ]);
+});
+
+test('builds GitHub-style heading and explicit HTML anchors', () => {
+  const markdown = [
+    '# Install & Run',
+    '## Repeat',
+    '## Repeat',
+    '## Repeat',
+    '<a id="manual-anchor"></a>',
+    '<span name="legacy-anchor"></span>',
+  ].join('\n');
+
+  assert.equal(githubSlug('Install & Run'), 'install--run');
+  assert.deepEqual([...buildAnchorSet(markdown)], [
+    'install--run',
+    'repeat',
+    'repeat-1',
+    'repeat-2',
+    'manual-anchor',
+    'legacy-anchor',
+  ]);
+});
+
+test('preserves inline code, supports Setext headings, and keeps slugs unique', () => {
+  const markdown = [
+    '# Use `npm test` now',
+    'Setext Title',
+    '============',
+    '# foo',
+    '# foo-1',
+    '# foo',
+  ].join('\n');
+
+  assert.deepEqual([...buildAnchorSet(markdown)], [
+    'use-npm-test-now',
+    'setext-title',
+    'foo',
+    'foo-1',
+    'foo-2',
+  ]);
+});
+
+test('validates files, directories, encoded paths, and local fragments', () => {
+  const root = path.resolve('fixture-repository');
+  const documents = new Map([
+    [
+      'README.md',
+      [
+        '# Home',
+        '[guide](docs/guide.md#usage)',
+        '[guide query](docs/guide.md?plain=1#usage)',
+        '[space](docs/My%20Guide.md#hello-world)',
+        '[same document](#home)',
+        '[directory](docs/)',
+        '[escaped](docs/foo\\(bar\\).md)',
+      ].join('\n'),
+    ],
+    ['docs/guide.md', '# Usage'],
+    ['docs/My Guide.md', '# Hello World'],
+    ['docs/foo(bar).md', '# Parentheses'],
+  ]);
+  const existingPaths = new Set([
+    'README.md',
+    'docs',
+    'docs/guide.md',
+    'docs/My Guide.md',
+    'docs/foo(bar).md',
+  ]);
+
+  assert.deepEqual(
+    validateDocuments(root, documents, existingPaths),
+    [],
+  );
+});
+
+test('reports missing paths and fragments with stable diagnostics', () => {
+  const root = path.resolve('fixture-repository');
+  const documents = new Map([
+    [
+      'README.md',
+      [
+        '[missing](docs/missing.md)',
+        '[missing fragment](docs/guide.md#absent)',
+        '[non-Markdown fragment](docs/guide.txt#usage)',
+        '[invalid encoding](docs/%E0%A4%A.md)',
+        '[escape](../../outside.md)',
+      ].join('\n'),
+    ],
+    ['docs/guide.md', '# Usage'],
+  ]);
+  const existingPaths = new Set([
+    'README.md',
+    'docs',
+    'docs/guide.md',
+    'docs/guide.txt',
+  ]);
+
+  assert.deepEqual(validateDocuments(root, documents, existingPaths), [
+    {
+      destination: 'docs/missing.md',
+      line: 1,
+      reason: 'target does not exist: docs/missing.md',
+      source: 'README.md',
+    },
+    {
+      destination: 'docs/guide.md#absent',
+      line: 2,
+      reason: 'fragment not found in docs/guide.md: #absent',
+      source: 'README.md',
+    },
+    {
+      destination: 'docs/guide.txt#usage',
+      line: 3,
+      reason: 'cannot validate fragment on non-Markdown target: docs/guide.txt',
+      source: 'README.md',
+    },
+    {
+      destination: 'docs/%E0%A4%A.md',
+      line: 4,
+      reason: 'invalid percent encoding',
+      source: 'README.md',
+    },
+    {
+      destination: '../../outside.md',
+      line: 5,
+      reason: 'target escapes repository root',
+      source: 'README.md',
+    },
+  ]);
+});
+
+test('accepts duplicate and explicit anchors but rejects malformed fragments', () => {
+  const root = path.resolve('fixture-repository');
+  const documents = new Map([
+    [
+      'README.md',
+      [
+        '[duplicate](guide.md#repeat-1)',
+        '[manual](guide.md#manual-anchor)',
+        '[encoded](guide.md#%68ello-world)',
+        '[bad](guide.md#%E0%A4%A)',
+      ].join('\n'),
+    ],
+    [
+      'guide.md',
+      [
+        '# Repeat',
+        '# Repeat',
+        '# Hello world',
+        '<a id="manual-anchor"></a>',
+      ].join('\n'),
+    ],
+  ]);
+
+  assert.deepEqual(validateDocuments(root, documents), [
+    {
+      destination: 'guide.md#%E0%A4%A',
+      line: 4,
+      reason: 'invalid percent encoding',
+      source: 'README.md',
+    },
+  ]);
+});
+
+test('CLI scans tracked Markdown and ignores untracked files', (t) => {
+  const root = makeRepository(t, {
+    'README.md': '[guide](docs/guide.md#usage)',
+    'docs/guide.md': '# Usage',
+    'untracked.md': '[broken](missing.md)',
+  }, ['README.md', 'docs/guide.md']);
+
+  const result = runCli(root);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /2 Markdown files checked — 0 broken local link\(s\) — PASSED/,
+  );
+  assert.equal(result.stderr, '');
+});
+
+test('CLI returns one and prints stable source diagnostics for broken links', (t) => {
+  const root = makeRepository(t, {
+    'README.md': [
+      '# Home',
+      '[missing](docs/missing.md)',
+      '[fragment](README.md#absent)',
+    ].join('\n'),
+  });
+
+  const result = runCli(root);
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stdout,
+    /README\.md:2: broken local link 'docs\/missing\.md' — target does not exist: docs\/missing\.md/,
+  );
+  assert.match(
+    result.stdout,
+    /README\.md:3: broken local link 'README\.md#absent' — fragment not found in README\.md: #absent/,
+  );
+  assert.match(result.stdout, /1 Markdown files checked — 2 broken local link\(s\) — FAILED/);
+  assert.equal(result.stderr, '');
+});
+
+test('CLI reports Git inventory failures without a stack trace', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-skills-link-no-git-'));
+  t.after(() => fs.rmSync(root, { force: true, recursive: true }));
+
+  const result = runCli(root);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /^ERROR: validate-links failed unexpectedly: /);
+  assert.doesNotMatch(result.stderr, /\n\s+at /);
+});
+
+test('CLI sorts diagnostics by locale-independent code-unit order', (t) => {
+  const root = makeRepository(t, {
+    'z.md': '[broken](missing-z.md)',
+    'ä.md': '[broken](missing-a.md)',
+  });
+
+  const result = runCli(root);
+
+  assert.equal(result.status, 1);
+  assert.ok(
+    result.stdout.indexOf('z.md:1:') < result.stdout.indexOf('ä.md:1:'),
+    result.stdout,
+  );
+});

--- a/scripts/validate-links.js
+++ b/scripts/validate-links.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { validateDocuments } = require('./lib/markdown-link-lint');
+
+function toPosix(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function trackedPaths(root) {
+  return execFileSync('git', ['ls-files', '-z', '--'], {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).split('\0').filter(Boolean).map(toPosix);
+}
+
+function existingPathsFor(files) {
+  const existingPaths = new Set(['.', ...files]);
+  for (const filePath of files) {
+    let parent = path.posix.dirname(filePath);
+    while (parent !== '.') {
+      existingPaths.add(parent);
+      parent = path.posix.dirname(parent);
+    }
+  }
+  return existingPaths;
+}
+
+function compareDiagnostics(left, right) {
+  const sourceOrder = left.source < right.source
+    ? -1
+    : left.source > right.source ? 1 : 0;
+  const destinationOrder = left.destination < right.destination
+    ? -1
+    : left.destination > right.destination ? 1 : 0;
+  return (
+    sourceOrder
+    || left.line - right.line
+    || destinationOrder
+  );
+}
+
+function main(root = process.cwd()) {
+  const files = trackedPaths(root);
+  const markdownFiles = files.filter((filePath) => /\.md$/i.test(filePath));
+  const documents = new Map(
+    markdownFiles.map((filePath) => [
+      filePath,
+      fs.readFileSync(path.join(root, filePath), 'utf8'),
+    ]),
+  );
+  const diagnostics = validateDocuments(
+    root,
+    documents,
+    existingPathsFor(files),
+  ).sort(compareDiagnostics);
+
+  for (const diagnostic of diagnostics) {
+    console.log(
+      `${diagnostic.source}:${diagnostic.line}: broken local link `
+      + `'${diagnostic.destination}' — ${diagnostic.reason}`,
+    );
+  }
+
+  const status = diagnostics.length === 0 ? 'PASSED' : 'FAILED';
+  console.log(
+    `${markdownFiles.length} Markdown files checked — ${diagnostics.length} `
+    + `broken local link(s) — ${status}`,
+  );
+  if (diagnostics.length > 0) process.exitCode = 1;
+}
+
+try {
+  main();
+} catch (error) {
+  const message = String(error.message ?? error).split(/\r?\n/, 1)[0];
+  console.error(`ERROR: validate-links failed unexpectedly: ${message}`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

- add a dependency-free validator for repository-local Markdown paths and heading fragments
- cover inline and reference links, fenced and inline code, escaped destinations, query strings, Setext and ATX headings, and duplicate slug collisions
- add focused `node:test` coverage and run the validator in CI
- keep diagnostics deterministic and actionable with source file, line, destination, and reason

## Why

The existing repository checks validate skill content, command parity, and evaluation routing, but they do not detect broken repository-local Markdown paths or anchors across documentation, agents, references, and commands.

Previous pull requests fixed individual broken references. This adds the missing regression gate so future moves, renames, and heading edits fail CI before broken navigation reaches users.

## Impact

Contributors get an early, dependency-free CI check for invalid local links and anchors. External URLs are intentionally left out of scope, avoiding flaky network-dependent validation.

## Validation

- `node --test scripts/validate-links-test.js` — 14/14 passed
- `node --test scripts/run-evals-test.js` — 12/12 passed
- `node scripts/validate-links.js` — 86 files checked, 0 broken links
- `node scripts/validate-skills.js` — 24 skills, 0 errors or warnings
- `node scripts/validate-commands.js` — 8 commands, 0 errors
- `node scripts/run-evals.js --min-rank1 80` — 124 checks, 86% rank-1, passed
- `git diff --check` — passed

## Duplicate check

Immediately before publication, open issues and pull requests were searched for `markdown link`, `link validator`, `link checker`, and `broken anchor`. The only adjacent open item was #366, which concerns shared reference URLs for `npx` installs and does not add repository-wide local path and anchor validation.