### PR TITLE
docs: distinguish project orchestration conventions from Claude Code subagent capabilities

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -18,8 +18,8 @@ In Claude Code, each call passes `subagent_type` matching the persona's `name` f
 
 In other harnesses without an Agent tool, invoke each persona's system prompt sequentially and treat their outputs as if returned in parallel — the merge phase still works.
 
-Constraints (from Claude Code's subagent model):
-- Subagents cannot spawn other subagents — do not let one persona delegate to another.
+Constraints (from this repository's orchestration model):
+- Subagents do not spawn other subagents — personas are single-level specialists and do not delegate to each other.
 - Each subagent gets its own context window and returns only its report to this main session.
 - If you need teammates that talk to each other instead of just reporting back, use Claude Code Agent Teams and reference these personas as teammate types (see `references/orchestration-patterns.md`).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ The only multi-persona orchestration pattern this repo endorses is **parallel fa
 
 See [docs/agents.md](docs/agents.md) for the decision matrix and [references/orchestration-patterns.md](references/orchestration-patterns.md) for the full pattern catalog.
 
-**Claude Code interop:** the personas in `agents/` work as Claude Code subagents (auto-discovered from this plugin's `agents/` directory) and as Agent Teams teammates (referenced by name when spawning). Two platform constraints align with our rules: subagents cannot spawn other subagents, and teams cannot nest. Plugin agents silently ignore the `hooks`, `mcpServers`, and `permissionMode` frontmatter fields.
+**Claude Code interop:** the personas in `agents/` work as Claude Code subagents (auto-discovered from this plugin's `agents/` directory) and as Agent Teams teammates (referenced by name when spawning). The repo convention that personas do not invoke other personas aligns with recommended orchestration boundaries; note that subagents can spawn nested subagents up to 5 levels deep in Claude Code when configured with the `Agent` tool, but this repo intentionally avoids nested persona trees. Plugin agents silently ignore the `hooks`, `mcpServers`, and `permissionMode` frontmatter fields.
 
 ## Creating a New Skill
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -99,7 +99,7 @@ Why this fails:
 ## Rules for personas
 
 1. A persona is a single role with a single output format. If you find yourself adding a second role, create a second persona.
-2. **Personas do not invoke other personas.** Composition is the job of slash commands or the user. On Claude Code this is also a hard platform constraint — *"subagents cannot spawn other subagents"* — so the rule is enforced for you.
+2. **Personas do not invoke other personas.** Composition is the job of slash commands or the user. While Claude Code supports subagent nesting when equipped with the `Agent` tool, this project enforces single-level orchestration (user/command → persona) to maintain clean context windows and avoid paraphrasing loss.
 3. A persona may invoke skills (the *how*).
 4. Every persona file ends with a "Composition" block stating where it fits.
 


### PR DESCRIPTION
Closes #377

### Summary of Changes
- Updated `AGENTS.md`, `docs/agents.md`, and `.claude/commands/ship.md` to clarify that avoiding nested persona trees is a project orchestration convention, rather than a hard platform limitation.
- Preserves the project's single-level orchestration rule (user/command → persona) while ensuring compatibility notes accurately reflect Claude Code subagent capabilities.