### PR TITLE
fix(skills): resolve references/ links from the skill directory

### DIFF
--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Run skill evals (trigger + routing)
         run: node scripts/run-evals.js --min-rank1 80
 
+      - name: Validate references/ links in skills
+        run: node scripts/validate-reference-links.js
+
+      - name: Test reference-link validator
+        run: node --test scripts/validate-reference-links-test.js
+
   validate-commands:
     name: Validate command parity and description sync
     runs-on: ubuntu-latest

--- a/scripts/validate-reference-links-test.js
+++ b/scripts/validate-reference-links-test.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { afterEach, test } = require('node:test');
+
+const VALIDATOR = path.join(__dirname, 'validate-reference-links.js');
+const sandboxes = [];
+
+function makeSandbox() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-skills-validate-reference-links-test-'));
+  const scriptsDir = path.join(root, 'scripts');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+  fs.copyFileSync(VALIDATOR, path.join(scriptsDir, 'validate-reference-links.js'));
+  sandboxes.push(root);
+  return root;
+}
+
+function writeFile(root, relativePath, content) {
+  const file = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+}
+
+function run(root) {
+  return spawnSync(process.execPath, [path.join(root, 'scripts', 'validate-reference-links.js')], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+}
+
+afterEach(() => {
+  for (const root of sandboxes.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('passes when a skill reaches the shared checklist two levels up', () => {
+  const root = makeSandbox();
+  writeFile(root, 'references/definition-of-done.md', '# Definition of Done\n');
+  writeFile(
+    root,
+    'skills/using-agent-skills/SKILL.md',
+    'See `../../references/definition-of-done.md`.\n'
+  );
+
+  const result = run(root);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /1 skills checked — 0 error\(s\) — PASSED/);
+});
+
+test('fails when a skill links the shared checklist as if it were colocated', () => {
+  // The regression: references/ lives at the repo root, but the link is
+  // resolved from skills/<name>/, so it points two levels too deep.
+  const root = makeSandbox();
+  writeFile(root, 'references/definition-of-done.md', '# Definition of Done\n');
+  writeFile(
+    root,
+    'skills/using-agent-skills/SKILL.md',
+    'See `references/definition-of-done.md`.\n'
+  );
+
+  const result = run(root);
+
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stdout, /1 skills checked — 1 error\(s\) — FAILED/);
+  assert.match(
+    result.stdout,
+    /L1: references\/definition-of-done\.md — resolves to skills\/using-agent-skills\/references\/definition-of-done\.md/
+  );
+  assert.match(result.stdout, /use `\.\.\/\.\.\/references\/<file>\.md`/);
+});
+
+test('checks markdown link syntax, not just backtick mentions', () => {
+  const root = makeSandbox();
+  writeFile(root, 'references/definition-of-done.md', '# Definition of Done\n');
+  writeFile(root, 'skills/using-agent-skills/SKILL.md', 'See [DoD](references/definition-of-done.md).\n');
+
+  const result = run(root);
+
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stdout, /L1: references\/definition-of-done\.md/);
+});
+
+test('passes when a skill colocates its own references directory', () => {
+  // CLAUDE.md allows self-contained skills to keep references under
+  // skills/<name>/references/. Those links are correct as written.
+  const root = makeSandbox();
+  writeFile(root, 'skills/dataviz/references/palette.md', '# Palette\n');
+  writeFile(root, 'skills/dataviz/SKILL.md', 'See `references/palette.md`.\n');
+
+  const result = run(root);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /1 skills checked — 0 error\(s\) — PASSED/);
+});
+
+test('fails when a link points at a checklist that no longer exists', () => {
+  const root = makeSandbox();
+  writeFile(root, 'references/definition-of-done.md', '# Definition of Done\n');
+  writeFile(root, 'skills/shipping-and-launch/SKILL.md', 'See `../../references/renamed.md`.\n');
+
+  const result = run(root);
+
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stdout, /L1: \.\.\/\.\.\/references\/renamed\.md/);
+  assert.match(result.stdout, /1 skills checked — 1 error\(s\) — FAILED/);
+});
+
+test('ignores paths that are not references/ links', () => {
+  // Skills legitimately name artifacts the user has yet to create. Widening
+  // this validator into a general markdown linter would fail the build on them.
+  const root = makeSandbox();
+  writeFile(root, 'references/definition-of-done.md', '# Definition of Done\n');
+  writeFile(
+    root,
+    'skills/planning-and-task-breakdown/SKILL.md',
+    [
+      'Save the task list to `tasks/todo.md` and the plan to `tasks/plan.md`.',
+      'Record findings in `PERF.md` or `docs/ideas/[idea-name].md`.',
+      'Related: `skills/incremental-implementation/SKILL.md`.',
+      'See `../../references/definition-of-done.md`.',
+      '',
+    ].join('\n')
+  );
+
+  const result = run(root);
+
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /1 skills checked — 0 error\(s\) — PASSED/);
+});
+
+test('reports every unresolvable link, not just the first per skill', () => {
+  const root = makeSandbox();
+  writeFile(root, 'references/security-checklist.md', '# Security\n');
+  writeFile(root, 'references/performance-checklist.md', '# Performance\n');
+  writeFile(
+    root,
+    'skills/code-review-and-quality/SKILL.md',
+    ['See `references/security-checklist.md`.', 'And `references/performance-checklist.md`.', ''].join('\n')
+  );
+
+  const result = run(root);
+
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stdout, /1 skills checked — 2 error\(s\) — FAILED/);
+});

--- a/scripts/validate-reference-links.js
+++ b/scripts/validate-reference-links.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * validate-reference-links.js
+ *
+ * Guards links from skills to the shared `references/` checklists.
+ *
+ * Those checklists live in the repo-root `references/` directory, but every
+ * SKILL.md used to link them as `references/<file>.md` — a path relative to
+ * the skill's own directory, which is two levels below the root. All 18 links
+ * across 11 skills resolved to files that do not exist, in the repo and in
+ * every plugin-install layout (~/.claude/plugins/cache/..., ~/.codex/...).
+ * Agents that followed the guidance — for example using-agent-skills pointing
+ * at the Definition of Done — hit a file-not-found and stalled.
+ *
+ * Nothing else in CI catches this: validate-artifact-paths.js is scoped to
+ * spec/plan/todo artifacts and is explicitly not a general markdown linter.
+ *
+ * The rule enforced here: every `references/*.md` link in a SKILL.md must
+ * resolve to an existing file relative to that skill's own directory. This
+ * accepts both conventions in CLAUDE.md — shared checklists reached via
+ * `../../references/`, and a skill's own colocated `references/` directory.
+ *
+ * Scope is deliberately narrow: only `references/*.md` links, only SKILL.md
+ * files. It is not a general markdown path linter — skills legitimately
+ * mention paths that do not exist yet (`tasks/todo.md`, `PERF.md`,
+ * `docs/ideas/[idea-name].md`), and those must not fail the build.
+ *
+ * Exit codes: 0 = all clear, 1 = one or more unresolvable links.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const SKILLS_DIR = path.join(ROOT, 'skills');
+
+// Matches a link to a references/ markdown file, with any number of leading
+// `../` segments: `references/x.md`, `../../references/x.md`. Anchored on a
+// non-path character so `myreferences/x.md` does not match.
+const REFERENCE_LINK_RE = /(?<![A-Za-z0-9._/-])((?:\.\.\/)*references\/[A-Za-z0-9._-]+\.md)/g;
+
+function findViolations(skillDir, skillFile) {
+  const violations = [];
+  const lines = fs.readFileSync(skillFile, 'utf8').split(/\r?\n/);
+
+  lines.forEach((line, i) => {
+    for (const match of line.matchAll(REFERENCE_LINK_RE)) {
+      const link = match[1];
+      if (!fs.existsSync(path.resolve(skillDir, link))) {
+        violations.push({ line: i + 1, link });
+      }
+    }
+  });
+
+  return violations;
+}
+
+function main() {
+  console.log('Checking references/ links in skills...\n');
+
+  if (!fs.existsSync(SKILLS_DIR)) {
+    console.log('No skills/ directory — nothing to check.');
+    return;
+  }
+
+  let checked = 0;
+  let errors = 0;
+
+  const skillNames = fs.readdirSync(SKILLS_DIR).sort();
+  for (const name of skillNames) {
+    const skillDir = path.join(SKILLS_DIR, name);
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    if (!fs.statSync(skillDir).isDirectory() || !fs.existsSync(skillFile)) continue;
+
+    checked++;
+    const violations = findViolations(skillDir, skillFile);
+
+    if (violations.length === 0) {
+      console.log(`  ✓  skills/${name}/SKILL.md`);
+    } else {
+      console.log(`  ✗  skills/${name}/SKILL.md`);
+      for (const { line, link } of violations) {
+        const resolved = path.relative(ROOT, path.resolve(skillDir, link));
+        console.log(`       L${line}: ${link} — resolves to ${resolved}, which does not exist`);
+        errors++;
+      }
+    }
+  }
+
+  const status = errors > 0 ? 'FAILED' : 'PASSED';
+  console.log(`\n${checked} skills checked — ${errors} error(s) — ${status}`);
+
+  if (errors > 0) {
+    console.log('\nLinks to references/ are resolved from the skill\'s own directory.');
+    console.log('Shared checklists live in the repo-root references/, two levels up:');
+    console.log('use `../../references/<file>.md`, not `references/<file>.md`.');
+    process.exit(1);
+  }
+}
+
+main();

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -348,8 +348,8 @@ For triaging `npm audit` findings and supply-chain risk (typosquatting, compromi
 ```
 ## See Also
 
-- For detailed security review guidance, see `references/security-checklist.md`
-- For performance review checks, see `references/performance-checklist.md`
+- For detailed security review guidance, see `../../references/security-checklist.md`
+- For performance review checks, see `../../references/performance-checklist.md`
 
 ## Common Rationalizations
 

--- a/skills/doubt-driven-development/SKILL.md
+++ b/skills/doubt-driven-development/SKILL.md
@@ -43,7 +43,7 @@ If you doubt every keystroke, you ship nothing. The skill applies only to non-tr
 
 This skill is designed for the **main-session orchestrator**, where Step 3 (DOUBT, detailed below) can spawn a fresh-context reviewer.
 
-- **Do NOT add this skill to a persona's `skills:` frontmatter.** A persona that follows Step 3 would spawn another persona — the orchestration anti-pattern explicitly forbidden by `references/orchestration-patterns.md` ("personas do not invoke other personas").
+- **Do NOT add this skill to a persona's `skills:` frontmatter.** A persona that follows Step 3 would spawn another persona — the orchestration anti-pattern explicitly forbidden by `../../references/orchestration-patterns.md` ("personas do not invoke other personas").
 - **If you find yourself applying this skill from inside a subagent context** (where Claude Code prevents nested subagent spawn): the preferred path is to surface to the user that doubt-driven cannot run nested and let the main session handle it. As a last resort only, a degraded self-questioning fallback exists — rewrite ARTIFACT + CONTRACT as a fresh self-prompt with a hard mental separator from your prior reasoning, and walk Steps 1–5. This is **not fresh-context review** (you carry your own context with you), so flag the result as degraded and prefer escalation whenever the user is reachable.
 
 ## The Process
@@ -226,7 +226,7 @@ If 3 cycles is "obviously insufficient" because the artifact is large: the artif
 - **`source-driven-development`**: SDD verifies *facts about frameworks* against official docs. Doubt-driven verifies *your reasoning about the artifact*. SDD checks the API exists; doubt-driven checks you used it correctly under the contract.
 - **`test-driven-development`**: TDD's RED step is doubt made concrete — a failing test is a disproof attempt. When TDD applies, that failing test *is* the doubt step for behavioral claims.
 - **`debugging-and-error-recovery`**: when the reviewer surfaces a real failure mode, drop into the debugging skill to localize and fix.
-- **Repo orchestration rules** (`references/orchestration-patterns.md`): this skill orchestrates from the main session. A persona calling another persona is anti-pattern B — see Loading Constraints above.
+- **Repo orchestration rules** (`../../references/orchestration-patterns.md`): this skill orchestrates from the main session. A persona calling another persona is anti-pattern B — see Loading Constraints above.
 
 ## Verification
 

--- a/skills/frontend-ui-engineering/SKILL.md
+++ b/skills/frontend-ui-engineering/SKILL.md
@@ -294,7 +294,7 @@ function useToggleTask() {
 
 ## See Also
 
-For detailed accessibility requirements and testing tools, see `references/accessibility-checklist.md`.
+For detailed accessibility requirements and testing tools, see `../../references/accessibility-checklist.md`.
 
 ## Common Rationalizations
 

--- a/skills/incremental-implementation/SKILL.md
+++ b/skills/incremental-implementation/SKILL.md
@@ -246,4 +246,4 @@ After completing all increments for a task:
 
 ## See Also
 
-Per-increment verification is the local check. Before declaring a task done, apply the project-wide Definition of Done as the final gate, the standing bar every increment clears regardless of the task. See `references/definition-of-done.md`.
+Per-increment verification is the local check. Before declaring a task done, apply the project-wide Definition of Done as the final gate, the standing bar every increment clears regardless of the task. See `../../references/definition-of-done.md`.

--- a/skills/observability-and-instrumentation/SKILL.md
+++ b/skills/observability-and-instrumentation/SKILL.md
@@ -200,4 +200,4 @@ After instrumenting a feature, confirm:
 - [ ] Every new alert is symptom-based, has a runbook link, and was test-fired once
 - [ ] An induced failure in staging was located via telemetry alone, without reading the source
 
-For the at-a-glance version of this list, including the pre-launch instrumentation gate, see `references/observability-checklist.md`.
+For the at-a-glance version of this list, including the pre-launch instrumentation gate, see `../../references/observability-checklist.md`.

--- a/skills/performance-optimization/SKILL.md
+++ b/skills/performance-optimization/SKILL.md
@@ -349,7 +349,7 @@ npx lhci autorun
 
 ## See Also
 
-For detailed performance checklists, optimization commands, and anti-pattern reference, see `references/performance-checklist.md`.
+For detailed performance checklists, optimization commands, and anti-pattern reference, see `../../references/performance-checklist.md`.
 
 
 ## Common Rationalizations

--- a/skills/planning-and-task-breakdown/SKILL.md
+++ b/skills/planning-and-task-breakdown/SKILL.md
@@ -231,4 +231,4 @@ Before starting implementation, confirm:
 
 ## See Also
 
-Acceptance criteria are per-task and answer "did we build the right thing?". They sit on top of the project-wide Definition of Done, the standing bar every task clears before it counts as done. See `references/definition-of-done.md`.
+Acceptance criteria are per-task and answer "did we build the right thing?". They sit on top of the project-wide Definition of Done, the standing bar every task clears before it counts as done. See `../../references/definition-of-done.md`.

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -74,7 +74,7 @@ If you can't name the trust boundaries for a feature, you're not ready to secure
 
 ## OWASP Top 10 Prevention Patterns
 
-These are prevention patterns, not a ranking. For the 2021 ordering, see the quick-reference table in `references/security-checklist.md`.
+These are prevention patterns, not a ranking. For the 2021 ordering, see the quick-reference table in `../../references/security-checklist.md`.
 
 ### Injection (SQL, NoSQL, OS Command)
 
@@ -300,7 +300,7 @@ When you defer a fix, document the reason and set a review date.
 
 Do not assume npm or treat the nearest manifest as the install root. Apply this order:
 
-1. **Find the installation boundary and manager.** Use the workspace root that owns the lockfile, or an independent nested project only when it is outside that workspace. There, corroborate `packageManager` (when present), the lockfile, and CI; stop on disagreement or competing lockfiles. Pin the manager version and use the matrix in `references/security-checklist.md`.
+1. **Find the installation boundary and manager.** Use the workspace root that owns the lockfile, or an independent nested project only when it is outside that workspace. There, corroborate `packageManager` (when present), the lockfile, and CI; stop on disagreement or competing lockfiles. Pin the manager version and use the matrix in `../../references/security-checklist.md`.
 2. **Block dependency scripts before first execution.** Bootstrap with scripts disabled or a documented fail-closed policy, inspect the pending script source, approve only the minimum required packages, commit the policy, then verify with a clean frozen/immutable install. Never blanket-approve scripts.
 
 Audits only find known advisories; they do not catch a newly malicious or typosquatted package. Therefore:
@@ -424,7 +424,7 @@ container.textContent = await llm.reply(userMessage);
 ```
 ## See Also
 
-For detailed security checklists and pre-commit verification steps, see `references/security-checklist.md`.
+For detailed security checklists and pre-commit verification steps, see `../../references/security-checklist.md`.
 
 ## Common Rationalizations
 

--- a/skills/shipping-and-launch/SKILL.md
+++ b/skills/shipping-and-launch/SKILL.md
@@ -265,10 +265,10 @@ Every deployment needs a rollback plan before it happens:
 ```
 ## See Also
 
-- For the project-wide Definition of Done that every change must clear before this checklist, see `references/definition-of-done.md`
-- For security pre-launch checks, see `references/security-checklist.md`
-- For performance pre-launch checklist, see `references/performance-checklist.md`
-- For accessibility verification before launch, see `references/accessibility-checklist.md`
+- For the project-wide Definition of Done that every change must clear before this checklist, see `../../references/definition-of-done.md`
+- For security pre-launch checks, see `../../references/security-checklist.md`
+- For performance pre-launch checklist, see `../../references/performance-checklist.md`
+- For accessibility verification before launch, see `../../references/accessibility-checklist.md`
 
 ## Common Rationalizations
 

--- a/skills/test-driven-development/SKILL.md
+++ b/skills/test-driven-development/SKILL.md
@@ -358,7 +358,7 @@ This separation ensures the test is written without knowledge of the fix, making
 
 ## See Also
 
-For JavaScript/TypeScript testing patterns illustrating these principles — Jest, React Testing Library, Supertest, Playwright — see `references/testing-patterns.md`. The principles transfer to any ecosystem; the syntax and tools there are JS/TS-specific.
+For JavaScript/TypeScript testing patterns illustrating these principles — Jest, React Testing Library, Supertest, Playwright — see `../../references/testing-patterns.md`. The principles transfer to any ecosystem; the syntax and tools there are JS/TS-specific.
 
 ## Common Rationalizations
 

--- a/skills/using-agent-skills/SKILL.md
+++ b/skills/using-agent-skills/SKILL.md
@@ -110,7 +110,7 @@ Your job is surgical precision, not unsolicited renovation.
 
 Every skill includes a verification step. A task is not complete until verification passes. "Seems right" is never sufficient — there must be evidence (passing tests, build output, runtime data).
 
-Per-skill verification is the local check. The project-wide bar that applies to *every* change, regardless of which skill is active, is the Definition of Done: tests pass, no regressions, behavior verified at runtime, docs updated. See `references/definition-of-done.md`. It complements each task's acceptance criteria rather than replacing them.
+Per-skill verification is the local check. The project-wide bar that applies to *every* change, regardless of which skill is active, is the Definition of Done: tests pass, no regressions, behavior verified at runtime, docs updated. See `../../references/definition-of-done.md`. It complements each task's acceptance criteria rather than replacing them.
 
 ## Failure Modes to Avoid
 


### PR DESCRIPTION
Closes #468.

## Problem

All 18 links from `skills/*/SKILL.md` to the shared `references/` checklists are written relative to the skill's own directory, but those files live in the repo root, two levels up. They resolve to paths that do not exist — including in a full Claude Code marketplace install where `references/` is present:

```console
$ P=~/.claude/plugins/cache/addy-agent-skills/agent-skills/7829ffd90d97
$ ls $P/references/ | wc -l
7
$ test -f $P/skills/using-agent-skills/references/definition-of-done.md \
    && echo FOUND || echo "NOT FOUND"
NOT FOUND
```

An agent that follows the guidance — `using-agent-skills` pointing at the Definition of Done, for example — gets a file-not-found and stalls. The same 404 reproduces on the Codex 0.6.6 plugin cache.

## Change

Two commits:

1. **fix** — rewrite the 18 links to `../../references/<file>.md`. Text-only, one line each across 11 skills; structure and tone untouched.
2. **ci** — add `scripts/validate-reference-links.js` plus tests, wired into the `validate-skills` job.

The gate resolves every `references/*.md` link in `skills/*/SKILL.md` against that skill's own directory. It accepts both conventions in CLAUDE.md: shared checklists reached via `../../references/`, and a skill's own colocated `references/`.

Scope is deliberately narrow, following the precedent `validate-artifact-paths.js` sets in its own header ("It is not a general markdown path linter"). Skills legitimately name paths that do not exist yet — `tasks/todo.md`, `PERF.md`, `docs/ideas/[idea-name].md` — and a general linter would fail the build on them. A test pins that.

If you would rather take only the path fix, the second commit drops cleanly.

## Verification

- Gate run against the pre-fix tree (`d2478bf`): `18 error(s)`, exit 1 — matching exactly the 18 links changed here.
- Gate run on this branch: `0 error(s)`, exit 0.
- 7 unit tests: the regression itself, colocated `references/`, markdown-link syntax, a renamed target, multiple violations in one skill, and the non-reference paths that must be ignored.
- `bash hooks/session-start-test.sh` → `session-start JSON payload OK`, required by CONTRIBUTING.md because `skills/using-agent-skills/SKILL.md` is touched.
- `validate-skills`, `validate-versions`, `validate-commands`, `validate-artifact-paths` and their `--test` companions all pass.

## Relationship to #366

#366 addresses an overlapping problem a different way — absolute GitHub URLs, so per-skill `npx` installs can reach the checklists too. Two observations rather than a claim of precedence:

- It is currently `dirty` against `main`, and its stated premise — that relative paths "work only with the full repo present (Claude Code marketplace plugin, whole-repo clone)" — does not hold. That is what #468 documents.
- It converts 17 of the 18 links. `skills/security-and-hardening/SKILL.md` line 303 (`use the matrix in references/security-checklist.md`, inside a numbered list item) is not covered by it.

If you prefer the URL direction, drop this PR's first commit and rebase #366; the CI gate in the second commit still applies either way, since it only inspects relative `references/*.md` links and passes trivially once they are absolute URLs. Happy to reshape this in whichever direction you want.

## Known limitation

The validator does not strip fenced code blocks, so a SKILL.md that documents the anti-pattern inside a fence would be flagged. Nothing in the repo does that today. I left it out rather than duplicating `stripFencedCodeBlocks`, whose fence parsing is the subject of #437 and #444 — once that lands, sharing it looks like the right move.
