### PR TITLE
docs(antigravity): correct plugin install path

### DIFF
--- a/docs/antigravity-setup.md
+++ b/docs/antigravity-setup.md
@@ -25,7 +25,9 @@ agy plugin install https://github.com/addyosmani/agent-skills.git
    agy plugin install /path/to/agent-skills
    ```
 
-This will validate the plugin and install it into your global Antigravity configuration directory (`~/.gemini/antigravity-cli/plugins/agent-skills/`).
+This will validate the plugin and install it into your global Antigravity configuration directory (`~/.gemini/config/plugins/agent-skills/`).
+
+> **Note:** on current agy releases the plugin lands under `~/.gemini/config/plugins/`, not the legacy `~/.gemini/antigravity-cli/plugins/` path used by older versions. If you don't see the plugin at the legacy path, check `~/.gemini/config/plugins/agent-skills/` first.
 
 ### Option 2: Import from Gemini CLI
 


### PR DESCRIPTION
Partially addresses #445

## What changed

`docs/antigravity-setup.md` claimed the plugin installs to `~/.gemini/antigravity-cli/plugins/agent-skills/`, but the issue reporter confirmed that on current agy releases it actually lands in `~/.gemini/config/plugins/agent-skills/`. Updated the path and added a note so users look in the right place first.

## What this does NOT fix

The second half of #445 — the 8 slash commands not surfacing in the agy prompt box — needs reproduction with a real agy install (the plugin's `plugin validate` reports the TOML commands as processed, and `validate-commands.js` passes, so the files are well-formed; the disconnect is in how agy discovers them). I don't have agy available in my environment to reproduce, so I'm limiting this PR to the verifiable documentation fix rather than guessing at the command-discovery format.
