### PR TITLE
docs: explain per-skill reference limitation (#361)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ npx skills add addyosmani/agent-skills --skill interview-me              # requi
 npx skills add addyosmani/agent-skills --skill test-driven-development   # red-green-refactor, enforced
 ```
 
+> **Installing one skill?** A per-skill `npx` install copies only
+> `skills/<name>/`, not the repo-level `references/` directory. The skill still
+> works, but paths to supplementary shared checklists are unavailable. Use a
+> whole-repo integration, clone the repository, or copy the needed checklist into
+> a `references/` directory inside the installed skill. This portability gap is
+> tracked in [#361](https://github.com/addyosmani/agent-skills/issues/361).
+
 Prefer a native integration? Pick your tool below.
 
 <details>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -140,6 +140,14 @@ The `references/` directory contains supplementary checklists:
 
 Load a reference when you need detailed patterns beyond what the skill covers.
 
+If you install one skill with `npx skills add ... --skill <name>`, only the
+selected `skills/<name>/` directory is copied. The skill still works, but paths
+to supplementary checklists in the repo-level `references/` directory are
+unavailable. Use a whole-repo integration, clone the repository, or copy the
+needed checklist into a `references/` directory inside the installed skill.
+This portability gap is tracked in
+[addyosmani/agent-skills#361](https://github.com/addyosmani/agent-skills/issues/361).
+
 ## Spec and task artifacts
 
 The `/spec` and `/plan` commands create working artifacts (`SPEC.md`, `tasks/plan.md`, `tasks/todo.md`). Treat them as **living documents** while the work is in progress:


### PR DESCRIPTION
## Summary

Documents the acknowledged per-skill install limitation from #361 at the two points where users are most likely to encounter it: the README's `--skill` examples and the getting-started guide's shared-reference section.

A per-skill `npx skills add ... --skill <name>` install copies only `skills/<name>/`. The skill itself still works, but supplementary paths into the repo-level `references/` directory are unavailable. The new guidance makes that boundary explicit and gives three accurate workarounds: use a whole-repo integration, clone the repository, or place the needed checklist in a `references/` directory inside the installed skill.

## What changed

- Added a compact portability note directly below the README's per-skill install examples.
- Added the same guidance where `docs/getting-started.md` introduces shared references.
- Clarified that this is a supplementary-link limitation, not a broken skill install.
- Linked both notes to #361 so users can follow the underlying packaging discussion.

## Scope and relationship to #366

This is documentation only. It does not rewrite skill references, duplicate shared checklists, or change the third-party installer, and it does not close #361.

#366 proposes canonical GitHub URLs as the implementation fix and also includes a README note tied to that approach. The maintainer is still weighing that URL strategy; this PR documents the current behavior and workarounds without choosing an implementation for the underlying bug.

## Verification

- `node scripts/validate-skills.js` - 24 skills, 0 errors, 0 warnings
- `node scripts/validate-commands.js` - 8 commands, 0 errors
- `node scripts/run-evals.js` - 124 checks passed, 0 errors, 0 warnings; rank-1 86%
- `git diff --check` - clean
