### PR TITLE
feat(spec): Phase 0 scope check — capability map for multi-capability requirements (#431)

### DIFF
--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -12,4 +12,6 @@ Begin by understanding what the user wants to build. Ask clarifying questions ab
 
 Then generate a structured spec covering all six core areas: objective, commands, project structure, code style, testing strategy, and boundaries.
 
+If the request bundles several independently testable capabilities, first propose a capability map (module ids, dependency direction, build order) per the skill's Phase 0 and get it approved, then spec each module in dependency order.
+
 Save the spec as SPEC.md in the project root and confirm with the user before proceeding.

--- a/.gemini/commands/spec.toml
+++ b/.gemini/commands/spec.toml
@@ -11,5 +11,7 @@ Begin by understanding what the user wants to build. Ask clarifying questions ab
 
 Then generate a structured spec covering all six core areas: objective, commands, project structure, code style, testing strategy, and boundaries.
 
+If the request bundles several independently testable capabilities, first propose a capability map (module ids, dependency direction, build order) per the skill's Phase 0 and get it approved, then spec each module in dependency order.
+
 Save the spec as SPEC.md in the project root and confirm with the user before proceeding.
 """

--- a/commands/spec.toml
+++ b/commands/spec.toml
@@ -11,5 +11,7 @@ Begin by understanding what the user wants to build. Ask clarifying questions ab
 
 Then generate a structured spec covering all six core areas: objective, commands, project structure, code style, testing strategy, and boundaries.
 
+If the request bundles several independently testable capabilities, first propose a capability map (module ids, dependency direction, build order) per the skill's Phase 0 and get it approved, then spec each module in dependency order.
+
 Save the spec as SPEC.md in the project root and confirm with the user before proceeding.
 """

--- a/evals/cases/spec-driven-development.json
+++ b/evals/cases/spec-driven-development.json
@@ -13,6 +13,14 @@
       {
         "prompt": "We are starting a new service, define the requirements first",
         "top_k": 3
+      },
+      {
+        "prompt": "This one requirement covers identity, billing, notifications, and reporting — decompose it into independently specifiable modules first",
+        "top_k": 3
+      },
+      {
+        "prompt": "Before we spec this platform, map the capabilities and their dependency order",
+        "top_k": 3
       }
     ],
     "negative": [
@@ -23,6 +31,10 @@
       {
         "prompt": "Simplify this clever one-liner into readable code",
         "owner": "code-simplification"
+      },
+      {
+        "prompt": "Break the approved spec into ordered implementation tasks",
+        "owner": "planning-and-task-breakdown"
       }
     ]
   },
@@ -38,6 +50,21 @@
         "The spec includes explicit boundaries and non-goals",
         "Ambiguities are surfaced as questions rather than silently resolved",
         "A testing strategy is part of the spec",
+        "No implementation code is written"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Read portal-brief.md and produce the spec work for the customer portal initiative.",
+      "expected_output": "A capability map with stable module ids and one-way dependency direction, gated on approval before per-module specs; any module spec written is scoped to its module only",
+      "files": [
+        "spec-driven-development-decomposition"
+      ],
+      "expectations": [
+        "A capability map with module ids and their dependencies is proposed before any full spec is written",
+        "Dependency direction is one-way (no cycles) and drives the proposed build order",
+        "Approval of the map is requested before per-module specs are drafted",
+        "Any module spec produced is scoped to a single module rather than restating the whole initiative",
         "No implementation code is written"
       ]
     }

--- a/evals/fixtures/spec-driven-development-decomposition/portal-brief.md
+++ b/evals/fixtures/spec-driven-development-decomposition/portal-brief.md
@@ -1,0 +1,22 @@
+# Customer portal — product brief
+
+Leadership wants a self-serve customer portal shipped as one initiative. The
+request, as handed down:
+
+- Customers sign in with email/password or company SSO and manage their
+  account and team members.
+- Customers pick a plan, enter payment details, and receive monthly invoices;
+  plan changes prorate.
+- Customers get email notifications for invoices, payment failures, and team
+  invitations; enterprise customers can register webhooks for the same events.
+- Admins see a usage dashboard: seats, API calls, and spend per month.
+
+Constraints gathered so far:
+
+- Billing must know who the customer is, so it depends on account data.
+- Notifications fire on billing and account events.
+- The dashboard reads from billing and notification delivery records.
+- The four areas have different reviewers: platform owns accounts, finance
+  owns billing, and growth owns notifications and the dashboard.
+- Each area should be shippable and verifiable on its own; finance wants to
+  sign off on billing without waiting for the dashboard.

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 # agent-skills session start hook
 # Injects the using-agent-skills meta-skill into every new session
+#
+# Every output path must emit the standard SessionStart envelope
+#   {"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}
+# Hosts that validate hook output (Codex CLI, Claude Code) reject other shapes.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$(dirname "$SCRIPT_DIR")/skills"
 META_SKILL="$SKILLS_DIR/using-agent-skills/SKILL.md"
 
 if ! command -v jq >/dev/null 2>&1; then
-  echo '{"priority": "INFO", "message": "agent-skills: jq is required for the session-start hook but was not found on PATH. Install jq (e.g. `brew install jq` or `apt-get install jq`) to enable meta-skill injection. Skills remain available individually."}'
+  echo '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "agent-skills: jq is required for the session-start hook but was not found on PATH. Install jq (e.g. `brew install jq` or `apt-get install jq`) to enable meta-skill injection. Skills remain available individually."}}'
   exit 0
 fi
 
@@ -15,10 +19,10 @@ if [ -f "$META_SKILL" ]; then
   CONTENT=$(cat "$META_SKILL")
   # Use jq to properly escape and construct valid JSON
   jq -cn \
-    --arg message "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.
+    --arg context "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.
 
 $CONTENT" \
-    '{priority: "IMPORTANT", message: $message}'
+    '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $context}}'
 else
-  echo '{"priority": "INFO", "message": "agent-skills: using-agent-skills meta-skill not found. Skills may still be available individually."}'
+  echo '{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "agent-skills: using-agent-skills meta-skill not found. Skills may still be available individually."}}'
 fi

--- a/skills/spec-driven-development/SKILL.md
+++ b/skills/spec-driven-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spec-driven-development
-description: Creates specs before coding. Use when starting a new project, feature, or significant change and no specification exists yet. Use when requirements are unclear, ambiguous, or only exist as a vague idea.
+description: Creates specs before coding. Use when starting a new project, feature, or significant change and no specification exists yet. Use when requirements are unclear, ambiguous, or only exist as a vague idea. Use when a single requirement spans several independently testable capabilities and needs decomposing into a capability map of modules before specifying.
 ---
 
 # Spec-Driven Development
@@ -21,7 +21,7 @@ Write a structured specification before writing any code. The spec is the shared
 
 ## The Gated Workflow
 
-Spec-driven development has four phases. Do not advance to the next phase until the current one is validated.
+Spec-driven development has four phases, preceded by a scope check (Phase 0) that activates only when one request bundles several independently testable capabilities. Do not advance to the next phase until the current one is validated.
 
 ```
 SPECIFY ──→ PLAN ──→ TASKS ──→ IMPLEMENT
@@ -30,6 +30,39 @@ SPECIFY ──→ PLAN ──→ TASKS ──→ IMPLEMENT
  Human      Human    Human      Human
  reviews    reviews  reviews    reviews
 ```
+
+### Phase 0: Scope Check
+
+Most requests describe one capability. If this one does, skip this phase and go straight to Specify — Phase 0 exists for the exception, not the rule, and it puts no hierarchy on single-capability features.
+
+**Detection.** Decompose before specifying when a single requirement bundles several independently testable capabilities:
+
+- The requirement names distinct capabilities with their own consumers or data (e.g. identity, billing, notifications, reporting)
+- Acceptance criteria cluster into groups that could ship and be verified separately
+- One capability could be cut or replaced without rewriting the others' requirements
+
+**Propose a capability map before writing any spec.** Small and reviewable — a module table plus a build order, not a project plan:
+
+```markdown
+# Capability Map: [Initiative Name]
+
+| Module id | Responsibility | Depends on |
+|---|---|---|
+| identity | Accounts, sessions, SSO | — |
+| billing | Plans, invoices, payments | identity |
+| notifications | Email and webhook fan-out | identity |
+| reporting | Usage dashboards | billing, notifications |
+
+Build order: identity → billing, notifications → reporting
+```
+
+- **Stable module ids.** Kebab-case, chosen once, never renamed mid-initiative. Specs, plans, and downstream commands select work by these ids instead of guessing which spec is active.
+- **Dependency direction, no cycles.** Arrows point one way. If two modules each need the other, they are one module.
+- **Interfaces live at the boundary.** The map records that `billing` depends on `identity`; the contract between them belongs in the provider module's spec (see `api-and-interface-design` for designing it).
+
+**The map is gated like every phase.** The human reviews module boundaries, dependency direction, and build order before any module spec is written. Getting the map wrong is expensive; reviewing ten lines is not.
+
+**Then recurse per module.** Run Specify → Plan → Tasks → Implement for each module in dependency order. Each module gets its own spec, scoped to that module's objective, boundaries, and success criteria. Save the approved map at the project root and each module's spec alongside it, named by module id (`SPEC-identity.md`, `SPEC-billing.md`) — the map, not filename guessing, is the index of what exists.
 
 ### Phase 1: Specify
 
@@ -186,6 +219,8 @@ The spec is a living document, not a one-time artifact:
 | "The spec will slow us down" | A 15-minute spec prevents hours of rework. Waterfall in 15 minutes beats debugging in 15 hours. |
 | "Requirements will change anyway" | That's why the spec is a living document. An outdated spec is still better than no spec. |
 | "The user knows what they want" | Even clear requests have implicit assumptions. The spec surfaces those assumptions. |
+| "It's one big feature; splitting it is overhead" | If acceptance criteria cluster into independently testable groups, a monolithic spec forces every downstream task to reason over the whole contract. A ten-line capability map is the cheap alternative. |
+| "I'll decompose during planning" | Planning slices tasks within a spec. By then the oversized artifact already exists — module boundaries and dependency direction must be decided before the spec is written, not after. |
 
 ## Red Flags
 
@@ -194,6 +229,8 @@ The spec is a living document, not a one-time artifact:
 - Implementing features not mentioned in any spec or task list
 - Making architectural decisions without documenting them
 - Skipping the spec because "it's obvious what to build"
+- One spec whose requirements span several independently testable capabilities
+- Module boundaries or build order decided implicitly during implementation because no capability map was approved up front
 
 ## Verification
 
@@ -204,3 +241,5 @@ Before proceeding to implementation, confirm:
 - [ ] Success criteria are specific and testable
 - [ ] Boundaries (Always/Ask First/Never) are defined
 - [ ] The spec is saved to a file in the repository
+- [ ] If the request bundles several independently testable capabilities, a capability map (module ids, dependency direction, build order) was approved before any module spec was written
+- [ ] Every module spec traces to a module id in the approved map


### PR DESCRIPTION
Implements #431 at the v1 scope set in the maintainer's comment there: extend `spec-driven-development` (no new skill), with a bounded front-step — **detect multi-capability scope, propose a capability map plus dependency direction, get human approval, then recurse per module** — and nothing more.

## What's added

**Phase 0: Scope Check** in `skills/spec-driven-development/SKILL.md`, before Phase 1:

- **Detection** — three concrete signals that one requirement bundles several independently testable capabilities (distinct consumers/data, acceptance criteria that cluster into separately shippable groups, a capability cuttable without rewriting the others).
- **Capability map** — a ten-line reviewable artifact: module table (stable kebab-case ids, responsibility, depends-on) plus a build order. Rules: ids are chosen once and never renamed; dependency direction is one-way with no cycles (mutual dependency ⇒ one module); interface contracts belong in the provider module's spec (referencing `api-and-interface-design` rather than duplicating it).
- **Approval gate** — the map is reviewed like every other phase before any module spec is written.
- **Recursion** — Specify → Plan → Tasks → Implement per module in dependency order, each module spec scoped to that module.

**Scope constraints honored** (the non-negotiables from the issue):

- The simple path is preserved and stated first: single-capability requests skip Phase 0 entirely; no hierarchy is forced on small features.
- No per-module artifact tree. Module specs reuse the root-level `SPEC-<id>.md` naming so the artifact layout **follows the delta-spec direction in #383 rather than leading it** — same convention, keyed by module id.
- Stable module identity is what downstream commands select by, instead of guessing which spec is active.

**Supporting edits:**

- Description gains the decomposition vocabulary (kept in what-then-"Use when…" format).
- The three `/spec` command wrappers (`.claude/commands/spec.md`, `commands/spec.toml`, `.gemini/commands/spec.toml`) gain one matching step, in parity.
- Rationalizations (+2), Red Flags (+2), Verification (+2) rows for the new failure modes.
- Eval case: **+2 positive triggers** (both rank #1), **+1 owner-negative** ("Break the approved spec into ordered implementation tasks" → `planning-and-task-breakdown` must outrank, guarding the decomposition/planning boundary), **+1 execution eval** backed by a new fixture (`evals/fixtures/spec-driven-development-decomposition/portal-brief.md`, a four-capability initiative with stated dependencies) whose expectations require the map before any spec, acyclic dependency direction, an approval gate, and module-scoped specs.

## Verification

- `node scripts/validate-skills.js` → 24/24 pass
- `node scripts/validate-commands.js` → 8/8 pass
- `node scripts/run-evals.js --min-rank1 80` → 127 checks, 0 errors, 0 warnings; rank-1 86% (67/78 — up 2 prompts, both new positives rank first); no new collision warnings
- `--behavioral spec-driven-development --dry-run` resolves both evals and the new fixture

## Sequencing

Three open PRs touch the spec description line or adjacent sections: #383 (spec evolution, mine), #434 (description vocabulary, mine), and this. The overlaps are one-line/append-only, so whichever lands first, I'll rebase the others the same day. Per the issue discussion, this PR is written to compose with #383: the map + `SPEC-<id>.md` naming slots into its conventions unchanged.

Closes #431.