### PR TITLE
fix(hooks): emit the standard SessionStart envelope (#465)

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 # agent-skills session start hook
 # Injects the using-agent-skills meta-skill into every new session
+#
+# Every output path must emit the standard SessionStart envelope
+#   {"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}
+# Hosts that validate hook output (Codex CLI, Claude Code) reject other shapes.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$(dirname "$SCRIPT_DIR")/skills"
 META_SKILL="$SKILLS_DIR/using-agent-skills/SKILL.md"
 
 if ! command -v jq >/dev/null 2>&1; then
-  echo '{"priority": "INFO", "message": "agent-skills: jq is required for the session-start hook but was not found on PATH. Install jq (e.g. `brew install jq` or `apt-get install jq`) to enable meta-skill injection. Skills remain available individually."}'
+  echo '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "agent-skills: jq is required for the session-start hook but was not found on PATH. Install jq (e.g. `brew install jq` or `apt-get install jq`) to enable meta-skill injection. Skills remain available individually."}}'
   exit 0
 fi
 
@@ -15,10 +19,10 @@ if [ -f "$META_SKILL" ]; then
   CONTENT=$(cat "$META_SKILL")
   # Use jq to properly escape and construct valid JSON
   jq -cn \
-    --arg message "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.
+    --arg context "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.
 
 $CONTENT" \
-    '{priority: "IMPORTANT", message: $message}'
+    '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $context}}'
 else
-  echo '{"priority": "INFO", "message": "agent-skills: using-agent-skills meta-skill not found. Skills may still be available individually."}'
+  echo '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "agent-skills: using-agent-skills meta-skill not found. Skills may still be available individually."}}'
 fi


### PR DESCRIPTION
Fixes #465.

## Problem

`hooks/session-start.sh` emits `{"priority": "IMPORTANT", "message": "..."}` on all three of its output paths. Codex CLI validates SessionStart hook output and hard-fails on that shape — the report in #465 shows `error: hook returned invalid session start JSON output` against the 0.6.6 plugin cache. The shape both Codex and Claude Code document for SessionStart is:

```json
{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}
```

The old `priority`/`message` shape isn't Claude Code's documented contract either — it only worked there because Claude Code is permissive about SessionStart stdout, so this is a strict improvement for both hosts rather than a Codex-specific branch.

## Change

One file. All three output paths now emit the standard envelope:

- meta-skill injection (built with `jq` for correct escaping, as before)
- `jq`-missing fallback (static JSON literal)
- meta-skill-missing fallback (static JSON literal)

No change to the hook's registration in `hooks/hooks.json`, its trigger conditions, or the injected content.

## Verification

Each path asserted with `jq -e '.hookSpecificOutput.hookEventName == "SessionStart" and (.hookSpecificOutput.additionalContext | type == "string" and length > 0)'`:

- happy path: run in place → envelope contains the meta-skill content
- `jq` missing: `PATH='' /bin/bash hooks/session-start.sh` → valid fallback envelope
- meta-skill missing: script copied outside the repo → valid fallback envelope
- `bash -n` clean

## Overlap check

#294 (hook hardening) touches only `sdd-cache-*.sh` and `simplify-ignore.sh`; no open PR touches `session-start.sh`. Grepped the repo for consumers of the old `priority`/`message` shape — the only occurrences were this script's own literals.