### PR TITLE
ci: bump actions to Node 24 runtimes and drop EOL Node 20

### DIFF
--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -13,9 +13,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Validate all skills
         run: node scripts/validate-skills.js
@@ -30,12 +30,12 @@ jobs:
     name: Validate command parity and description sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Validate commands across all tool directories
         run: node scripts/validate-commands.js


### PR DESCRIPTION
## Problem

Every CI run currently logs deprecation annotations: `actions/checkout@v4` and `actions/setup-node@v4` target the Node 20 runner runtime, which GitHub is force-running on Node 24 ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The workflow also mixes majors — three jobs already pin `checkout@v6` while `validate-commands` is still on `@v4` — and `node-version: '20'` pins a Node line that reached end-of-life on 2026-04-30.

## Changes (one file, 5 lines)

- `actions/checkout@v4` → `@v6` in `validate-commands`, matching the major the other three jobs already use
- `actions/setup-node@v4` → `@v6` (Node 24 runtime) in both jobs that use it
- `node-version: '20'` → `'24'` (active LTS, supported until April 2028)

The setup-node v5+ automatic package-manager caching does not apply here — the repo has no `package.json` at the root — so the bump changes no behavior beyond the runtime.

## Verification

All five node steps the workflow runs were executed locally on Node v24.13.0 against this branch:

- `validate-skills.js` — 24 skills, 0 errors
- `node --test run-evals-test.js` — 12/12 pass
- `run-evals.js --min-rank1 80` — 124 checks, rank-1 rate 86%, PASSED
- `validate-commands.js` — 8 commands, 0 errors
- `node --test validate-commands-test.js` — 6/6 pass

No open PR or issue currently touches these pins (searched for `setup-node`, `node-version`, `checkout@v6`, Node 20 deprecation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)