### PR TITLE
Add a likelihood axis to review finding triage

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -54,6 +54,17 @@ Categorize every finding:
 
 **Suggestion** — Consider for improvement (naming, code style, optional optimization)
 
+### Likelihood
+
+Those three categories are consequence — how bad it is *if* the issue fires. Before assigning one, decide whether it fires at all: name the condition that triggers the finding, and check that condition against the project's real inputs, invariants, and configuration. Read them; don't guess.
+
+- **Critical** and **Important** are for findings that are both consequential and *plausible* under those conditions.
+- A finding whose trigger the code already prevents, or that needs a scale this project won't reach, drops to **Suggestion** with its condition stated — downgraded and noted, never silently dropped. The author may know the condition is reachable for reasons the diff doesn't show; that call is theirs.
+- If you cannot name the condition, you have not established the finding.
+- If you cannot check the condition, say so and label the finding unverified. Guessing high and guessing low are the same error.
+
+`REQUEST CHANGES` requires at least one Critical or Important finding that survives this check.
+
 ## Review Output Template
 
 ```markdown
@@ -64,13 +75,13 @@ Categorize every finding:
 **Overview:** [1-2 sentences summarizing the change and overall assessment]
 
 ### Critical Issues
-- [File:line] [Description and recommended fix]
+- [File:line] [Description, the condition that makes it fire, and recommended fix]
 
 ### Important Issues
-- [File:line] [Description and recommended fix]
+- [File:line] [Description, the condition that makes it fire, and recommended fix]
 
 ### Suggestions
-- [File:line] [Description]
+- [File:line] [Description — for a downgraded finding, the condition and why it can't occur here]
 
 ### What's Done Well
 - [Positive observation — always include at least one]
@@ -89,6 +100,8 @@ Categorize every finding:
 4. Don't approve code with Critical issues
 5. Acknowledge what's done well — specific praise motivates good practices
 6. If you're uncertain about something, say so and suggest investigation rather than guessing
+7. Rate likelihood as well as consequence — a true finding that cannot fire under this project's inputs is a Suggestion, not a blocker
+8. Don't pad the review. Every finding costs the author a read and a dismissal; a list of impossible findings gets skimmed, and the real one gets skimmed with it
 
 ## Composition
 

--- a/evals/cases/code-review-and-quality.json
+++ b/evals/cases/code-review-and-quality.json
@@ -38,7 +38,9 @@
         "Findings cover more than one axis (correctness, readability, architecture, security, performance)",
         "Every finding carries a severity label from the skill's taxonomy",
         "Security of user input is explicitly considered for the new endpoint",
-        "The review leads with high-leverage findings rather than nits"
+        "The review leads with high-leverage findings rather than nits",
+        "Blocking findings name the condition that makes them fire, rather than asserting risk generically",
+        "Any finding judged unlikely under the project's actual inputs is downgraded with its condition stated, not omitted"
       ]
     }
   ]

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -188,6 +188,22 @@ Label every comment with its severity so the author knows what's required vs opt
 
 This prevents authors from treating all feedback as mandatory and wasting time on optional suggestions.
 
+**Rate likelihood, not just consequence.** Severity is blast radius — how bad it is *if* the issue fires. It says nothing about *whether* it fires. Triage on both: consequence × likelihood, not consequence alone. This is the axis that separates a real bug from the endless supply of technically-correct-but-impossible findings a reviewer can generate ("breaks at 10M rows" on a 400-row internal tool). Neither severity nor your own confidence can filter those — you are *right* about them, and they are still noise.
+
+Assess likelihood **against this project's actual inputs, invariants, and configuration. Read them; do not guess**:
+
+| Likelihood | Triggering condition | Effect |
+|---|---|---|
+| **Likely** | Occurs on the normal path or the first realistic input | Label on consequence |
+| **Plausible** | Needs a specific but real condition — an error path, a concurrent write, a large input | Label on consequence |
+| **Remote** | Needs a conjunction the code already prevents, a scale this system won't reach, or a configuration it doesn't use | Downgrade to **Optional:** / **FYI**, with the condition stated |
+
+**Name the condition, don't assert the risk.** "Fails if two workers process one shard" is checkable — the reader compares it against the single-consumer invariant and settles it. "Could have a race" is not. If you cannot name the condition that makes a finding fire, you have not established the finding — the same bar as reproducing a bug before you raise it.
+
+**Downgrade, never drop.** A remote finding keeps its comment, its condition, and your reasoning; it just stops blocking. The author may know the condition is reachable for reasons the diff doesn't show. Downgrading hands them that call — deleting takes it away, and a filter the author can't see reads as "the reviewer found nothing".
+
+**Reserve Request changes for findings that are both consequential and plausible.** Blocking a merge on things that cannot happen trains authors to discount the whole review, including the finding that was real.
+
 **Lead with what matters.** Order findings by leverage: correctness and security first, then structural regressions and missed simplifications, then everything else. Don't bury a real issue under cosmetic nits — a few high-conviction comments beat a long list. If you have one structural problem and ten nits, the structural problem *is* the review.
 
 ### Step 5: Verify the Verification
@@ -273,6 +289,7 @@ When reviewing code — whether written by you, another agent, or a human:
 - **Don't rubber-stamp.** "LGTM" without evidence of review helps no one.
 - **Don't soften real issues.** "This might be a minor concern" when it's a bug that will hit production is dishonest.
 - **Quantify problems when possible.** "This N+1 query will add ~50ms per item in the list" is better than "this could be slow."
+- **Quantify likelihood too.** "This overflows above 2^31 rows; the table is capped at 1M by the migration" is an honest finding. Reporting the overflow without checking the cap is not — it borrows the authority of a real bug for something that cannot happen. Overstating likelihood is the same dishonesty as softening a real issue, pointed the other way.
 - **Push back on approaches with clear problems.** Sycophancy is a failure mode in reviews. If the implementation has issues, say so directly and propose alternatives.
 - **Accept override gracefully.** If the author has full context and disagrees, defer to their judgment. Comment on code, not people — reframe personal critiques to focus on the code itself.
 
@@ -306,6 +323,7 @@ For triaging `npm audit` findings and supply-chain risk (typosquatting, compromi
 
 ### Context
 - [ ] I understand what this change does and why
+- [ ] I know this project's real inputs, invariants, and scale well enough to judge whether a finding can fire
 
 ### Correctness
 - [ ] Change matches spec/task requirements
@@ -364,6 +382,9 @@ For triaging `npm audit` findings and supply-chain risk (typosquatting, compromi
 | "It's only a small addition to this file" | Small diffs still push files past a healthy size and bolt branches onto unrelated flows. Judge the resulting structure, not the diff size. |
 | "It's just a version bump" | A bump is a behavior change you didn't write. Read the changelog; semver doesn't guarantee no breakage. |
 | "I'll upgrade everything in one PR to save time" | A bulk bump that breaks the build hides which package did it. One dependency per change keeps the cause and the revert clean. |
+| "It's technically possible, so it's a real finding" | Possible isn't likely. If the trigger needs something the code already prevents, downgrade it and say why. Still worth writing down; not worth blocking on. |
+| "Better to flag it just in case" | Every finding costs the author a read, an evaluation, and a dismissal. A review padded with impossible findings gets skimmed — and the real one gets skimmed with it. |
+| "I can't check the project's limits, so I'll assume the worst" | Then say that: flag it as unverified and name what you'd need to check. Downgrading on a guess and blocking on a guess are the same error. |
 
 ## Red Flags
 
@@ -374,6 +395,9 @@ For triaging `npm audit` findings and supply-chain risk (typosquatting, compromi
 - Large PRs that are "too big to review properly" (split them)
 - No regression tests with bug fix PRs
 - Review comments without severity labels — makes it unclear what's required vs optional
+- Findings labelled on consequence alone, with no check of whether the condition can occur in this project
+- A blocking review whose findings all need conditions the code already prevents
+- A finding downgraded to Optional with no stated reason — the author can't tell whether you checked or guessed
 - Accepting "I'll fix it later" — it never happens
 - A refactor that moves code around without reducing the number of concepts a reader must hold
 - A change that grows an already-large file instead of decomposing it
@@ -388,6 +412,8 @@ After review is complete:
 
 - [ ] All Critical issues are resolved
 - [ ] All Required (no-prefix) changes are resolved or explicitly deferred with justification
+- [ ] Every Critical and Required finding names the condition that makes it fire, checked against this project's inputs and invariants
+- [ ] Findings judged remote were downgraded with their condition stated, not deleted
 - [ ] Tests pass
 - [ ] Build succeeds
 - [ ] The verification story is documented (what changed, how it was verified)

--- a/skills/doubt-driven-development/SKILL.md
+++ b/skills/doubt-driven-development/SKILL.md
@@ -172,9 +172,14 @@ The reviewer's output is data, not verdict. **You are still the orchestrator.** 
 For each finding, classify in this **precedence order** (first matching class wins):
 
 1. **Contract misread** — reviewer flagged something specifically because the CONTRACT you provided was unclear or incomplete. Fix the contract first, re-classify on the next cycle.
-2. **Valid + actionable** — real issue requiring a change to the artifact. Change it, re-loop.
-3. **Valid trade-off** — issue is real but cost of fixing exceeds cost of accepting. Document the trade-off explicitly so the user sees it.
-4. **Noise** — reviewer flagged something that's actually correct under context the reviewer didn't have. Note it, move on, and ask: would adding that context to the contract have prevented the false flag?
+2. **Valid but immaterial** — the issue is real and the reviewer understood it correctly, but its triggering condition cannot occur: the artifact or contract already prevents it, or it needs a scale or configuration this system doesn't have. Document it with the condition; do not change the artifact and do not re-loop on it.
+3. **Valid + actionable** — real issue requiring a change to the artifact. Change it, re-loop.
+4. **Valid trade-off** — issue is real but cost of fixing exceeds cost of accepting. Document the trade-off explicitly so the user sees it.
+5. **Noise** — reviewer flagged something that's actually correct under context the reviewer didn't have. Note it, move on, and ask: would adding that context to the contract have prevented the false flag?
+
+**Why `immaterial` precedes `actionable`:** an adversarial reviewer is prompted to assume you are overconfident, so it will surface true-but-impossible failure modes by design. Asking "can this fire?" before "what do I change?" is what keeps Step 5 from grinding on them. It is a distinct class from the two that look adjacent: `trade-off` is about fix *cost*, `noise` is about reviewer *context* — `immaterial` is a fully-informed, correctly-understood finding whose trigger is unreachable.
+
+**This class is not an escape hatch.** To use it you must quote the invariant — from the artifact or the contract — that prevents the trigger. If you cannot point at it, the class is `actionable`, not `immaterial`. "It probably won't happen" is a guess, and a guess is not a classification. Note that laundering findings here does not evade the doubt-theater signal in Red Flags: `immaterial` is not `actionable`, so a cycle that classifies everything this way still trips it.
 
 A fresh reviewer can be wrong because it lacks context. Don't defer just because it's "fresh."
 
@@ -201,6 +206,8 @@ If 3 cycles is "obviously insufficient" because the artifact is large: the artif
 | "If I doubt every step I'll never ship" | The skill applies to non-trivial decisions, not every keystroke. Re-read "When NOT to Use." |
 | "Two opinions are always better than one" | Not when the second has less context and produces noise. Reconcile, don't defer. |
 | "The reviewer disagreed so I was wrong" | The reviewer lacks your context — disagreement is information, not verdict. Re-read the artifact, classify, then decide. |
+| "The finding is technically true, so I have to act on it" | True and reachable are different questions. If an invariant in the artifact prevents the trigger, it's `immaterial` — quote the invariant and move on. |
+| "This one feels unlikely, I'll call it immaterial" | A feeling isn't an invariant. Point at the line that prevents it or classify it `actionable`. |
 | "Cross-model is always better" | Cross-model catches blind spots a single model shares with itself, but it adds cost and tool fragility. Offer it every interactive doubt cycle — the user decides whether the artifact warrants it. The agent's job is to surface the choice, not to gate it. |
 | "User said yes once, so I can keep invoking the CLI" | Each invocation is its own authorization. The artifact, the prompt, and the flags change between calls — re-confirm the exact command with the user before every run. |
 
@@ -219,6 +226,7 @@ If 3 cycles is "obviously insufficient" because the artifact is large: the artif
 - Falling back silently when an external CLI errors or is missing — surface the failure and let the user redirect
 - Stripping the contract from the reviewer's input
 - Passing the CLAIM to the reviewer (biases toward agreement)
+- Classifying a finding `immaterial` without quoting the invariant that prevents its trigger
 
 ## Interaction with Other Skills
 
@@ -236,7 +244,8 @@ After applying doubt-driven development:
 - [ ] At least one fresh-context review per non-trivial artifact (a failing test produced by TDD's RED step satisfies this for behavioral claims, per Interaction with Other Skills)
 - [ ] The reviewer received ARTIFACT + CONTRACT — NOT the CLAIM, NOT your reasoning
 - [ ] The reviewer's prompt was adversarial ("find issues"), not validating ("is it good")
-- [ ] Findings were classified against the artifact text (not rubber-stamped) using the precedence: contract misread / actionable / trade-off / noise
+- [ ] Findings were classified against the artifact text (not rubber-stamped) using the precedence: contract misread / immaterial / actionable / trade-off / noise
+- [ ] Every finding classified `immaterial` quotes the invariant that prevents its trigger
 - [ ] A stop condition was met (trivial findings, 3 cycles, or user override)
 - [ ] In interactive mode, cross-model was **explicitly offered** to the user (regardless of artifact stakes) and the response was acknowledged in the output
 - [ ] In non-interactive mode, cross-model was skipped and the skip was announced


### PR DESCRIPTION
Closes #436.

Drafts the likelihood axis you described, scoped to what you asked for: `code-review-and-quality`'s finding triage and the `code-reviewer` persona, echoing into `doubt-driven-development`. I left `security-auditor` and `web-performance-auditor` alone — they already carry the instinct informally, and you didn't ask for them.

Used **likelihood** rather than the `materialization` name from the issue; it's your vocabulary and it reads better in a review context.

## What changed

**`skills/code-review-and-quality/SKILL.md`** — Step 4 gains the axis after the existing prefix table:

- A three-band table (likely / plausible / remote) keyed on the triggering condition, not on a numeric score. Scores invite reverse-engineering to justify a severity already chosen; a named condition is checkable by the author.
- **Name the condition, don't assert the risk.** "Fails if two workers process one shard" is settleable against the single-consumer invariant; "could have a race" is not. Tied explicitly to the reproduce-before-you-raise bar you mentioned.
- **Downgrade, never drop**, with the reasoning stated.
- `Request changes` reserved for findings that are both consequential and plausible.

Echoed in the places the skill already keeps its discipline: one line in Honesty in Review (quantifying likelihood is the same duty as quantifying impact), one Context checklist item, three rationalizations, three red flags, two verification items.

**`agents/code-reviewer.md`** — a `### Likelihood` block under Output Format applying the same rule to Critical/Important/Suggestion, two new Rules, and the output template now asks for the triggering condition on blocking findings.

**`skills/doubt-driven-development/SKILL.md`** — a new RECONCILE class, **valid but immaterial**, inserted at position 2. Precedence matters here: if it sits after `valid + actionable` it can never match, because "real issue requiring a change" matches first. Putting it before forces "can this fire?" ahead of "what do I change?", which is what lets Step 5 terminate honestly instead of grinding.

It is genuinely a distinct class, not a rename of an existing one — `valid trade-off` is about fix *cost*, `noise` is about the reviewer *lacking context*. A fully-informed, correctly-understood finding whose trigger is unreachable had no home before and landed in `actionable`.

## Your two constraints

You flagged the risk that this becomes an excuse to wave real bugs through. Both guards are in the diff:

**Assessed, not guessed.** Every instruction says to check the condition against the project's real inputs, invariants, and configuration and to read them. The failure mode you'd expect — "I can't check, so I'll assume it's fine" — gets a rationalization row and an explicit rule: an unverifiable condition is labelled *unverified*, not downgraded. Guessing high and guessing low are the same error. In `doubt-driven-development` the bar is harder: to classify `immaterial` you must quote the invariant that prevents the trigger, or the class is `actionable`. A feeling isn't an invariant.

**Downgraded and noted, never dropped.** Stated in all three files, with the reason: the author may know the condition is reachable for reasons the diff doesn't show, so downgrading hands them the call while deleting takes it away. A filter the author can't see reads as "the reviewer found nothing". There's a red flag for a finding downgraded with no stated reason, and a verification item for it.

One interaction worth checking: the new class does **not** let an agent evade the doubt-theater signal, since `immaterial` is not `actionable` — a cycle that classifies everything this way still trips the existing red flag. I made that explicit rather than leaving it to be inferred.

## Verification

```
node scripts/validate-skills.js     # 24 skills, 0 errors, 0 warnings
node scripts/validate-commands.js   # 8 commands, 0 errors
node scripts/run-evals-test.js      # 12/12 pass
bash hooks/session-start-test.sh    # payload OK
```

**Separable hunk:** `evals/cases/code-review-and-quality.json` adds two behavioral expectations so the rule is checkable rather than just stated. Drop that hunk if you'd rather land the guidance first and let the eval follow — nothing else depends on it.

No new files, no restructuring; every addition sits in a section that already exists.
