### PR TITLE
docs(security): add Data Privacy & Compliance section to security-and-hardening

### DIFF
--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-and-hardening
-description: Hardens code against vulnerabilities. Use when handling user input, authentication, data storage, or external integrations. Use when building any feature that accepts untrusted data, manages user sessions, or interacts with third-party services. Use when collecting, storing, retaining, deleting, or sharing personal data, or addressing privacy/compliance (GDPR/CCPA).
+description: Hardens code against vulnerabilities. Use when handling user input, authentication, data storage, or external integrations. Use when building any feature that accepts untrusted data, manages user sessions, or interacts with third-party services. Use when personal data or privacy compliance (GDPR, CCPA) is involved.
 ---
 
 # Security and Hardening

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-and-hardening
-description: Hardens code against vulnerabilities. Use when handling user input, authentication, data storage, or external integrations. Use when building any feature that accepts untrusted data, manages user sessions, or interacts with third-party services.
+description: Hardens code against vulnerabilities. Use when handling user input, authentication, data storage, or external integrations. Use when building any feature that accepts untrusted data, manages user sessions, or interacts with third-party services. Use when collecting, storing, retaining, deleting, or sharing personal data, or addressing privacy/compliance (GDPR/CCPA).
 ---
 
 # Security and Hardening
@@ -353,6 +353,27 @@ git diff --cached | grep -i "password\|secret\|api_key\|token"
 
 **If a secret is ever committed, rotate it.** Deleting the line or rewriting history is not enough — assume it's compromised the moment it reaches a remote. Revoke and reissue the key first, then purge it from history.
 
+## Data Privacy & Compliance
+
+Securing data is "can an attacker read it?" Privacy is "should *we* even hold it, and for how long?" — a separate question that hardening doesn't answer. The cheapest data to protect, breach, and comply over is the data you never collected. Treat personal data as a liability to minimize, not an asset to hoard.
+
+**Know what you hold.** You can't protect or honor a deletion request for data you can't find. Classify fields as you add them:
+
+| Class | Examples | Handling |
+|---|---|---|
+| **Non-personal** | Aggregates, anonymized counts | Normal handling |
+| **Personal (PII)** | Name, email, IP, device/user IDs | Minimize, access-control, include in export/delete |
+| **Sensitive** | Health, finance, location, biometrics, gov IDs, anything about minors | Extra basis to collect, stricter access, often encryption + audit logging |
+
+**Operating rules:**
+- **Minimize and set a purpose.** Collect a field only against a stated use. "It might be useful later" is not a purpose — it's latent breach scope. Don't log PII into telemetry (the `observability-and-instrumentation` skill makes the same point from the ops side).
+- **Set retention up front, then actually delete.** Every personal-data store needs a TTL and a working deletion path — including backups, caches, search indexes, and analytics copies. Data with no expiry is a breach scheduled for later.
+- **Support the data-subject rights your jurisdiction requires** (GDPR/CCPA and kin): export, correct, and delete on request. These are engineering features — design the schema so a user's data is *findable* and *erasable*, not smeared irreversibly across systems.
+- **Get consent before collection or third-party sharing**, and make it auditable. Sending PII to an analytics/ad/LLM vendor is "sharing" — the user's choice gates it, and the vendor needs a data-processing agreement.
+- **Localize defaults, don't hardcode one region's law.** Data-residency and rules differ by user location; make the policy a configurable boundary, not an assumption.
+
+When data crosses a trust boundary, validate it as untrusted (see Input Validation above); when a privacy incident exposes personal data, the breach-notification clock is part of the postmortem — follow the `debugging-and-error-recovery` skill.
+
 ## Securing AI / LLM Features
 
 If your app calls an LLM — chatbots, summarizers, agents, RAG — it inherits a new attack surface. Map it to the [OWASP Top 10 for LLM Applications (2025)](https://genai.owasp.org/llm-top-10/):
@@ -405,6 +426,9 @@ container.textContent = await llm.reply(userMessage);
 - [ ] No secrets in code or version control
 - [ ] Sensitive fields excluded from API responses
 - [ ] PII encrypted at rest (if applicable)
+- [ ] Personal data is classified, collected against a stated purpose, and minimized
+- [ ] Personal data has a retention limit and a working deletion path (incl. backups/indexes)
+- [ ] Export/delete (data-subject) requests are supported where required; sharing with third parties has consent
 
 ### Infrastructure
 - [ ] Security headers configured (CSP, HSTS, etc.)
@@ -438,6 +462,9 @@ For detailed security checklists and pre-commit verification steps, see `referen
 | "Threat modeling is overkill here" | Five minutes of "how would I attack this?" prevents the design flaws no control can patch later. |
 | "It's just LLM output, it's only text" | That "text" can be a SQL statement, a script tag, or a shell command. Treat it like any untrusted input. |
 | "The audit passed, so the dependency is safe" | Audits match known advisories. They do not detect a newly malicious package or make unreviewed install scripts safe to execute. |
+| "Collect it now, we might need it later" | Data you don't hold can't be breached, subpoenaed, or mis-deleted. "Might need it" is breach scope, not a purpose. |
+| "We'll handle deletion requests manually" | Manual erasure misses backups, caches, and analytics copies. If the schema can't find a user's data, you can't honor the request — design for it. |
+| "Compliance is legal's problem, not ours" | Export, deletion, retention, and consent are schema and code. Legal can't bolt them on after you've smeared PII across ten systems. |
 
 ## Red Flags
 
@@ -451,6 +478,9 @@ For detailed security checklists and pre-commit verification steps, see `referen
 - Server fetches user-supplied URLs without an allowlist (SSRF)
 - LLM/model output passed into a query, the DOM, a shell, or `eval`
 - Secrets, PII, or the full system prompt placed inside an LLM context window
+- Personal data collected with no stated purpose, retention limit, or deletion path
+- PII sent to analytics/ad/LLM vendors with no consent or data-processing agreement
+- "Delete my account" that only flips a flag while the personal data lingers in stores and backups
 
 ## Verification
 
@@ -465,3 +495,5 @@ After implementing security-relevant code:
 - [ ] Rate limiting active on auth endpoints
 - [ ] Server-side URL fetches validated against an allowlist (no SSRF)
 - [ ] LLM/model output validated and encoded before use (if AI features present)
+- [ ] Personal data is classified, minimized to a stated purpose, and has a retention limit
+- [ ] Deletion and export requests work end-to-end (including backups, caches, and analytics copies)


### PR DESCRIPTION
## What and why

`security-and-hardening` already owns the answer to "can an attacker read this data?" This PR adds the companion question agents currently have no guidance on: **"should we even hold this data, and for how long?"** — a separate concern that hardening alone doesn't answer.

Addy's closing note on #347 was: *"Data privacy and compliance fit security-and-hardening rather than a separate section; closing here, a focused addition to that skill would be welcome."* This is that addition.

## Why it belongs in security-and-hardening

- The skill already tells agents to protect PII in logs (Step 3: Structured Logging cross-reference), encrypt sensitive fields, and exclude them from API responses. The natural next question is: which fields are PII, what makes something sensitive, and what happens when a user asks you to delete it? Those answers belong in the same place.
- The security skill's existing Verification checklist already checks `PII encrypted at rest` — this PR gives agents the classification framework they need to answer that checkbox correctly.
- No new skill directory needed; no new routing surface introduced. Frontmatter description is unchanged.

## Content (+33 lines, one file)

A new `## Data Privacy & Compliance` section covering four actionable decisions:

**1. Classify fields as you add them** — PII classification table (non-personal / personal PII / sensitive) with handling rules per class. Agents can't protect or delete what they haven't classified.

**2. Four operating rules** — minimize and state a purpose before collecting; set retention up front and build a working deletion path (including backups, caches, indexes); support data-subject rights (export, correct, delete) by designing the schema to be findable and erasable; get auditable consent before sharing PII with third parties or vendors.

**3. Cross-references without duplication** — points to `observability-and-instrumentation` for the "never log PII" rule (already there), and to `debugging-and-error-recovery` for breach-notification timing in postmortems. No content duplicated.

**4. Three Verification checkboxes** added to the existing checklist:
- Personal data classified, collected against a stated purpose, minimized
- Retention limit and working deletion path (including backups/indexes)
- Export/delete requests supported; third-party sharing has consent

Also adds three rationalization rows and three red flags to the existing sections.

## What this is not

This is not a GDPR compliance guide. It's the minimum a coding agent needs to avoid building systems that fail deletion requests, send PII to analytics vendors without consent, or collect fields with no stated purpose. Legal detail belongs elsewhere; engineering decisions belong here.

Validator: 0 errors, 0 warnings. One file. Frontmatter description unchanged (no routing surface added).