### PR TITLE
fix(docs): reframe Claude Code orchestration constraints as project convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ The only multi-persona orchestration pattern this repo endorses is **parallel fa
 
 See [docs/agents.md](docs/agents.md) for the decision matrix and [references/orchestration-patterns.md](references/orchestration-patterns.md) for the full pattern catalog.
 
-**Claude Code interop:** the personas in `agents/` work as Claude Code subagents (auto-discovered from this plugin's `agents/` directory) and as Agent Teams teammates (referenced by name when spawning). Two platform constraints align with our rules: subagents cannot spawn other subagents, and teams cannot nest. Plugin agents silently ignore the `hooks`, `mcpServers`, and `permissionMode` frontmatter fields.
+**Claude Code interop:** the personas in `agents/` work as Claude Code subagents (auto-discovered from this plugin's `agents/` directory) and as Agent Teams teammates (referenced by name when spawning). Our convention mirrors what the platform allows — as of Claude Code v2.1.172 subagents can nest up to 5 levels ([changelog](https://code.claude.com/docs/en/changelog)) — but this repo deliberately enforces stricter rules: personas do not invoke personas, and teams do not nest. We keep the convention as a project rule rather than relying on the platform to block it. Plugin agents silently ignore the `hooks`, `mcpServers`, and `permissionMode` frontmatter fields.
 
 ## Creating a New Skill
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -99,7 +99,7 @@ Why this fails:
 ## Rules for personas
 
 1. A persona is a single role with a single output format. If you find yourself adding a second role, create a second persona.
-2. **Personas do not invoke other personas.** Composition is the job of slash commands or the user. On Claude Code this is also a hard platform constraint — *"subagents cannot spawn other subagents"* — so the rule is enforced for you.
+2. **Personas do not invoke other personas.** Composition is the job of slash commands or the user. This is a deliberate project convention. Claude Code v2.1.172 lifted the prior subagent-nesting cap ([changelog](https://code.claude.com/docs/en/changelog)), so subagents can now spawn their own subagents up to 5 levels — the platform no longer enforces this for you. The repo keeps the rule anyway so composition stays in the hands of slash commands or the user, not individual personas.
 3. A persona may invoke skills (the *how*).
 4. Every persona file ends with a "Composition" block stating where it fits.
 

--- a/references/orchestration-patterns.md
+++ b/references/orchestration-patterns.md
@@ -140,12 +140,12 @@ One subtlety: the `skills` and `mcpServers` frontmatter fields in a persona are 
 
 ### Platform-enforced rules
 
-Two rules in this catalog aren't just convention — Claude Code enforces them:
+One rule in this catalog is still enforced by Claude Code; the other is a deliberate project convention:
 
-- **"Subagents cannot spawn other subagents"** (verbatim from the docs). Anti-pattern B (persona-calls-persona) and Anti-pattern D (deep persona trees) cannot exist on Claude Code by construction.
-- **"No nested teams"** — teammates cannot spawn their own teams. Same anti-patterns blocked at the team level.
+- **"No nested teams"** — teammates cannot spawn their own teams. Same anti-patterns blocked at the team level. ([Agent Teams docs](https://code.claude.com/docs/en/agent-teams))
+- **"Personas do not invoke personas"** is now a **project convention**, not a platform constraint. As of Claude Code v2.1.172, subagents can spawn their own subagents up to 5 levels ([sub-agents docs](https://code.claude.com/docs/en/sub-agents), [changelog](https://code.claude.com/docs/en/changelog)), so Anti-pattern B (persona-calls-persona) and Anti-pattern D (deep persona trees) *could* exist on Claude Code. This repo bans them anyway — composition is the job of slash commands or the user, not individual personas.
 
-This means you can adopt the patterns in this catalog without worrying about contributors accidentally building the anti-patterns. They'll just fail to load.
+The platform-enforced rule means contributors can't accidentally build nested teams. The convention rule means reviewers must catch persona-calls-persona and deep persona trees in code review, since the platform won't block them anymore.
 
 ### Built-in subagents to know about
 
@@ -250,15 +250,9 @@ The lead spawns three teammates referencing the existing persona names. The pers
 
 You can interrupt at any teammate by cycling with `Shift+Down` and typing — useful for redirecting an investigator who's gone down a wrong path.
 
-### When to clean up
+### Wrapping up
 
-When the investigation lands on a root cause, tell the lead:
-
-```
-Clean up the team
-```
-
-Always cleanup through the lead, not a teammate (per the docs: teammates lack full team context for cleanup).
+When the investigation lands on a root cause, the lead ends the session. As of Claude Code v2.1.178 the explicit `TeamCreate`/`TeamDelete` tooling has been removed ([changelog](https://code.claude.com/docs/en/changelog)), so there is no separate "clean up the team" step — close the team session through the lead when you're done.
 
 ### Cost expectation
 


### PR DESCRIPTION
## Summary

Fixes #377 (reported by @federicobartoli).

Claude Code's platform behavior has moved on since these docs were written, and the repo still describes the old behavior as a hard platform constraint. This PR reframes the repo rules as **deliberate project convention** rather than platform limitations, and keeps the conventions themselves intact.

## What changed

**1. Subagent nesting is no longer a platform constraint (v2.1.172)**

As of Claude Code v2.1.172, subagents can spawn their own subagents up to 5 levels ([sub-agents docs](https://code.claude.com/docs/en/sub-agents), [changelog](https://code.claude.com/docs/en/changelog)). The repo convention — *personas do not invoke personas* — stays, but the docs no longer claim the platform enforces it.

- `AGENTS.md` — the **Claude Code interop** note now says the repo *deliberately enforces stricter rules* rather than relying on the platform to block nesting, and cites v2.1.172.
- `docs/agents.md` — **Rules for personas**, rule 2 now cites v2.1.172 and frames the rule as a project convention, removing the *"subagents cannot spawn other subagents"* / *"enforced for you"* language.
- `references/orchestration-patterns.md` — **Platform-enforced rules** section is rewritten: only *"no nested teams"* remains platform-enforced; *"personas do not invoke personas"* is called out as a project convention, with anti-pattern B (persona-calls-persona) and anti-pattern D (deep persona trees) reframed as *could exist on Claude Code* but banned by the repo. Reviewers must now catch these in code review since the platform won't block them.

**2. Agent Teams cleanup step softened (v2.1.178)**

As of Claude Code v2.1.178, `TeamCreate`/`TeamDelete` were removed ([Agent Teams docs](https://code.claude.com/docs/en/agent-teams), [changelog](https://code.claude.com/docs/en/changelog)). The `Clean up the team` code-block instruction in the Agent Teams worked example is replaced with a short **Wrapping up** note telling the lead to close the session, with no separate cleanup step.

## What did NOT change

- The repo orchestration convention itself: **personas do not invoke personas; composition is the job of slash commands or the user.**
- The *"no nested teams"* rule, which is still platform-enforced per current docs.
- Doc structure — edits are minimal and localized to the affected sentences/sections.

## Files modified

- `AGENTS.md`
- `docs/agents.md`
- `references/orchestration-patterns.md`

Closes #377