### PR TITLE
fix(hooks): security hardening for opt-in hooks (#295)

### DIFF
--- a/hooks/SDD-CACHE.md
+++ b/hooks/SDD-CACHE.md
@@ -46,7 +46,11 @@ This hook caches fetched content on disk, but **revalidates with the origin serv
 
    `${CLAUDE_PROJECT_DIR}` resolves to the directory you launched Claude Code from. The snippet above works when the hooks live inside the same project. If you installed `agent-skills` elsewhere (e.g. as a shared plugin under `~/agent-skills`), replace `${CLAUDE_PROJECT_DIR}/hooks/...` with the absolute path to each script.
 
-2. Make sure `.claude/sdd-cache/` is in your `.gitignore` (already included in this repo).
+2. Make sure `.claude/sdd-cache/` is in your `.gitignore` (already included in this repo). If you use the cache in a different project, add this line to your `.gitignore`:
+
+```
+.claude/sdd-cache/
+```
 
 3. Use `/source-driven-development` (or the skill) as usual. No changes to the skill or the agent's workflow — the cache is transparent.
 
@@ -68,6 +72,9 @@ One cache entry per URL, stored as JSON in `.claude/sdd-cache/<sha>.json`:
 **Freshness rules:**
 
 - Entry is served only if the origin confirms `304 Not Modified`.
+- **TTL cap:** entries older than `SDD_CACHE_MAX_AGE` seconds (default `86400` = 24h) are bypassed and removed even on `304`, preventing a compromised origin from serving stale content indefinitely. Override with the `SDD_CACHE_MAX_AGE` env var.
+- **SSRF protection:** only `https://` URLs are accepted; internal/loopback/metadata hosts (e.g. `169.254.169.254`, `localhost`, `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `::1`, `fc00::/7`) are rejected before any curl call. Redirects are not followed (`-L` removed).
+- **Cache permissions:** the cache directory is `chmod 700` and cache files are written with `umask 077` so only the owner can read them.
 - Entries without an `ETag` or `Last-Modified` header are never cached — without a validator, the hook cannot verify freshness later, and caching would mean trusting memory.
 - Cache key is `sha256(url)`. The same URL asked with a different prompt hits the same entry; the cached body reflects the prompt used on the first fetch, and that prompt is shown alongside the hit so the agent can decide whether to re-use or re-fetch manually.
 

--- a/hooks/sdd-cache-post.sh
+++ b/hooks/sdd-cache-post.sh
@@ -26,10 +26,19 @@ is_url_safe() {
   # Extract host (strip scheme, path, port)
   local host="${url#https://}"
   host="${host%%/*}"
-  host="${host%%:*}"
-  # Reject common internal/loopback/metadata hosts
+  # Handle bracketed IPv6 literal: https://[2001:db8::1]:443/path
+  case "$host" in \[*)
+    host="${host#[}"
+    host="${host%%]*}"
+    ;; *)
+    host="${host%%:*}"
+    ;;
+  esac
+  # Reject common internal/loopback/metadata hosts. IPv6 literals are
+  # rejected wholesale (curl would need -g handling we don't want to trust);
+  # any bracket form reaching here has been de-bracketed to its raw address.
   case "$host" in
-    localhost|127.*|0.0.0.0|169.254.169.254|10.*|172.1[6-9].*|172.2[0-9].*|172.3[01].*|192.168.*|::1|[fF][cCdD]??:*) return 1 ;;
+    localhost|127.*|0.0.0.0|169.254.169.254|10.*|172.1[6-9].*|172.2[0-9].*|172.3[01].*|192.168.*|::1|[fF][cCdD]??:*|*:*) return 1 ;;
   esac
   return 0
 }

--- a/hooks/sdd-cache-post.sh
+++ b/hooks/sdd-cache-post.sh
@@ -17,6 +17,23 @@ command -v jq   >/dev/null 2>&1 || exit 0
 command -v curl >/dev/null 2>&1 || exit 0
 command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 || exit 0
 
+# is_url_safe: reject non-https URLs and internal/loopback/metadata hosts to
+# prevent SSRF. Returns 0 (safe) or 1 (unsafe). Must be called before any curl.
+is_url_safe() {
+  local url="$1"
+  # Require https:// scheme
+  case "$url" in https://*) ;; *) return 1 ;; esac
+  # Extract host (strip scheme, path, port)
+  local host="${url#https://}"
+  host="${host%%/*}"
+  host="${host%%:*}"
+  # Reject common internal/loopback/metadata hosts
+  case "$host" in
+    localhost|127.*|0.0.0.0|169.254.169.254|10.*|172.1[6-9].*|172.2[0-9].*|172.3[01].*|192.168.*|::1|[fF][cCdD]??:*) return 1 ;;
+  esac
+  return 0
+}
+
 if [ -t 0 ]; then INPUT="{}"; else INPUT=$(cat); fi
 
 # Debug logging: active when SDD_CACHE_DEBUG=1 is set, or when a sentinel
@@ -32,6 +49,7 @@ dbg "fired, input=$(printf '%s' "$INPUT" | head -c 400)"
 URL=$(printf '%s'    "$INPUT" | jq -r '.tool_input.url    // empty' 2>/dev/null || true)
 PROMPT=$(printf '%s' "$INPUT" | jq -r '.tool_input.prompt // empty' 2>/dev/null || true)
 if [ -z "$URL" ]; then dbg "no url in tool_input, exit"; exit 0; fi
+if ! is_url_safe "$URL"; then dbg "url rejected by is_url_safe, exit"; exit 0; fi
 dbg "url=$URL prompt=$(printf '%s' "$PROMPT" | head -c 80)"
 
 # WebFetch tool_response shape (Claude Code as of 2026-04): an object with
@@ -74,12 +92,13 @@ hash_key() {
 
 CACHE_DIR="${CLAUDE_PROJECT_DIR:-$PWD}/.claude/sdd-cache"
 mkdir -p "$CACHE_DIR"
+chmod 700 "$CACHE_DIR"
 CACHE_FILE="$CACHE_DIR/$(hash_key "$URL").json"
 
-# Capture validators from the origin. Follow redirects so they match the
-# URL the agent actually talked to. Strip CR so awk's paragraph mode
-# recognises blank separators between response blocks on a redirect chain.
-HEAD_OUT=$(curl -sI -L --max-time 5 "$URL" 2>/dev/null | tr -d '\r' || true)
+# Capture validators from the origin. Strip CR so awk's paragraph mode
+# recognises blank separators between response blocks. Redirects are not
+# followed (-L removed) to prevent SSRF via redirect to internal hosts.
+HEAD_OUT=$(curl -sI --max-time 5 "$URL" 2>/dev/null | tr -d '\r' || true)
 
 # Take only the final response's headers (last paragraph) to avoid picking
 # up validators from intermediate 301/302 hops.
@@ -113,6 +132,9 @@ if [ -z "$ETAG" ] && [ -z "$LAST_MOD" ]; then
 fi
 
 NOW=$(date +%s)
+
+# Restrictive umask so cache files are only readable by the owner.
+umask 077
 
 TMP="${CACHE_FILE}.$$.tmp"
 if jq -n \

--- a/hooks/sdd-cache-pre.sh
+++ b/hooks/sdd-cache-pre.sh
@@ -31,10 +31,19 @@ is_url_safe() {
   # Extract host (strip scheme, path, port)
   local host="${url#https://}"
   host="${host%%/*}"
-  host="${host%%:*}"
-  # Reject common internal/loopback/metadata hosts
+  # Handle bracketed IPv6 literal: https://[2001:db8::1]:443/path
+  case "$host" in \[*)
+    host="${host#[}"
+    host="${host%%]*}"
+    ;; *)
+    host="${host%%:*}"
+    ;;
+  esac
+  # Reject common internal/loopback/metadata hosts. IPv6 literals are
+  # rejected wholesale (curl would need -g handling we don't want to trust);
+  # any bracket form reaching here has been de-bracketed to its raw address.
   case "$host" in
-    localhost|127.*|0.0.0.0|169.254.169.254|10.*|172.1[6-9].*|172.2[0-9].*|172.3[01].*|192.168.*|::1|[fF][cCdD]??:*) return 1 ;;
+    localhost|127.*|0.0.0.0|169.254.169.254|10.*|172.1[6-9].*|172.2[0-9].*|172.3[01].*|192.168.*|::1|[fF][cCdD]??:*|*:*) return 1 ;;
   esac
   return 0
 }

--- a/hooks/sdd-cache-pre.sh
+++ b/hooks/sdd-cache-pre.sh
@@ -22,6 +22,23 @@ command -v jq   >/dev/null 2>&1 || exit 0
 command -v curl >/dev/null 2>&1 || exit 0
 command -v shasum >/dev/null 2>&1 || command -v sha256sum >/dev/null 2>&1 || exit 0
 
+# is_url_safe: reject non-https URLs and internal/loopback/metadata hosts to
+# prevent SSRF. Returns 0 (safe) or 1 (unsafe). Must be called before any curl.
+is_url_safe() {
+  local url="$1"
+  # Require https:// scheme
+  case "$url" in https://*) ;; *) return 1 ;; esac
+  # Extract host (strip scheme, path, port)
+  local host="${url#https://}"
+  host="${host%%/*}"
+  host="${host%%:*}"
+  # Reject common internal/loopback/metadata hosts
+  case "$host" in
+    localhost|127.*|0.0.0.0|169.254.169.254|10.*|172.1[6-9].*|172.2[0-9].*|172.3[01].*|192.168.*|::1|[fF][cCdD]??:*) return 1 ;;
+  esac
+  return 0
+}
+
 if [ -t 0 ]; then INPUT="{}"; else INPUT=$(cat); fi
 
 # Debug logging: active when SDD_CACHE_DEBUG=1 is set, or when a sentinel
@@ -36,6 +53,7 @@ dbg "fired"
 
 URL=$(printf '%s' "$INPUT" | jq -r '.tool_input.url // empty' 2>/dev/null || true)
 if [ -z "$URL" ]; then dbg "no url in tool_input, exit"; exit 0; fi
+if ! is_url_safe "$URL"; then dbg "url rejected by is_url_safe, exit"; exit 0; fi
 dbg "url=$URL"
 
 # Cache key is sha256(URL), truncated to 128 bits.
@@ -69,13 +87,25 @@ HEADERS=()
 [ -n "$LAST_MOD" ] && HEADERS+=(-H "If-Modified-Since: $LAST_MOD")
 
 STATUS=$(curl -sI -o /dev/null -w "%{http_code}" \
-  --max-time 5 -L \
+  --max-time 5 \
   "${HEADERS[@]}" \
   "$URL" 2>/dev/null || echo "000")
 dbg "revalidation HEAD status=$STATUS"
 
 if [ "$STATUS" != "304" ]; then
   dbg "not 304, letting WebFetch proceed"
+  exit 0
+fi
+
+# TTL cap: even on 304, reject entries older than SDD_CACHE_MAX_AGE seconds
+# (default 86400 = 24h). Prevents a compromised origin from serving stale
+# 304s indefinitely (cache poisoning).
+SDD_CACHE_MAX_AGE="${SDD_CACHE_MAX_AGE:-86400}"
+NOW=$(date +%s)
+AGE=$((NOW - FETCHED_AT))
+if [ "$AGE" -gt "$SDD_CACHE_MAX_AGE" ]; then
+  dbg "cache entry age ${AGE}s exceeds max-age ${SDD_CACHE_MAX_AGE}s, bypass"
+  rm -f "$CACHE_FILE"
   exit 0
 fi
 

--- a/hooks/simplify-ignore.sh
+++ b/hooks/simplify-ignore.sh
@@ -9,12 +9,17 @@
 # The file on disk ALWAYS has placeholders while the session is active.
 # The real content (with model's changes applied) lives in the backup.
 #
-# Dependencies: jq, shasum or sha1sum (auto-detected)
+# Dependencies: jq, shasum or sha1sum (auto-detected), perl (for trailing
+# newline normalisation — checked up front so a missing binary doesn't abort
+# mid-rewrite under set -e).
 
 set -euo pipefail
 
 if ! command -v jq >/dev/null 2>&1; then
   printf '%s\n' "error: missing jq" >&2; exit 1
+fi
+if ! command -v perl >/dev/null 2>&1; then
+  printf '%s\n' "error: missing perl" >&2; exit 1
 fi
 
 CACHE="${CLAUDE_PROJECT_DIR:-.}/.claude/.simplify-ignore-cache"
@@ -33,6 +38,13 @@ FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev
 }
 if [ -n "$parse_error" ]; then
   printf 'Warning: %s (input: %.120s)\n' "$parse_error" "$INPUT" >&2
+fi
+
+# Symlink safety: reject symlinked file paths before any read/write processing.
+# This prevents symlink-overwrite attacks where an untrusted file_path points
+# at a symlink that redirects to a sensitive file.
+if [ -n "$FILE_PATH" ] && [ -L "$FILE_PATH" ]; then
+  exit 0
 fi
 
 hash_cmd() {
@@ -135,7 +147,7 @@ ${line}"
   # Preserve trailing newline status of source
   if [ -s "$dest" ] && [ -s "$src" ] && [ -n "$(tail -c 1 "$src")" ]; then
     perl -pe 'chomp if eof' "$dest" > "${dest}.nnl" && \
-      cat "${dest}.nnl" > "$dest" && rm -f "${dest}.nnl"
+      mv -f "${dest}.nnl" "$dest"
   fi
 
   [ $count -gt 0 ] && return 0 || return 1
@@ -150,8 +162,18 @@ if [ -z "$TOOL_NAME" ]; then
     pathfile="$CACHE/${fid}.path"
     [ -f "$pathfile" ] || { rm -f "$bak"; continue; }
     orig=$(cat "$pathfile")
+    if [ -L "$orig" ]; then
+      # Symlink safety: skip restoring to a symlink target
+      printf 'Warning: %s is a symlink, skipping restore\n' "$orig" >&2
+      rm -f "$bak" "$pathfile" "$CACHE/${fid}".block.* "$CACHE/${fid}".reason.* "$CACHE/${fid}".prefix.* "$CACHE/${fid}".suffix.*
+      rmdir "$CACHE/${fid}.lock" 2>/dev/null
+      continue
+    fi
     if [ -f "$orig" ]; then
-      cat "$bak" > "$orig"
+      # Atomic restore: write to temp, then mv into place
+      RESTORE_TMP="$CACHE/${fid}.$$.restore"
+      cat "$bak" > "$RESTORE_TMP"
+      mv -f "$RESTORE_TMP" "$orig"
       rm -f "$bak" "$pathfile" "$CACHE/${fid}".block.* "$CACHE/${fid}".reason.* "$CACHE/${fid}".prefix.* "$CACHE/${fid}".suffix.*
       rmdir "$CACHE/${fid}.lock" 2>/dev/null
     else
@@ -202,11 +224,12 @@ if [ "$TOOL_NAME" = "Read" ]; then
   cp -p "$FILE_PATH" "$CACHE/${ID}.bak" 2>/dev/null || cp "$FILE_PATH" "$CACHE/${ID}.bak"
   printf '%s' "$FILE_PATH" > "$CACHE/${ID}.path"
 
-  # Filter in-place (cat > preserves inode and permissions)
+  # Re-verify target is a regular file (not a symlink) before write-back.
+  # Filter in-place: write to temp, then atomic mv (preserves inode on same fs).
   FILTERED="$CACHE/${ID}.$$.tmp"
   rm -f "$FILTERED"
   if filter_file "$FILE_PATH" "$FILTERED" "$ID"; then
-    cat "$FILTERED" > "$FILE_PATH"
+    [ -f "$FILE_PATH" ] && [ ! -L "$FILE_PATH" ] && mv -f "$FILTERED" "$FILE_PATH"
     rm -f "$FILTERED"
   else
     rm -f "$FILTERED" "$CACHE/${ID}.bak" "$CACHE/${ID}.path"
@@ -267,7 +290,7 @@ if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
   # Preserve trailing newline status
   if [ -s "$EXPANDED" ] && [ -s "$FILE_PATH" ] && [ -n "$(tail -c 1 "$FILE_PATH")" ]; then
     perl -pe 'chomp if eof' "$EXPANDED" > "${EXPANDED}.nnl" && \
-      cat "${EXPANDED}.nnl" > "$EXPANDED" && rm -f "${EXPANDED}.nnl"
+      mv -f "${EXPANDED}.nnl" "$EXPANDED"
   fi
   # Warn if model deleted a protected block entirely
   for bf in "$CACHE/${ID}".block.*; do
@@ -283,8 +306,8 @@ if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
       fi
     fi
   done
-  # Preserve inode and permissions
-  cat "$EXPANDED" > "$FILE_PATH"
+  # Re-verify target is a regular file (not a symlink), then atomic swap.
+  [ -f "$FILE_PATH" ] && [ ! -L "$FILE_PATH" ] && mv -f "$EXPANDED" "$FILE_PATH"
   rm -f "$EXPANDED"
 
   # Save expanded version as new backup (this is the "real" file with model's changes)
@@ -294,7 +317,7 @@ if [ "$TOOL_NAME" = "Edit" ] || [ "$TOOL_NAME" = "Write" ]; then
   FILTERED="$CACHE/${ID}.$$.tmp"
   rm -f "$FILTERED"
   if filter_file "$FILE_PATH" "$FILTERED" "$ID"; then
-    cat "$FILTERED" > "$FILE_PATH"
+    [ -f "$FILE_PATH" ] && [ ! -L "$FILE_PATH" ] && mv -f "$FILTERED" "$FILE_PATH"
     rm -f "$FILTERED"
   fi
 


### PR DESCRIPTION
## Security hardening for opt-in hooks

Fixes #295.

### Findings and fixes

**1. SSRF via unvalidated curl** (`hooks/sdd-cache-pre.sh:71-74`, `hooks/sdd-cache-post.sh:82`)

Both hooks used `curl -L` with no scheme/host allowlist, following redirects, on a URL from `.tool_input.url`.

**Fix:**
- Added `is_url_safe()` helper function that requires `https://` scheme and rejects internal/loopback/metadata hosts (`169.254.169.254`, `localhost`, `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `::1`, `fc00::/7`).
- Applied `is_url_safe()` in both `sdd-cache-pre.sh` and `sdd-cache-post.sh` before any curl call.
- Dropped `-L` (redirect following) from both curl invocations.

**2. Cache poisoning via no TTL cap** (`hooks/sdd-cache-post.sh` / `hooks/sdd-cache-pre.sh`)

No max-age enforcement — a compromised origin could serve stale 304s indefinitely.

**Fix:**
- Added TTL cap in `sdd-cache-pre.sh`: entries older than `SDD_CACHE_MAX_AGE` seconds (default `86400` = 24h, configurable via env var) are bypassed and removed even on HTTP 304.

**3. Tamperable cache files** (`hooks/sdd-cache-post.sh`, `hooks/SDD-CACHE.md`)

Cache files written with default umask and predictable filenames.

**Fix:**
- `chmod 700` the cache directory in `sdd-cache-post.sh`.
- `umask 077` before writing cache files in `sdd-cache-post.sh`.
- Added `.gitignore` guidance for `.claude/sdd-cache/` in `SDD-CACHE.md`.

**4. Symlink overwrite** (`hooks/simplify-ignore.sh`)

`cat > "$target"` on untrusted `file_path` with no symlink check — a symlink could redirect writes to a sensitive file.

**Fix:**
- Added `[ -L "$FILE_PATH" ] && exit 0` right after `FILE_PATH` is parsed, before any Read/Write/Edit processing.
- Re-verified target is a regular non-symlink file (`[ -f "$FILE_PATH" ] && [ ! -L "$FILE_PATH" ]`) before every write-back.
- Added symlink check on `$orig` in the Stop handler restore path (skip with warning if symlinked).
- Changed all write-backs from `cat > target` to `mv -f temp target` (atomic swap).

**5. Non-atomic rewrite under `set -e`** (`hooks/simplify-ignore.sh`)

Perl-dependent operations could abort mid-rewrite, leaving files in an inconsistent state.

**Fix:**
- Declared `perl` as a dependency and added up-front check (exits with error if missing).
- Replaced all non-atomic `cat > target` writes with `mv -f temp target` (atomic).
- Applies to: Read hook filter, Edit/Write expand, Edit/Write re-filter, Stop handler restore, and trailing-newline normalization in `filter_file` and the expand path.

### Tests

- `bash hooks/simplify-ignore-test.sh` — 21/21 pass (before and after)
- `bash hooks/session-start-test.sh` — pass (before and after)
- `bash -n` syntax check — all 3 shell scripts pass

### Notes

- Changes are focused and minimal; these are opt-in hooks, not default behavior.
- Existing function signatures preserved — `simplify-ignore-test.sh` function extraction unaffected.
- No changes to `session-start.sh` or the default hooks registration.