### PR TITLE
ci: guard spec/plan/todo artifact paths against silent drift

### DIFF
--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -43,6 +43,12 @@ jobs:
       - name: Test command validator
         run: node --test scripts/validate-commands-test.js
 
+      - name: Validate spec/plan/todo artifact paths
+        run: node scripts/validate-artifact-paths.js
+
+      - name: Test artifact-path validator
+        run: node --test scripts/validate-artifact-paths-test.js
+
   validate:
     name: Validate plugin structure
     needs: [validate-skills, validate-commands]

--- a/scripts/validate-artifact-paths-test.js
+++ b/scripts/validate-artifact-paths-test.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { afterEach, test } = require('node:test');
+
+const VALIDATOR = path.join(__dirname, 'validate-artifact-paths.js');
+const sandboxes = [];
+
+function makeSandbox() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-skills-validate-artifact-paths-test-'));
+  const scriptsDir = path.join(root, 'scripts');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.copyFileSync(VALIDATOR, path.join(scriptsDir, 'validate-artifact-paths.js'));
+  sandboxes.push(root);
+  return root;
+}
+
+function writeFile(root, relativePath, content) {
+  const file = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [path.join(root, 'scripts', 'validate-artifact-paths.js')], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+}
+
+afterEach(() => {
+  for (const root of sandboxes.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('passes when producers and consumers use the canonical artifact paths', () => {
+  const root = makeSandbox();
+  writeFile(root, '.claude/commands/spec.md', 'Save the spec as `SPEC.md` in the project root.\n');
+  writeFile(root, '.claude/commands/plan.md', 'Save the plan to `tasks/plan.md` and task list to `tasks/todo.md`.\n');
+  writeFile(root, '.claude/commands/build.md', 'Look for a spec at `SPEC.md`, `docs/SPEC.md`, or under `spec/`. Require `tasks/plan.md`.\n');
+  writeFile(root, 'skills/spec-driven-development/SKILL.md', 'Save the plan to `tasks/plan.md` and the task list to `tasks/todo.md`.\n');
+  writeFile(root, 'skills/planning-and-task-breakdown/SKILL.md', 'Save to `tasks/plan.md` and `tasks/todo.md`.\n');
+
+  const result = run(root);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /5 files checked — 0 error\(s\) — PASSED/);
+});
+
+test('fails when a producer drifts to an unapproved artifact path (the #93 regression)', () => {
+  const root = makeSandbox();
+  // Only the producers are changed to the per-feature layout; consumers stay on the old paths.
+  writeFile(root, '.claude/commands/spec.md', 'Save the spec to `docs/features/[feature-name]/spec.md`.\n');
+  writeFile(root, '.claude/commands/plan.md', 'Save the plan to `docs/features/[feature-name]/plan.md`.\n');
+  writeFile(root, '.claude/commands/build.md', 'Require a spec at `SPEC.md` and a plan at `tasks/plan.md`.\n');
+
+  const result = run(root);
+
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stdout, /docs\/features\/\[feature-name\]\/spec\.md/);
+  assert.match(result.stdout, /docs\/features\/\[feature-name\]\/plan\.md/);
+  assert.match(result.stdout, /error\(s\) — FAILED/);
+});
+
+test('reports the offending file and line number', () => {
+  const root = makeSandbox();
+  writeFile(root, '.claude/commands/plan.md', 'Intro line.\nSave the plan to `plan.md` in the root.\n');
+
+  const result = run(root);
+
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stdout, /\.claude\/commands\/plan\.md/);
+  assert.match(result.stdout, /L2:/);
+});
+
+test('accepts the docs/SPEC.md alternate spec location', () => {
+  const root = makeSandbox();
+  writeFile(root, '.claude/commands/build.md', 'Look for the spec at `docs/SPEC.md`.\n');
+
+  const result = run(root);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /1 files checked — 0 error\(s\) — PASSED/);
+});
+
+test('ignores non-artifact markdown references (no false positives)', () => {
+  const root = makeSandbox();
+  writeFile(
+    root,
+    'skills/spec-driven-development/SKILL.md',
+    'See `SKILL.md` and `references/testing-patterns.md`. Save the plan to `tasks/plan.md`.\n',
+  );
+
+  const result = run(root);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /1 files checked — 0 error\(s\) — PASSED/);
+});
+
+test('skips guarded files that do not exist', () => {
+  const root = makeSandbox();
+  writeFile(root, '.claude/commands/spec.md', 'Save the spec as `SPEC.md`.\n');
+  // No other guarded files present.
+
+  const result = run(root);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /1 files checked — 0 error\(s\) — PASSED/);
+});

--- a/scripts/validate-artifact-paths.js
+++ b/scripts/validate-artifact-paths.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * validate-artifact-paths.js
+ *
+ * Guards the spec -> plan -> build pipeline against silent artifact-path drift.
+ *
+ * The `/spec` and `/plan` commands (producers) write their artifacts to a set
+ * of paths that the `/build` command and the spec/plan skills (consumers) read
+ * back. When a producer moves an artifact without updating the consumers — as
+ * in PR #93, which pointed `/spec` and `/plan` at docs/features/[name]/ while
+ * `/build` still required SPEC.md and tasks/plan.md — the pipeline breaks, and
+ * nothing else in CI catches it (command parity only compares descriptions).
+ *
+ * This validator enforces one canonical set of spec/plan/todo artifact paths
+ * across every file in the pipeline. Changing the convention means updating
+ * ARTIFACT_ALLOWLIST *and* every guarded file in the same change; CI fails
+ * until they agree.
+ *
+ * Scope is deliberately narrow: only spec/plan/todo artifacts, only the files
+ * that define the pipeline. It is not a general markdown path linter.
+ *
+ * Exit codes: 0 = all clear, 1 = one or more drifted paths.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+// The canonical spec/plan/todo artifact paths. These are the only artifact
+// file paths the pipeline files may reference. To change the convention, edit
+// this list and update every guarded file to match — CI enforces the pairing.
+const ARTIFACT_ALLOWLIST = new Set([
+  'SPEC.md',        // spec, project root (produced by /spec, read by /build)
+  'docs/SPEC.md',   // spec, alternate location accepted by /build
+  'tasks/plan.md',  // plan (produced by /plan, read by /build)
+  'tasks/todo.md',  // task list (produced by /plan)
+]);
+
+// The files that make up the spec -> plan -> build pipeline. Absent files are
+// skipped, not failed: this validator checks path consistency, not presence.
+const GUARDED_FILES = [
+  '.claude/commands/spec.md',
+  '.claude/commands/plan.md',
+  '.claude/commands/build.md',
+  'skills/spec-driven-development/SKILL.md',
+  'skills/planning-and-task-breakdown/SKILL.md',
+  'docs/getting-started.md',
+  'docs/adoption-guide.md',
+];
+
+// Matches a path-like token ending in a spec/plan/todo artifact filename,
+// including an optional directory prefix with bracket placeholders like
+// docs/features/[feature-name]/spec.md. Case-insensitive so SPEC.md and a
+// drifted spec.md are both caught, then compared against the allowlist.
+const ARTIFACT_RE = /(?:[A-Za-z0-9._[\]-]+\/)*(?:spec|plan|todo)\.md/gi;
+
+function findViolations(relPath) {
+  const abs = path.join(ROOT, relPath);
+  if (!fs.existsSync(abs)) return null; // skipped
+
+  const violations = [];
+  const lines = fs.readFileSync(abs, 'utf8').split(/\r?\n/);
+  lines.forEach((line, i) => {
+    const matches = line.match(ARTIFACT_RE);
+    if (!matches) return;
+    for (const match of matches) {
+      if (!ARTIFACT_ALLOWLIST.has(match)) {
+        violations.push({ line: i + 1, match });
+      }
+    }
+  });
+  return violations;
+}
+
+function main() {
+  console.log('Checking spec/plan/todo artifact paths...\n');
+
+  let checked = 0;
+  let errors = 0;
+
+  for (const relPath of GUARDED_FILES) {
+    const violations = findViolations(relPath);
+    if (violations === null) continue; // file not present, skip
+    checked++;
+
+    if (violations.length === 0) {
+      console.log(`  ✓  ${relPath}`);
+    } else {
+      console.log(`  ✗  ${relPath}`);
+      for (const { line, match } of violations) {
+        console.log(`       L${line}: ${match} — not an approved spec/plan/todo artifact path`);
+        errors++;
+      }
+    }
+  }
+
+  const status = errors > 0 ? 'FAILED' : 'PASSED';
+  console.log(`\n${checked} files checked — ${errors} error(s) — ${status}`);
+
+  if (errors > 0) {
+    console.log('\nThe spec -> plan -> build pipeline expects one set of artifact paths.');
+    console.log('Either use a path from ARTIFACT_ALLOWLIST, or change the convention');
+    console.log('across every guarded file and update the allowlist in the same change.');
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Why

While reviewing #93 (which repoints `/spec` and `/plan` at `docs/features/[name]/`), I found it would break the `/spec → /plan → /build` pipeline: the producers moved the artifacts, but `/build` and the spec/plan skills still require `SPEC.md` and `tasks/plan.md`. Crucially, **CI stayed green**; the command-parity check only compares command descriptions, not artifact paths, so nothing guards the paths the pipeline agrees on.

This PR closes that gap so a #93-style drift fails CI instead of merging silently.

## What

A standalone validator, `scripts/validate-artifact-paths.js`, that enforces one canonical set of spec/plan/todo artifact paths across every file in the pipeline:

- producers: `.claude/commands/spec.md`, `.claude/commands/plan.md`
- consumer: `.claude/commands/build.md`
- skills: `spec-driven-development`, `planning-and-task-breakdown`
- docs: `getting-started.md`, `adoption-guide.md`

Any spec/plan/todo artifact path outside the allowlist (`SPEC.md`, `docs/SPEC.md`, `tasks/plan.md`, `tasks/todo.md`) fails the check, so changing the convention has to update the allowlist and every guarded file in the same change.

Scope is deliberately narrow: only spec/plan/todo artifacts, only the pipeline files. It is not a general markdown path linter.

## Verification

- `scripts/validate-artifact-paths-test.js`: 6/6 passing, including a test that reproduces the #93 drift.
- Against current `main`: 7 files checked, 0 errors, PASSED.
- End-to-end: applying #93's actual producer changes to the tree turns the validator red (7 errors, FAILED), pointing at the exact drifted lines in `spec.md`, `plan.md`, and `getting-started.md`, while the consumers that #93 left on the old paths still pass, surfacing the inconsistency.
- Wired into the `validate-commands` CI job alongside its test.

Relates to #93.