### PR TITLE
fix(code-review): add missing security and performance checklists

### DIFF
--- a/skills/code-review-and-quality/references/performance-checklist.md
+++ b/skills/code-review-and-quality/references/performance-checklist.md
@@ -1,0 +1,52 @@
+# Performance Review Checklist
+
+Run this alongside the Performance axis of the five-axis review whenever a
+change touches hot paths, data fetching, UI rendering, or anything a user
+will wait on. Quantify findings when you can — "this adds ~50ms per list item"
+beats "this could be slow."
+
+## Data fetching & queries
+
+- [ ] No N+1 query patterns (per-item queries in loops)
+- [ ] List endpoints paginated; no unbounded fetches
+- [ ] Queries use appropriate indexes; no table scans in hot paths
+- [ ] No fetching fields/records the caller never uses
+- [ ] Caching applied where the same data is requested repeatedly, with a
+      sensible invalidation story
+
+## Async & blocking
+
+- [ ] No synchronous/blocking operations inside async paths
+- [ ] No busy-wait loops or unbounded retries without backoff
+- [ ] Long-running work doesn't hold locks, connection pools, or thread pools
+- [ ] Timeouts on all external calls (HTTP, DB, filesystem)
+
+## Hot paths & allocation
+
+- [ ] No large allocations or copies inside loops (e.g. per-iteration
+      cloning, string concatenation in a loop)
+- [ ] No accidental O(n²): nested loops over the same collection, repeated
+      linear scans where a map/set/index suffices
+- [ ] No re-computation of values that could be hoisted or memoized
+- [ ] Database calls inside render loops or per-row handlers
+
+## UI
+
+- [ ] No unnecessary re-renders (unstable props, missing memoization where it
+      pays off)
+- [ ] No synchronous heavy work on the main/UI thread
+- [ ] Large lists virtualized; images lazy-loaded where appropriate
+
+## Deployables
+
+- [ ] No significant bundle/binary size regressions from the change
+- [ ] Startup-time work (eager initialization, heavy imports) not added to
+      request paths
+- [ ] Background jobs have concurrency limits; no unbounded queue growth
+
+## Verification
+
+- [ ] Performance claims backed by a profile or benchmark, not intuition
+- [ ] Baseline vs after comparison where the change is performance-sensitive
+- [ ] Regressions are **Required** findings; don't defer a measurable slowdown
+      without a filed bug and owner

--- a/skills/code-review-and-quality/references/security-checklist.md
+++ b/skills/code-review-and-quality/references/security-checklist.md
@@ -1,0 +1,55 @@
+# Security Review Checklist
+
+Run this alongside the Security axis of the five-axis review for any change
+that touches input handling, data flow, authentication, dependencies, or
+anything deployable. Lead with what matters: a confirmed vulnerability is a
+**Critical:** finding regardless of diff size.
+
+## Secrets & credentials
+
+- [ ] No secrets, tokens, or connection strings in code, logs, or version control
+- [ ] Secrets come from environment/config, never hardcoded with fallbacks
+- [ ] Log statements cannot leak sensitive values (request bodies, headers, tokens)
+- [ ] Error messages returned to clients don't reveal internals (stack traces, paths, SQL)
+
+## Input handling
+
+- [ ] All user input validated and sanitized at the system boundary
+- [ ] SQL queries parameterized — no string concatenation anywhere
+- [ ] Output encoded to prevent XSS (context-aware: HTML, attribute, JS, URL)
+- [ ] Command execution does not interpolate untrusted input
+- [ ] File uploads: extension/content validation, size limits, no path traversal
+- [ ] External data (APIs, logs, user content, config files, webhooks) treated as untrusted
+
+## Access control
+
+- [ ] Authentication required on every protected route/operation
+- [ ] Authorization checked per resource, not just at the endpoint level
+- [ ] No IDOR: object access verified against the caller's permissions
+- [ ] Sensitive operations require re-auth or elevated checks where appropriate
+- [ ] Default is deny; explicit allowlists for anything open
+
+## Data & dependencies
+
+- [ ] Sensitive data encrypted at rest and in transit (TLS everywhere)
+- [ ] Dependencies from trusted sources; `npm audit` / equivalent shows no known
+      vulnerabilities in the changed set
+- [ ] New dependencies justified (see Dependency Discipline in SKILL.md); no
+      typosquat-style names or unmaintained packages
+- [ ] Lockfile committed and reviewed; no hand-edits
+
+## Common blind spots
+
+- [ ] SSRF: can user-controlled URLs make the server fetch internal resources?
+- [ ] Redirects/forwards use validated, allowlisted targets
+- [ ] Rate limiting / abuse protection on auth, upload, and mutation endpoints
+- [ ] Session and token lifecycle: expiry, rotation, revocation
+- [ ] CSRF protection on state-changing requests
+- [ ] Cryptography uses vetted libraries — no hand-rolled primitives
+- [ ] Debug/backdoor code (test hooks, hardcoded admin paths) removed before merge
+
+## Verdict
+
+- [ ] **Critical** issues: none, or all fixed before merge
+- [ ] Security findings labeled with severity and a concrete exploit scenario
+- [ ] If a finding is deferred, it has a filed bug with an owner — "later" is not a plan


### PR DESCRIPTION
## Problem

`skills/code-review-and-quality/SKILL.md` (lines 351-352) promises two support files that were never shipped:

- `references/security-checklist.md`
- `references/performance-checklist.md`

The skill bundle contains only `SKILL.md`. Agents that follow the See Also section hit missing files, and hub installs of this skill had to tolerate the dangling references.

## Fix

Add the two checklists the SKILL.md already promises, aligned with its Security and Performance review axes (secrets, input handling, access control, dependency supply-chain; N+1, hot paths, async, UI, verification).

## Relationship to #400

PR #400 fixes the same defect by trimming SKILL.md to remove the references (self-contained skill, consistent with the repo's mostly single-file convention). This PR instead ships the promised files. Either resolves the dangling links; the maintainer may prefer one or merge both (if both merge, the files become dead weight after #400 — so pick one).