### PR TITLE
fix: clean up throwaway workspace directories after eval runs

### DIFF
--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -489,6 +489,7 @@ function runBehavioral(skillName, dryRun) {
     // edit files and run commands in the throwaway workspace; without it,
     // headless denials would force the exact narrate-instead-of-perform
     // failure mode that trace grading exists to catch.
+    try {
     const trace = execFileSync(
       'claude',
       ['-p', '--verbose', '--output-format', 'stream-json',
@@ -527,6 +528,11 @@ function runBehavioral(skillName, dryRun) {
     fs.writeFileSync(`${base}.grading.json`, JSON.stringify(grading, null, 2) + '\n');
     console.log(`eval ${ev.id}: ${grading.summary.passed}/${grading.summary.total} expectations passed -> ${path.relative(ROOT, base)}.grading.json`);
     if (grading.summary.passed < grading.summary.total) failures++;
+    } finally {
+      // Clean up throwaway workspace to prevent leaking fixture data
+      // into world-readable temp directories.
+      try { fs.rmSync(workspace, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
   }
   process.exit(failures ? 1 : 0);
 }


### PR DESCRIPTION
## Temp Workspace Data Leak (High)

**File:** `scripts/run-evals.js` — `runBehavioral()` (L482-L531)

### The Bug

`materializeWorkspace()` creates directories in `os.tmpdir()` (L391) but `runBehavioral()` **never cleans them up** — not on success, not on failure.

If `execFileSync` throws (timeout, signal, OOM), the workspace with all fixture data persists in `/tmp` indefinitely. On most Linux systems, `/tmp` is world-readable, so fixture data (which may contain sensitive test credentials, API keys in config files, etc.) leaks to other users on the system.

The test file `run-evals-test.js` properly uses `try/finally` cleanup at line 234, proving the pattern was known:

\\\javascript
// run-evals-test.js (line 234) — cleanup exists in tests but not production
} finally {
  fs.rmSync(workspace, { recursive: true, force: true });
}
\\\

### Fix

Wrap the eval execution loop body in `try/finally` with best-effort `fs.rmSync` cleanup, matching the pattern already used in the test file.

### Changes

Single file: `scripts/run-evals.js` (+6 lines, +0 deletions)