### PR TITLE
fix(codex): complete plugin install flow and manifest metadata

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -10,12 +10,20 @@
   "repository": "https://github.com/addyosmani/agent-skills",
   "license": "MIT",
   "skills": "./skills/",
-  "hooks": {
-    "hooks": {}
-  },
   "interface": {
     "displayName": "Agent Skills",
     "shortDescription": "Senior-engineer workflows for AI coding agents: spec, plan, build, test, review, ship.",
-    "category": "Productivity"
+    "longDescription": "Agent Skills bundles 24 production engineering workflows from Addy Osmani, covering requirements, planning, implementation, testing, review, and shipping.",
+    "developerName": "Addy Osmani",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Help me choose the right engineering workflow for this task",
+      "Plan and implement this change using the relevant Agent Skills"
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -177,9 +177,10 @@ Install as a native Codex plugin (Codex CLI v0.122+):
 
 ```bash
 codex plugin marketplace add addyosmani/agent-skills
+codex plugin add agent-skills@agent-skills
 ```
 
-Codex reads the root `skills/` directory directly through `.codex-plugin/plugin.json`. Once installed, invoke skills in chat using `@` (e.g., `@spec-driven-development`). See [docs/codex-setup.md](docs/codex-setup.md) for local installation and troubleshooting.
+The first command registers the marketplace; the second installs the plugin. Codex reads the root `skills/` directory directly through `.codex-plugin/plugin.json`. Once installed, invoke skills in chat using `@` (e.g., `@spec-driven-development`). See [docs/codex-setup.md](docs/codex-setup.md) for local installation and troubleshooting.
 
 </details>
 

--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -2,20 +2,22 @@
 
 This repository is also a [Codex plugin](https://developers.openai.com/codex/plugins/build). The same root-level `skills/` directory used by Claude Code is consumed by Codex, so no files are copied or duplicated.
 
-## Install (one command)
+## Install
 
 ```bash
 codex plugin marketplace add addyosmani/agent-skills
+codex plugin add agent-skills@agent-skills
 ```
 
 > Requires Codex CLI v0.122 or later. On older releases the command was `codex marketplace add`. See the [Codex CLI docs](https://developers.openai.com/codex/cli).
 
-Codex clones the repo into `~/.codex/plugins/agent-skills/`, registers the marketplace in `~/.codex/config.toml`, and makes the plugin available. Restart Codex if it's already running.
+The first command registers this repository as the `agent-skills` marketplace. The second command installs and enables the `agent-skills` plugin from that marketplace. Start a new Codex session after installation so the skills are discovered.
 
 Local clones work too:
 
 ```bash
 codex plugin marketplace add /path/to/your/clone
+codex plugin add agent-skills@agent-skills
 ```
 
 ## Usage
@@ -24,8 +26,8 @@ After install, invoke a skill in Codex chat with `@` (e.g. `@spec-driven-develop
 
 ## How it works
 
-- `.codex-plugin/plugin.json` — Codex plugin manifest at the repo root. Points `skills` at `./skills/` and declares an empty Codex hook config so Codex does not auto-load Claude-oriented hooks from `hooks/hooks.json`.
+- `.codex-plugin/plugin.json` — Codex plugin manifest at the repo root. Points `skills` at `./skills/` and provides the metadata required by Codex.
 - `.agents/plugins/marketplace.json` — marketplace entry declaring the repo root (`./`) as the plugin source.
 - `skills/<name>/SKILL.md` — unchanged. Codex and Claude Code share the same `name` + `description` frontmatter format, so one file serves both platforms.
 
-Slash commands in `.claude/commands/` and personas in `agents/` stay Claude Code-specific — Codex has no native equivalent for either. On Codex, invoke the underlying skill directly instead of the slash command (e.g. `@spec-driven-development` instead of `/spec`).
+Slash commands in `.claude/commands/`, personas in `agents/`, and the lifecycle hook under `hooks/` stay Claude Code-specific. On Codex, invoke the underlying skill directly instead of the slash command (e.g. `@spec-driven-development` instead of `/spec`).


### PR DESCRIPTION
## Summary

- Add the missing Codex plugin installation command after marketplace registration
- Complete the interface metadata expected by Codex's bundled plugin validator
- Remove the empty `hooks` entry rejected by that validator while leaving the Claude Code lifecycle hook unchanged

## Context

`codex plugin marketplace add addyosmani/agent-skills` registers the marketplace but does not install its plugin. The plugin remains `not installed` until users run:

```bash
codex plugin add agent-skills@agent-skills
```

The Codex CLI accepts the previous manifest, while Codex's bundled plugin validator applies a stricter manifest contract: it rejects the `hooks` field and expects additional interface metadata.

This change aligns the Codex manifest with that validator without modifying the Claude Code lifecycle hook under `hooks/`.

## Validation

- Codex bundled plugin validator passes
- Verified that marketplace registration alone reports the plugin as `not installed`
- Verified that `codex plugin add` installs and enables the plugin
- Confirmed all 24 skills are present in the installed cache
- Validated all 24 skills and 8 command mappings
- Passed 18 unit tests and 124 evaluation checks

## Follow-up

It may also be useful to add a Codex installation job to `test-plugin-install.yml` in a follow-up change so both Claude Code and Codex installation paths are covered in CI.