### PR TITLE
docs(api): add idempotency-key implementation guidance to api-and-interface-design

### DIFF
--- a/skills/api-and-interface-design/SKILL.md
+++ b/skills/api-and-interface-design/SKILL.md
@@ -153,6 +153,67 @@ interface CreateTaskInput {
 | Boolean fields | is/has/can prefix | `isComplete`, `hasAttachments` |
 | Enum values | UPPER_SNAKE | `"IN_PROGRESS"`, `"COMPLETED"` |
 
+### 6. Honouring an Idempotency Key
+
+Accepting an `Idempotency-Key` is the contract. Honouring it is the implementation, and it is where the money is lost — a key the server accepts but handles carelessly is worse than no key at all, because the client now believes retrying is safe.
+
+**Derive the key from the intent, not the attempt.** The key must be stable across retries of one intent and different across distinct intents:
+
+```typescript
+crypto.randomUUID()                    // ✗ new key per attempt — every retry is a new charge
+`${userId}:${amount}`                  // ✗ two legitimate $50 charges collapse into one
+`${orderId}:${Date.now()}`             // ✗ a timestamp is randomUUID() wearing a hat
+
+req.headers['idempotency-key']         // ✓ client generates once, reuses on retry
+`charge:v1:${orderId}`                 // ✓ derived from an immutable identifier
+```
+
+The key comes from the client or the initiating event — never from the layer doing the retrying.
+
+**Claim atomically. A check followed by an act is a race:**
+
+```typescript
+// ✗ TOCTOU: two concurrent retries both read "not seen", both charge
+if (!(await db.exists(key))) {
+  await chargeCard(amount);
+  await db.insert(key);
+}
+
+// ✓ let the unique constraint pick the winner
+try {
+  await db.insert({ key, state: 'in_progress', requestHash });
+} catch (e) {
+  if (isUniqueViolation(e)) return replayOrReject(key);
+  throw;
+}
+const result = await chargeCard(amount);
+await db.update({ key, state: 'succeeded', response: result });
+```
+
+The unique constraint *is* the mechanism. A store that cannot enforce uniqueness in one operation cannot back this.
+
+**Guard the payload.** Same key with a different body is a client bug, and must fail loudly rather than serving the first response to a second request:
+
+```typescript
+if (existing.requestHash !== hash(req.body)) {
+  return res.status(422).json({ error: 'idempotency key reused with a different payload' });
+}
+```
+
+**Decide what an in-flight duplicate gets.** The first request is still running when the second arrives — the common case under retry storms:
+
+| Strategy | Response | Use when |
+|---|---|---|
+| Reject | `409 Conflict` | Client can retry later; simplest and safest |
+| Wait | Block for the result, bounded | Caller needs it synchronously |
+| Return pending | `202` + status URL | Long-running effects |
+
+Never let the second caller through because the first "seems stuck". A stalled attempt whose fate is unknown is exactly when duplicating costs most.
+
+**Every call has three outcomes, not two: success, failure, and _unknown_.** A timeout tells you nothing about whether the effect applied. Record the intent *before* calling out, so a crash between the call and the response leaves evidence something must resolve later — rather than a silently retried charge.
+
+**Set retention from the longest retry chain**, not from disk cost. Keys must outlive every path that can re-deliver the same intent, including a dead-letter queue replayed a week later and any provider dispute window. A 24-hour key TTL behind a 7-day DLQ is a duplicate waiting to happen.
+
 ## REST API Patterns
 
 ### Resource Design
@@ -270,6 +331,9 @@ function getTask(id: TaskId): Promise<Task> { ... }
 | "Nobody uses that undocumented behavior" | Hyrum's Law: if it's observable, somebody depends on it. Treat every public behavior as a commitment. |
 | "We can just maintain two versions" | Multiple versions multiply maintenance cost and create diamond dependency problems. Prefer the One-Version Rule. |
 | "Internal APIs don't need contracts" | Internal consumers are still consumers. Contracts prevent coupling and enable parallel work. |
+| "Accepting the Idempotency-Key header is enough" | The header is the contract; storing the key against the result is the implementation. A key you accept but don't honour tells the client retrying is safe when it isn't. |
+| "Our queue guarantees exactly-once delivery" | No queue does across a consumer crash — the broker's ack and your side effect are not in one transaction. Design for at-least-once with idempotent processing. |
+| "Duplicate requests are rare" | They're *correlated*. Retries spike exactly when a dependency is degraded — the moment duplicates are most likely and most expensive. |
 
 ## Red Flags
 
@@ -280,6 +344,10 @@ function getTask(id: TaskId): Promise<Task> { ... }
 - List endpoints without pagination
 - Verbs in REST URLs (`/api/createTask`, `/api/getUsers`)
 - Third-party API responses used without validation or sanitization
+- A `SELECT` for an idempotency key followed by an `INSERT` — that's a race, not a guard
+- An idempotency key derived from a UUID, timestamp, or anything else regenerated per attempt
+- The same key accepted with a different request body, silently returning the first response
+- A key retention window shorter than the longest path that can re-deliver the request
 
 ## Verification
 
@@ -292,3 +360,8 @@ After designing an API:
 - [ ] New fields are additive and optional (backward compatible)
 - [ ] Naming follows consistent conventions across all endpoints
 - [ ] API documentation or types are committed alongside the implementation
+- [ ] State-changing endpoints either honour an idempotency key or are documented as unsafe to retry
+- [ ] The key is claimed in one atomic operation, guarded by a unique constraint
+- [ ] A reused key with a different payload fails loudly rather than replaying the wrong response
+- [ ] The in-flight-duplicate response is a deliberate choice (409, wait, or 202) rather than whatever falls out
+- [ ] Key retention outlives the longest retry path, including dead-letter replay


### PR DESCRIPTION
Reworked as an addition to `api-and-interface-design`, per @addyosmani's review. One file, +73, no new skill.

## Where the seam is

#241 covers the **contract**: which methods are idempotent, accepting an `Idempotency-Key` header, replaying the stored result. This picks up where that stops — what the server has to *do* so the guarantee actually holds. A key you accept but handle carelessly is worse than no key, because the client now believes retrying is safe.

Added as `### 6. Honouring an Idempotency Key` under Core Principles:

- **Derive the key from the intent, not the attempt** — with the patterns that look right and aren't: `randomUUID()` per call, a timestamp, `user + amount`
- **Claim atomically** — a `SELECT` then an `INSERT` is a race; the unique constraint is the mechanism
- **Guard the payload** — same key, different body must fail loudly rather than replay the wrong response
- **Decide what an in-flight duplicate gets** — 409 / wait / 202, deliberately, rather than whatever falls out of the control flow
- **Unknown is a third outcome**, distinct from failure — record intent before calling out so a crash leaves evidence
- **Retention comes from the longest re-delivery path**, including DLQ replay, not from disk cost

Plus 3 rationalizations, 4 red flags and 5 verification items, so it's enforceable rather than advisory.

## On the overlap

You were right that a standalone skill was the wrong shape, and the repo's own tooling agreed more than I expected. When I ran the evals with the separate skill in place, its description **outranked `debugging-and-error-recovery` on that skill's own prompt** ("this test passed yesterday and fails today") — a false positive I couldn't tune away, because design-time failure analysis and diagnosing a live break genuinely share vocabulary.

Folding it in removes that entirely. Rank-1 routing goes from 85% to **86%**, better than either the baseline or the standalone version.

## Sequencing

#241 is still open and touches the same skill, though a different section — it adds an `### Idempotency` subsection under REST/HTTP semantics, and this sits in Core Principles. I've deliberately not touched the frontmatter description or the README row, since #241 already updates both.

If #241 lands first I'll rebase; if this lands first #241 should apply cleanly. Happy to reorder or to merge the two into one section if you'd rather have a single home for it — just say which.

```
node scripts/validate-skills.js          → 24 skills, 0 errors, 0 warnings
node scripts/validate-reference-links.js → 0 errors
node scripts/run-evals.js --min-rank1 80 → 124 checks, 0 errors, rank-1 86%
```

Thanks for the steer — the folded version is tighter than what I first sent.
