### PR TITLE
security: validate --behavioral skillName to prevent path traversal

### DIFF
--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -443,7 +443,16 @@ function parseGrading(raw) {
   return ok ? g : null;
 }
 
+// Skill name must be a valid kebab-case identifier — no path separators,
+// no "..", no absolute paths. Without this, --behavioral "../../x" would
+// resolve to files outside the project tree for both reads and writes.
+const VALID_SKILL_NAME = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
 function runBehavioral(skillName, dryRun) {
+  if (!skillName || !VALID_SKILL_NAME.test(skillName)) {
+    console.error(`Invalid skill name: "${skillName}" — must be kebab-case (e.g. "my-skill")`);
+    process.exit(1);
+  }
   const caseFile = path.join(CASES_DIR, `${skillName}.json`);
   if (!fs.existsSync(caseFile)) {
     console.error(`No eval case file for "${skillName}"`);


### PR DESCRIPTION
## Path Traversal via --behavioral CLI Argument (Critical)

**File:** `scripts/run-evals.js` — `runBehavioral()` (L446) + `main()` (L553)

### The Bug

The `skillName` argument from `--behavioral` has **zero validation**. It is used directly in `path.join()` for:

- **Reading:** `path.join(CASES_DIR, skillName + '.json')` — reads arbitrary `.json` files
- **Reading:** `path.join(SKILLS_DIR, skillName, 'SKILL.md')` — reads arbitrary files
- **Writing:** `path.join(RESULTS_DIR, skillName + '.eval-N')` — **writes** `.grading.json` to arbitrary paths

A value like `../../etc/passwd` traverses outside the project directory for both reads and writes.

### PoC

\\\javascript
// With skillName = '../../..'
path.resolve(path.join('/project/evals/results', '../../..') + '.eval-1')
// Resolves to: /.eval-1.grading.json ← ARBITRARY FILE WRITE outside project

path.resolve(path.join('/project/evals/cases', '../../package'))
// Resolves to: /project/package.json ← reads arbitrary .json
\\\

**Tested and confirmed** — no validation exists on `args[bIdx + 1]` before filesystem operations.

### Fix

Validate `skillName` against `/^[a-z0-9]+(-[a-z0-9]+)*$/` (kebab-case only) before any filesystem operation. This matches the existing `KEBAB_CASE` validation pattern used in `skill-lint.js`.

### Changes

Single file: `scripts/run-evals.js` (+9 lines, +0 deletions)