### PR TITLE
feat: add a native Reasonix plugin adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ The first command registers the marketplace; the second installs the plugin. Cod
 <details>
 <summary><b>Reasonix</b></summary>
 
+Requires Reasonix v1.22.0 or newer. Earlier releases may import host-specific
+companion files that the native manifest intentionally excludes.
+
 Install as a native Reasonix plugin after inspecting the capability boundary:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -185,6 +185,24 @@ The first command registers the marketplace; the second installs the plugin. Cod
 </details>
 
 <details>
+<summary><b>Reasonix</b></summary>
+
+Install as a native Reasonix plugin after inspecting the capability boundary:
+
+```bash
+reasonix plugin install https://github.com/addyosmani/agent-skills.git --dry-run
+reasonix plugin install https://github.com/addyosmani/agent-skills.git --yes
+```
+
+The Reasonix adapter exports all 24 skills, 8 slash commands, and 4 specialist
+personas. It intentionally excludes the repository-scoped `CLAUDE.md`,
+lifecycle hooks, and MCP configuration. See
+[docs/reasonix-setup.md](docs/reasonix-setup.md) for requirements, local
+installation, usage, and the expected dry-run inventory.
+
+</details>
+
+<details>
 <summary><b>Command Code</b></summary>
 
 Install natively with the built-in `cmd skills` command. Command Code clones the repo, discovers every `SKILL.md`, and installs into `.commandcode/skills/`:
@@ -379,6 +397,7 @@ agent-skills/
 ├── .gemini/commands/                  # 8 slash commands (Gemini CLI)
 ├── commands/                          # 8 slash commands (Antigravity CLI)
 ├── plugin.json                        # Antigravity plugin manifest
+├── reasonix-plugin.json               # Reasonix plugin manifest
 └── docs/                              # Setup guides per tool
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ npx skills add addyosmani/agent-skills            # install all 24 skills
 npx skills add addyosmani/agent-skills --list     # browse before installing
 ```
 
+> **Using Reasonix?** Reasonix v1.22.0 or newer can install this repository as
+> a native plugin with all 24 skills, 8 slash commands, and 4 specialist
+> personas. See the [Reasonix setup guide](docs/reasonix-setup.md).
+
 Or grab individual skills:
 
 ```bash

--- a/docs/reasonix-setup.md
+++ b/docs/reasonix-setup.md
@@ -1,0 +1,64 @@
+# Using agent-skills with Reasonix
+
+This repository is also a native Reasonix plugin. The adapter exposes the
+reusable workflow assets without importing repository-maintenance instructions
+or lifecycle hooks.
+
+## Objective
+
+Make the same agent-skills package available in Reasonix with a small,
+auditable capability surface:
+
+- all skills under `skills/`
+- slash commands under `.claude/commands/`
+- specialist personas under `agents/`
+
+The root `CLAUDE.md`, `hooks/`, and MCP configuration are intentionally not
+part of the Reasonix adapter. They configure development of this repository or
+other host-specific lifecycle behavior rather than reusable Reasonix features.
+
+## Install
+
+Inspect the exact capability inventory before installing:
+
+```bash
+reasonix plugin install https://github.com/addyosmani/agent-skills.git --dry-run
+```
+
+The preview should report 24 skills, 8 commands, 4 agents, and no hooks or MCP
+servers. Install only after the preview matches that boundary:
+
+```bash
+reasonix plugin install https://github.com/addyosmani/agent-skills.git --yes
+```
+
+Local clones work too:
+
+```bash
+reasonix plugin install /path/to/agent-skills --dry-run
+reasonix plugin install /path/to/agent-skills --yes
+```
+
+Use a Reasonix build whose native v2 plugin manifests load only explicitly
+declared resources. If the preview discovers `CLAUDE.md` or any hook, stop and
+upgrade Reasonix before installing.
+
+## Usage
+
+After installation, start a new Reasonix session. Skills and commands use the
+package-qualified namespace, for example:
+
+```text
+/agent-skills:spec-driven-development
+/agent-skills:spec
+/agent-skills:agent:code-reviewer
+```
+
+Use `/plugins show agent-skills` to inspect the installed inventory.
+
+## Adapter contract
+
+`reasonix-plugin.json` is the single source of truth for Reasonix discovery.
+It declares only `skills`, `commands`, and `agents`; no compatibility fallback
+or install script is required. Release validation keeps its version aligned
+with the repository's other plugin manifests.

--- a/docs/reasonix-setup.md
+++ b/docs/reasonix-setup.md
@@ -19,6 +19,10 @@ other host-specific lifecycle behavior rather than reusable Reasonix features.
 
 ## Install
 
+Reasonix v1.22.0 or newer is required. Earlier releases may import
+host-specific companion files outside the explicit native v2 capability
+boundary, even when those resources are not declared in the manifest.
+
 Inspect the exact capability inventory before installing:
 
 ```bash
@@ -39,9 +43,8 @@ reasonix plugin install /path/to/agent-skills --dry-run
 reasonix plugin install /path/to/agent-skills --yes
 ```
 
-Use a Reasonix build whose native v2 plugin manifests load only explicitly
-declared resources. If the preview discovers `CLAUDE.md` or any hook, stop and
-upgrade Reasonix before installing.
+If the preview discovers the root `CLAUDE.md`, any hook, or any MCP server,
+stop and upgrade Reasonix before installing.
 
 ## Usage
 

--- a/reasonix-plugin.json
+++ b/reasonix-plugin.json
@@ -1,0 +1,13 @@
+{
+  "apiVersion": "reasonix.io/plugin/v2",
+  "name": "agent-skills",
+  "version": "0.6.6",
+  "description": "Production-grade engineering skills for AI coding agents — covering the full software development lifecycle from spec to ship.",
+  "homepage": "https://github.com/addyosmani/agent-skills",
+  "repository": "https://github.com/addyosmani/agent-skills",
+  "contributes": {
+    "skills": ["skills"],
+    "commands": [".claude/commands"],
+    "agents": ["agents"]
+  }
+}

--- a/scripts/validate-versions-test.js
+++ b/scripts/validate-versions-test.js
@@ -7,6 +7,7 @@ const test = require("node:test");
 
 const manifestPaths = [
   "plugin.json",
+  "reasonix-plugin.json",
   ".codex-plugin/plugin.json",
   ".claude-plugin/plugin.json",
   ".claude-plugin/marketplace.json",

--- a/scripts/validate-versions.js
+++ b/scripts/validate-versions.js
@@ -7,6 +7,7 @@ const { readFileSync } = require("node:fs");
 
 const manifestPaths = [
   "plugin.json",
+  "reasonix-plugin.json",
   ".codex-plugin/plugin.json",
   ".claude-plugin/plugin.json",
   ".claude-plugin/marketplace.json",


### PR DESCRIPTION
## Summary

- add a strict native Reasonix v2 manifest
- export all 24 Skills, 8 slash Commands, and 4 specialist Agents
- intentionally exclude repository-scoped `CLAUDE.md`, lifecycle Hooks, and MCP sidecars
- add Reasonix installation and usage documentation
- include the new manifest in release version validation

## Why

Reasonix can already consume the Codex manifest, but that path exposes only Skills and applies compatibility discovery to host-specific sidecars. The native adapter gives Reasonix users the full reusable workflow surface while keeping the installed capability boundary small and auditable.

## Capability boundary

The new `reasonix-plugin.json` declares only:

- `skills/`
- `.claude/commands/`
- `agents/`

It does not declare Hooks or MCP servers, and it does not import the root `CLAUDE.md`, which configures contributors working on this repository rather than consumers of the skill pack.

## Dependency

This adapter requires the explicit-resource semantics proposed in [esengine/DeepSeek-Reasonix#8077](https://github.com/esengine/DeepSeek-Reasonix/pull/8077). The setup guide tells users to stop if an older Reasonix dry-run discovers `CLAUDE.md` or Hooks.

## Verification

- 24 skill structure checks passed with zero warnings
- 8 command parity and description checks passed
- 20 validator tests passed
- 124 deterministic skill evaluation checks passed; rank-1 trigger rate: 86% (65/76)
- Reasonix dry-run reported 24 Skills, 8 Commands, 4 Agents, 0 Hooks, and 0 MCP servers
