### PR TITLE
fix(hooks): support SessionStart on native Windows (#475)

### DIFF
--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -6,6 +6,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  test-windows-session-start-hook:
+    name: Test Windows session-start hook
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - run: node --test hooks/session-start-windows-test.js
+
   validate-skills:
     name: Validate skill content
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,18 +76,21 @@ We don't accept translations of the documentation (README, `docs/`) or of skills
 
 ## Testing Hooks
 
-The session-start hook (`hooks/session-start.sh`) injects the `using-agent-skills` meta-skill into every new Claude Code session. A regression test at `hooks/session-start-test.sh` validates the hook's JSON payload — both when `jq` is available and when it isn't.
+The session-start hooks (`hooks/session-start.sh` and `hooks/session-start.ps1`) inject the `using-agent-skills` meta-skill into every new session. Regression tests validate the JSON payload on POSIX and Windows, including the POSIX fallback when `jq` is not available.
 
 Run it before opening any PR that touches:
 
 - `hooks/session-start.sh`
+- `hooks/session-start.ps1`
+- `hooks/hooks.json`
 - `skills/using-agent-skills/SKILL.md` (the meta-skill content embedded by the hook)
 
 ```bash
 bash hooks/session-start-test.sh
+node --test hooks/session-start-windows-test.js
 ```
 
-Expected output: `session-start JSON payload OK`. The script exits non-zero on any assertion failure.
+Expected output: `session-start JSON payload OK` followed by passing Node test output. On non-Windows systems, the Node test still validates the hook configuration and skips the PowerShell runtime cases; CI runs those cases on Windows. Both commands exit non-zero on any assertion failure.
 
 ### Reproducing the no-jq fallback
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "SCRIPT=\"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"; [ -f \"$SCRIPT\" ] || SCRIPT=\"${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.sh\"; [ -f \"$SCRIPT\" ]&& bash \"$SCRIPT\" || true"
+            "command": "SCRIPT=\"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"; [ -f \"$SCRIPT\" ] || SCRIPT=\"${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.sh\"; [ -f \"$SCRIPT\" ]&& bash \"$SCRIPT\" || true",
+            "commandWindows": "powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"%CLAUDE_PLUGIN_ROOT%\\hooks\\session-start.ps1\""
           }
         ]
       }

--- a/hooks/session-start-windows-test.js
+++ b/hooks/session-start-windows-test.js
@@ -1,0 +1,92 @@
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '..');
+const hooksConfig = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'hooks.json'), 'utf8'),
+);
+const sessionStartHook = hooksConfig.hooks.SessionStart[0].hooks.find(
+  (hook) => hook.type === 'command',
+);
+
+test('SessionStart declares a native Windows PowerShell command', () => {
+  assert.ok(sessionStartHook, 'SessionStart command hook is missing');
+  assert.match(sessionStartHook.commandWindows, /powershell\.exe/i);
+  assert.match(sessionStartHook.commandWindows, /session-start\.ps1/i);
+  assert.doesNotMatch(sessionStartHook.commandWindows, /\b(?:bash|jq)\b/i);
+});
+
+function runWindowsHook({ includeMetaSkill }) {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'agent skills session hook '),
+  );
+
+  try {
+    const fixtureHooks = path.join(fixtureRoot, 'hooks');
+    fs.mkdirSync(fixtureHooks, { recursive: true });
+    fs.copyFileSync(
+      path.join(__dirname, 'session-start.ps1'),
+      path.join(fixtureHooks, 'session-start.ps1'),
+    );
+
+    if (includeMetaSkill) {
+      const fixtureMetaSkill = path.join(
+        fixtureRoot,
+        'skills',
+        'using-agent-skills',
+        'SKILL.md',
+      );
+      fs.mkdirSync(path.dirname(fixtureMetaSkill), { recursive: true });
+      fs.copyFileSync(
+        path.join(repoRoot, 'skills', 'using-agent-skills', 'SKILL.md'),
+        fixtureMetaSkill,
+      );
+    }
+
+    return execFileSync(
+      process.env.ComSpec || 'cmd.exe',
+      ['/d', '/s', '/c', sessionStartHook.commandWindows],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          CLAUDE_PLUGIN_ROOT: fixtureRoot,
+          CLAUDE_PROJECT_DIR: fixtureRoot,
+        },
+        input: '{}',
+      },
+    );
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+test(
+  'Windows SessionStart injects the meta-skill from a path containing spaces',
+  { skip: process.platform !== 'win32' },
+  () => {
+    const payload = JSON.parse(runWindowsHook({ includeMetaSkill: true }));
+    const output = payload.hookSpecificOutput;
+
+    assert.equal(output.hookEventName, 'SessionStart');
+    assert.match(output.additionalContext, /agent-skills loaded\./);
+    assert.match(output.additionalContext, /# Using Agent Skills/);
+    assert.match(output.additionalContext, /────────/);
+  },
+);
+
+test(
+  'Windows SessionStart exits cleanly when the meta-skill is missing',
+  { skip: process.platform !== 'win32' },
+  () => {
+    const payload = JSON.parse(runWindowsHook({ includeMetaSkill: false }));
+    const output = payload.hookSpecificOutput;
+
+    assert.equal(output.hookEventName, 'SessionStart');
+    assert.match(output.additionalContext, /meta-skill not found/);
+  },
+);

--- a/hooks/session-start.ps1
+++ b/hooks/session-start.ps1
@@ -1,0 +1,47 @@
+# agent-skills session start hook for native Windows
+# Injects the using-agent-skills meta-skill into every new session
+
+$ErrorActionPreference = 'Stop'
+
+# Windows PowerShell 5.1 otherwise uses the active console code page when stdout
+# is redirected, which can corrupt the Unicode flowchart in the meta-skill.
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+$OutputEncoding = [Console]::OutputEncoding
+
+function Write-HookPayload {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $AdditionalContext
+    )
+
+    $payload = [ordered]@{
+        hookSpecificOutput = [ordered]@{
+            hookEventName    = 'SessionStart'
+            additionalContext = $AdditionalContext
+        }
+    }
+
+    [Console]::Out.WriteLine(($payload | ConvertTo-Json -Compress))
+}
+
+try {
+    $pluginRoot = Split-Path -Parent $PSScriptRoot
+    $metaSkill = Join-Path $pluginRoot 'skills/using-agent-skills/SKILL.md'
+
+    if (Test-Path -LiteralPath $metaSkill -PathType Leaf) {
+        $content = [System.IO.File]::ReadAllText(
+            $metaSkill,
+            [System.Text.Encoding]::UTF8
+        )
+        $message = "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.`n`n$content"
+        Write-HookPayload -AdditionalContext $message
+    }
+    else {
+        Write-HookPayload `
+            -AdditionalContext 'agent-skills: using-agent-skills meta-skill not found. Skills may still be available individually.'
+    }
+}
+catch {
+    Write-HookPayload `
+        -AdditionalContext 'agent-skills: the session-start hook could not load the meta-skill. Skills remain available individually.'
+}


### PR DESCRIPTION
Fixes #475.

## Problem

The plugin only registers a POSIX SessionStart command. On native Windows, `bash.exe` can resolve to the WSL launcher and exit before the hook runs, while `jq` is not normally available. Codex then shows a startup hook failure and does not receive the `using-agent-skills` context.

## Change

- register a `commandWindows` override that uses the Windows PowerShell bundled with Windows
- add `hooks/session-start.ps1` with no Bash, WSL, `jq`, or third-party dependencies
- emit the standard `hookSpecificOutput.hookEventName/additionalContext` SessionStart envelope
- preserve UTF-8 when stdout is redirected, so the meta-skill flowchart is not corrupted
- add a `windows-latest` regression job that executes the configured command from a path containing spaces and checks clean missing-file fallback behavior
- document the Windows hook test alongside the existing POSIX test

## Relationship to #474

This is complementary to #474, not a duplicate. #474 updates the existing POSIX `session-start.sh` payload shape for #465. This PR leaves that file unchanged and adds the native Windows path requested by #475, while using the same standard SessionStart envelope.

## Verification

- `node --test hooks/session-start-windows-test.js`
- `bash hooks/session-start-test.sh`
- all 24 skill validations
- 32 script tests
- 124 skill eval checks
- command parity, artifact path, reference link, and manifest version validators
- `claude plugin validate .`

The PowerShell runtime cases are intentionally executed in GitHub Actions on `windows-latest`; non-Windows hosts still validate the hook registration statically.
