### PR TITLE
fix: resolveFixturePath incorrectly rejects valid path '.'

### DIFF
--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -187,7 +187,7 @@ function resolveFixturePath(root, rel) {
   const resolvedRoot = path.resolve(root);
   const resolvedPath = path.resolve(resolvedRoot, rel);
   const back = path.relative(resolvedRoot, resolvedPath);
-  if (back === '' || back === '..' || back.startsWith(`..${path.sep}`) || path.isAbsolute(back)) {
+  if (back === '..' || back.startsWith(`..${path.sep}`) || path.isAbsolute(back)) {
     throw new Error(`fixture path escapes workspace: ${rel}`);
   }
   return resolvedPath;


### PR DESCRIPTION
## Logic Bug in resolveFixturePath (High)

**File:** `scripts/run-evals.js` — `resolveFixturePath()` (L190)

### The Bug

The boundary check at line 190 includes `back === ''` as a rejection condition:

\\\javascript
if (back === '' || back === '..' || back.startsWith('..'+path.sep) || path.isAbsolute(back)) {
  throw new Error('fixture path escapes workspace: ' + rel);
}
\\\

When `rel = '.'`, the resolved path equals the root itself, and `path.relative(root, root)` returns `''`. The code rejects this as an 'escape' — but **a path that resolves to the root IS valid**, not an escape. This breaks any fixture path that needs to reference the root fixture directory.

### PoC

\\\javascript
resolveFixturePath(fixturesDir, '.');
// throws: 'fixture path escapes workspace: .'
// But '.' resolves to the root itself — that's a valid path, not an escape!
\\\

**Tested and confirmed** — `'.'` is rejected when it shouldn't be.

### Fix

Remove the `back === ''` check. The remaining checks (`back === '..'`, `back.startsWith('..' + path.sep)`, `path.isAbsolute(back)`) still correctly catch actual traversals.

### Changes

Single file: `scripts/run-evals.js` (+1 line, -1 line)