### PR TITLE
fix(evals): reject incomplete grader results

### DIFF
--- a/scripts/run-evals-test.js
+++ b/scripts/run-evals-test.js
@@ -8,7 +8,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const test = require('node:test');
-const { materializeWorkspace } = require('./run-evals');
+const { materializeWorkspace, parseGrading } = require('./run-evals');
 
 const RUNNER = path.join(__dirname, 'run-evals.js');
 
@@ -66,6 +66,59 @@ function run(root, args = []) {
     encoding: 'utf8',
   });
 }
+
+test('accepts a complete and consistent grader result', () => {
+  const raw = JSON.stringify({
+    expectations: [
+      { text: 'first expectation', passed: true, evidence: 'observed in the trace' },
+      { text: 'second expectation', passed: false, evidence: 'not observed in the trace' },
+    ],
+    summary: { passed: 1, failed: 1, total: 2, pass_rate: 0.5 },
+  });
+
+  assert.deepEqual(parseGrading(raw, 2), JSON.parse(raw));
+});
+
+test('rejects grader results that omit expectations', () => {
+  const raw = JSON.stringify({
+    expectations: [
+      { text: 'first expectation', passed: true, evidence: 'observed in the trace' },
+    ],
+    summary: { passed: 1, failed: 0, total: 1, pass_rate: 1 },
+  });
+
+  assert.equal(parseGrading(raw, 2), null);
+});
+
+test('rejects incomplete or inconsistent grader summaries', () => {
+  const expectation = { text: 'expected behavior', passed: false, evidence: 'not observed' };
+  const cases = [
+    {
+      expectations: [],
+      summary: { passed: 0, failed: 0, total: 0, pass_rate: 0 },
+    },
+    {
+      expectations: [{ text: 'expected behavior', passed: false }],
+      summary: { passed: 0, failed: 1, total: 1, pass_rate: 0 },
+    },
+    {
+      expectations: [expectation],
+      summary: { passed: 1, failed: 0, total: 1, pass_rate: 1 },
+    },
+    {
+      expectations: [expectation],
+      summary: { passed: 0, total: 1, pass_rate: 0 },
+    },
+    {
+      expectations: [expectation],
+      summary: { passed: 0, failed: 1, total: 1 },
+    },
+  ];
+
+  for (const grading of cases) {
+    assert.equal(parseGrading(JSON.stringify(grading), 1), null);
+  }
+});
 
 test('fails when a skill has no eval case file', () => {
   const root = makeSandbox();

--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -426,7 +426,7 @@ function materializeWorkspace(ev) {
   return workspace;
 }
 
-function parseGrading(raw) {
+function parseGrading(raw, expectedCount) {
   // Grader output may arrive fenced; extract the JSON object and validate shape.
   const m = raw.match(/\{[\s\S]*\}/);
   if (!m) return null;
@@ -436,10 +436,23 @@ function parseGrading(raw) {
   } catch {
     return null;
   }
+  const expectations = g.expectations;
+  const summary = g.summary;
+  const passed = Array.isArray(expectations)
+    ? expectations.filter((expectation) => expectation.passed === true).length
+    : 0;
   const ok =
-    Array.isArray(g.expectations) &&
-    g.expectations.every((e) => typeof e.text === 'string' && typeof e.passed === 'boolean') &&
-    g.summary && typeof g.summary.passed === 'number' && typeof g.summary.total === 'number';
+    Number.isInteger(expectedCount) && expectedCount > 0 &&
+    Array.isArray(expectations) && expectations.length === expectedCount &&
+    expectations.every((expectation) =>
+      typeof expectation.text === 'string' &&
+      typeof expectation.passed === 'boolean' &&
+      typeof expectation.evidence === 'string') &&
+    summary &&
+    Number.isInteger(summary.passed) && summary.passed === passed &&
+    Number.isInteger(summary.failed) && summary.failed === expectedCount - passed &&
+    Number.isInteger(summary.total) && summary.total === expectedCount &&
+    typeof summary.pass_rate === 'number' && Number.isFinite(summary.pass_rate);
   return ok ? g : null;
 }
 
@@ -526,7 +539,7 @@ function runBehavioral(skillName, dryRun) {
     // The trace can be megabytes; pass the grader prompt via stdin, never
     // argv, or it would blow past the OS argument-size limit (E2BIG).
     const raw = execFileSync('claude', ['-p'], { input: graderPrompt, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024, timeout: GRADER_TIMEOUT_MS });
-    const grading = parseGrading(raw);
+    const grading = parseGrading(raw, ev.expectations.length);
     const base = path.join(RESULTS_DIR, `${skillName}.eval-${ev.id}`);
     if (!grading) {
       fs.writeFileSync(`${base}.grading.raw.txt`, raw);
@@ -573,4 +586,4 @@ function main(args = process.argv.slice(2)) {
 
 if (require.main === module) main();
 
-module.exports = { materializeWorkspace };
+module.exports = { materializeWorkspace, parseGrading };


### PR DESCRIPTION
## Summary

- require one grader result for every declared expectation
- validate evidence and the complete summary shape
- reject pass/fail totals that disagree with the individual results

## Why

`parseGrading` accepted empty or partial expectation arrays and trusted their summary counters. A grader response could therefore report `0/0` or `1/1` and let a behavioral eval pass without grading every declared requirement.

## Validation

- `node --test scripts/run-evals-test.js`
- `node scripts/run-evals.js --min-rank1 80`
- `node scripts/validate-skills.js`
- `node scripts/validate-commands.js`