### PR TITLE
feat(plugin): conform root manifest to Agent Plugins 1.0.0

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,11 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agent-skills",
-  "version": "1.0.0",
-  "description": "Production-grade engineering skills for AI coding agents."
+  "version": "0.6.6",
+  "description": "Production-grade engineering skills for AI coding agents covering the full software development lifecycle from spec to ship.",
+  "author": { "name": "Addy Osmani", "url": "https://github.com/addyosmani" },
+  "homepage": "https://skills.addy.ie",
+  "repository": "https://github.com/addyosmani/agent-skills",
+  "license": "MIT",
+  "keywords": ["skills", "engineering", "spec", "tdd", "review", "ship"]
 }


### PR DESCRIPTION
Adds support for [Agent Plugins](https://agent-plugins.org), the vendor-neutral spec for portable skills. We're already most of the way there: our `skills/<name>/SKILL.md` layout is exactly the convention it standardizes.

The only thing missing was a conformant root manifest. This adds the required `$schema` field, fills in author/homepage/repo/license/keywords, and corrects the stale `1.0.0` version to `0.6.6`.

**Verified:** manifest validates against the 1.0.0 schema, all 24 skills already match the `skills/` convention, and `claude plugin validate` passes. No `mcp.json` since we ship no MCP servers. The `.claude-plugin` and `.codex-plugin` manifests are untouched, so current installs keep working.

**Out of scope:** our personas, commands, and hooks sit outside the Agent Plugins v1 format (skills and MCP only), so they stay client-specific. Expected, and nothing breaks.

Also fixes the stale version on this manifest, a step toward #440.

@nucliweb @federicobartoli tagging you both for a look. One thing worth a second eye: this manifest is also read by Codex, so I'd want to confirm the added `$schema` and version bump don't upset a Codex install before merge.
