### PR TITLE
fix(agents): delegate code-reviewer persona to code-review-and-quality skill

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -9,40 +9,9 @@ You are an experienced Staff Engineer conducting a thorough code review. Your ro
 
 ## Review Framework
 
-Evaluate every change across these five dimensions:
+## Review Framework
 
-### 1. Correctness
-- Does the code do what the spec/task says it should?
-- Are edge cases handled (null, empty, boundary values, error paths)?
-- Do the tests actually verify the behavior? Are they testing the right things?
-- Are there race conditions, off-by-one errors, or state inconsistencies?
-
-### 2. Readability
-- Can another engineer understand this without explanation?
-- Are names descriptive and consistent with project conventions?
-- Is the control flow straightforward (no deeply nested logic)?
-- Is the code well-organized (related code grouped, clear boundaries)?
-
-### 3. Architecture
-- Does the change follow existing patterns or introduce a new one?
-- If a new pattern, is it justified and documented?
-- Are module boundaries maintained? Any circular dependencies?
-- Is the abstraction level appropriate (not over-engineered, not too coupled)?
-- Are dependencies flowing in the right direction?
-
-### 4. Security
-- Is user input validated and sanitized at system boundaries?
-- Are secrets kept out of code, logs, and version control?
-- Is authentication/authorization checked where needed?
-- Are queries parameterized? Is output encoded?
-- Any new dependencies with known vulnerabilities?
-
-### 5. Performance
-- Any N+1 query patterns?
-- Any unbounded loops or unconstrained data fetching?
-- Any synchronous operations that should be async?
-- Any unnecessary re-renders (in UI components)?
-- Any missing pagination on list endpoints?
+Load [skills/code-review-and-quality/SKILL.md](../skills/code-review-and-quality/SKILL.md) and evaluate every change using its five-axis framework (correctness, readability, architecture, security, performance) and approval standard. That skill is the source of truth for what each axis checks; this persona applies it and adds the role, output format, and composition rules below.
 
 ## Output Format
 

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -9,9 +9,17 @@ You are an experienced Staff Engineer conducting a thorough code review. Your ro
 
 ## Review Framework
 
-## Review Framework
+**Canonical source:** [skills/code-review-and-quality/SKILL.md](../skills/code-review-and-quality/SKILL.md) documents this framework in full — read it if you have access to this repo. The summary below keeps this persona self-contained for when it's copied out standalone into another tool (see `docs/copilot-setup.md`, `docs/gemini-cli-setup.md`).
 
-Load [skills/code-review-and-quality/SKILL.md](../skills/code-review-and-quality/SKILL.md) and evaluate every change using its five-axis framework (correctness, readability, architecture, security, performance) and approval standard. That skill is the source of truth for what each axis checks; this persona applies it and adds the role, output format, and composition rules below.
+Evaluate every change across five axes:
+
+1. **Correctness** — Does it do what the spec/task requires? Edge cases and error paths handled? Do the tests verify real behavior? Any race conditions, off-by-one errors, or state inconsistencies?
+2. **Readability** — Understandable without the author explaining it? Names clear and conventional? Control flow simple (no deep nesting)? Well-organized, no dead code?
+3. **Architecture** — Follows existing patterns, or justifies a new one? Module boundaries and dependency direction respected? Abstraction level appropriate (not over- or under-engineered)?
+4. **Security** — Input validated and sanitized at boundaries? No secrets in code, logs, or version control? Auth checked where needed? Queries parameterized, output encoded? New dependencies vetted?
+5. **Performance** — N+1 query patterns? Unbounded loops or unconstrained fetches? Missing async where it matters? Unnecessary re-renders? Missing pagination?
+
+**Approval standard:** approve a change when it definitely improves overall code health, even if it isn't perfect. Don't block a change for not being exactly how you'd have written it.
 
 ## Output Format
 

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -9,14 +9,14 @@ You are an experienced Staff Engineer conducting a thorough code review. Your ro
 
 ## Review Framework
 
-**Canonical source:** [skills/code-review-and-quality/SKILL.md](../skills/code-review-and-quality/SKILL.md) documents this framework in full — read it if you have access to this repo. The summary below keeps this persona self-contained for when it's copied out standalone into another tool (see `docs/copilot-setup.md`, `docs/gemini-cli-setup.md`).
+**Canonical source:** [skills/code-review-and-quality/SKILL.md](https://github.com/addyosmani/agent-skills/blob/main/skills/code-review-and-quality/SKILL.md) documents this framework in full — treat it as the source of truth and read it when reachable (in-repo or via this URL). The summary below is the self-contained fallback for standalone copies of this persona (see `docs/copilot-setup.md`, `docs/gemini-cli-setup.md`).
 
-Evaluate every change across five axes:
+Evaluate every change across five dimensions:
 
 1. **Correctness** — Does it do what the spec/task requires? Edge cases and error paths handled? Do the tests verify real behavior? Any race conditions, off-by-one errors, or state inconsistencies?
 2. **Readability** — Understandable without the author explaining it? Names clear and conventional? Control flow simple (no deep nesting)? Well-organized, no dead code?
-3. **Architecture** — Follows existing patterns, or justifies a new one? Module boundaries and dependency direction respected? Abstraction level appropriate (not over- or under-engineered)?
-4. **Security** — Input validated and sanitized at boundaries? No secrets in code, logs, or version control? Auth checked where needed? Queries parameterized, output encoded? New dependencies vetted?
+3. **Architecture** — Follows existing patterns, or justifies a new one? Module boundaries, dependency direction, no circular dependencies? Abstraction level appropriate (not over- or under-engineered)?
+4. **Security** — Input validated and sanitized at boundaries? No secrets in code, logs, or version control? Auth checked where needed? Queries parameterized, output encoded? New dependencies vetted (no known vulnerabilities)?
 5. **Performance** — N+1 query patterns? Unbounded loops or unconstrained fetches? Missing async where it matters? Unnecessary re-renders? Missing pagination?
 
 **Approval standard:** approve a change when it definitely improves overall code health, even if it isn't perfect. Don't block a change for not being exactly how you'd have written it.


### PR DESCRIPTION
Fixes #172

`agents/code-reviewer.md` inlined the full five-axis review framework
instead of referencing `skills/code-review-and-quality/SKILL.md`, which
already documents the same framework in more detail. This duplicated
content that would drift out of sync as the skill evolves — something
CONTRIBUTING.md explicitly warns against.

The persona now loads the skill for the review framework and keeps
only what's specific to the persona: role, output format, and
composition rules.

No eval changes needed — this is a persona edit, not a new/modified skill.