### PR TITLE
fix(planning): define a single pluggable task list target (#482)

### DIFF
--- a/skills/planning-and-task-breakdown/SKILL.md
+++ b/skills/planning-and-task-breakdown/SKILL.md
@@ -30,7 +30,7 @@ Before writing any code, operate in read-only mode:
 - Map dependencies between components
 - Note risks and unknowns
 
-**Do NOT write code during planning.** The output is a plan document saved to `tasks/plan.md` and a task list saved to `tasks/todo.md`, not implementation.
+**Do NOT write code during planning.** The output is a plan document saved to `tasks/plan.md` and a task list recorded in the task list target (see Output Files; default `tasks/todo.md`), not implementation.
 
 ### Step 2: Identify the Dependency Graph
 
@@ -78,7 +78,7 @@ Each vertical slice delivers working, testable functionality.
 
 ### Step 4: Write Tasks
 
-Each task follows this structure:
+Each task follows this structure, whether it lands in the markdown task list or as an item in an external tracker (see Output Files):
 
 ```markdown
 ## Task [N]: [Short descriptive title]
@@ -112,7 +112,7 @@ Arrange tasks so that:
 3. Verification checkpoints occur after every 2-3 tasks
 4. High-risk tasks are early (fail fast)
 
-Add explicit checkpoints:
+Add explicit checkpoints to the task list target:
 
 ```markdown
 ## Checkpoint: After Tasks 1-3
@@ -142,10 +142,19 @@ If a task is L or larger, it should be broken into smaller tasks. An agent perfo
 
 ## Output Files
 
-- **Plan document:** Save the implementation plan to `tasks/plan.md`.
-- **Task list:** Save the checklist-style task list to `tasks/todo.md`.
+- **Plan document:** Save the implementation plan to `tasks/plan.md`. This is always a markdown file — design decisions, risks, and open questions don't map cleanly onto individual tracker issues.
+- **Task list:** Record each task in the **task list target** (defined below).
 
-Create the `tasks/` directory if it does not exist. These paths are the convention expected by the `/build` command and other downstream tooling.
+Create the `tasks/` directory if it does not exist.
+
+### Task List Target
+
+The task list target is where tasks and checkpoints are recorded. It is defined once, here; every other reference in this skill defers to it.
+
+- **Default: a checklist-style markdown file at `tasks/todo.md`.** This is the convention the `/build` command and other downstream tooling expect. Use it unless the project says otherwise.
+- **External tracker:** if the project's agent rules (`CLAUDE.md`, `AGENTS.md`, etc.) or the user designate an issue tracker (e.g. GitHub Issues, Jira, Linear, `bd`/beads), create one tracker item per task instead of writing `tasks/todo.md`. Map the Step 4 structure onto the tracker's fields: acceptance criteria and verification steps in the item body, dependencies via the tracker's linking mechanism (`bd dep add`, "blocked by", etc.). Record Step 5 checkpoints as tracker items too, or as a checklist in the plan document if the tracker has no natural equivalent.
+
+When using an external tracker, note it in `tasks/plan.md` (e.g. "Tasks tracked in Linear project FOO") so downstream steps and future sessions know where to look, and keep the plan document's Task List section as an ordered index of tracker item IDs or links rather than a duplicate checklist.
 
 ## Plan Document Template
 
@@ -192,6 +201,8 @@ Create the `tasks/` directory if it does not exist. These paths are the conventi
 - [Question needing human input]
 ```
 
+When tasks live in an external tracker, keep the Task List section above as an ordered index of tracker item IDs or links instead of a duplicate checklist.
+
 ## Parallelization Opportunities
 
 When multiple agents or sessions are available:
@@ -212,6 +223,7 @@ When multiple agents or sessions are available:
 ## Red Flags
 
 - Starting implementation without a written task list
+- Writing `tasks/todo.md` when the project has designated an external tracker (or scattering tasks across both)
 - Tasks that say "implement the feature" without acceptance criteria
 - No verification steps in the plan
 - All tasks are XL-sized
@@ -225,6 +237,7 @@ Before starting implementation, confirm:
 - [ ] Every task has acceptance criteria
 - [ ] Every task has a verification step
 - [ ] Task dependencies are identified and ordered correctly
+- [ ] Tasks are recorded in the task list target (default `tasks/todo.md`)
 - [ ] No task touches more than ~5 files
 - [ ] Checkpoints exist between major phases
 - [ ] The human has reviewed and approved the plan

--- a/skills/spec-driven-development/SKILL.md
+++ b/skills/spec-driven-development/SKILL.md
@@ -140,7 +140,7 @@ With the validated spec, generate a technical implementation plan:
 
 > Follow `planning-and-task-breakdown` for the dependency-graph mapping and vertical-slicing mechanics behind these steps; it is the canonical source. The bullets above are a lightweight summary; if they ever diverge, `planning-and-task-breakdown` takes precedence.
 >
-> **Output convention:** Save the plan to `tasks/plan.md` and the task list to `tasks/todo.md`, per the `/plan` command convention. Create `tasks/` if it does not exist. Downstream commands (`/build`, etc.) expect these paths.
+> **Output convention:** Save the plan to `tasks/plan.md` and record the task list in the task list target defined by `planning-and-task-breakdown` (default `tasks/todo.md`; projects may designate an external tracker instead). Create `tasks/` if it does not exist. Downstream commands (`/build`, etc.) expect these defaults.
 
 The plan should be reviewable: the human should be able to read it and say "yes, that's the right approach" or "no, change X."
 


### PR DESCRIPTION
Resolves #482.

## Problem

`planning-and-task-breakdown` hardcoded its task-list output to `tasks/todo.md` in five scattered places (Step 1, Step 4's template intro, Step 5's checkpoint template, Output Files, and the Plan Document Template), and `spec-driven-development`'s Phase 2 output convention restated the same path. Projects that track tasks in an external tracker (bd/beads, Jira, Linear, GitHub Issues) had to hand-edit a local fork and keep every reference in sync — exactly the workaround described in #482.

## Approach

This takes the issue's minimal option — one named section the whole file defers to — plus a documented override convention:

- **New `Task List Target` section under Output Files** defines the destination once. The default is unchanged: a checklist-style `tasks/todo.md`, the convention `/build` and downstream tooling expect.
- **External tracker override:** if the project's agent rules (`CLAUDE.md`, `AGENTS.md`) or the user designate a tracker, the skill creates one tracker item per task instead — Step 4's structure maps onto the item body, dependencies onto the tracker's linking mechanism, and checkpoints onto tracker items or a plan-doc checklist. The plan doc notes where tasks live so downstream steps and future sessions can find them.
- **`tasks/plan.md` stays a markdown file regardless** — design decisions, risks, and open questions don't map cleanly onto individual issues (per the issue author's own workaround).
- All other references in the skill now defer to the target ("the task list target") instead of restating the path, so overriding means reading one section, not syncing five edits.
- `spec-driven-development`'s output convention line now points at that definition instead of duplicating it — addressing the comment on #482 that flagged the same hardcoding there.

## Deliberately out of scope

The command files (`.claude/commands/`, `.gemini/commands/`, `commands/`) keep referencing the default paths: the default behavior is unchanged, and their clean-baseline checks remain correct. If maintainers want the commands to acknowledge the tracker convention too, happy to follow up, but keeping this PR to the two skills keeps it reviewable and collision-free with in-flight work.

## Verification

- `node scripts/validate-skills.js` — 24 skills checked, 0 errors, 0 warnings
- `node scripts/run-evals.js` — 124 checks passed, trigger rank-1 rate 86% (unchanged)
- Default-path behavior is byte-for-byte the same convention, so existing fixtures and downstream `/build` expectations are unaffected