### PR TITLE
fix(evals): add missing owner to negative trigger tests

### DIFF
--- a/evals/cases/code-simplification.json
+++ b/evals/cases/code-simplification.json
@@ -17,7 +17,8 @@
     ],
     "negative": [
       {
-        "prompt": "Add a feature flag system to the app"
+        "prompt": "Add a feature flag system to the app",
+        "owner": "incremental-implementation"
       },
       {
         "prompt": "Diagnose why the build broke overnight",

--- a/evals/cases/deprecation-and-migration.json
+++ b/evals/cases/deprecation-and-migration.json
@@ -17,7 +17,8 @@
     ],
     "negative": [
       {
-        "prompt": "Add dark mode to the settings page"
+        "prompt": "Add dark mode to the settings page",
+        "owner": "frontend-ui-engineering"
       },
       {
         "prompt": "Why is this test flaky on CI?",

--- a/evals/cases/doubt-driven-development.json
+++ b/evals/cases/doubt-driven-development.json
@@ -20,7 +20,8 @@
         "prompt": "Format this file with prettier"
       },
       {
-        "prompt": "Write the changelog entry for the release"
+        "prompt": "Write the changelog entry for the release",
+        "owner": "git-workflow-and-versioning"
       }
     ]
   },

--- a/evals/cases/frontend-ui-engineering.json
+++ b/evals/cases/frontend-ui-engineering.json
@@ -29,7 +29,8 @@
         "owner": "performance-optimization"
       },
       {
-        "prompt": "Tag and publish the release"
+        "prompt": "Tag and publish the release",
+        "owner": "git-workflow-and-versioning"
       }
     ]
   },

--- a/evals/cases/planning-and-task-breakdown.json
+++ b/evals/cases/planning-and-task-breakdown.json
@@ -21,7 +21,8 @@
         "owner": "debugging-and-error-recovery"
       },
       {
-        "prompt": "Encode the output so it is safe against XSS"
+        "prompt": "Encode the output so it is safe against XSS",
+        "owner": "security-and-hardening"
       }
     ]
   },

--- a/evals/cases/using-agent-skills.json
+++ b/evals/cases/using-agent-skills.json
@@ -21,7 +21,8 @@
         "owner": "debugging-and-error-recovery"
       },
       {
-        "prompt": "Make the modal accessible for keyboard users"
+        "prompt": "Make the modal accessible for keyboard users",
+        "owner": "frontend-ui-engineering"
       }
     ]
   },


### PR DESCRIPTION
## What

Six negative-trigger prompts (across six `evals/cases/*.json` files) declared no `owner`. Per `evals/README.md`:

> Declare that skill in `owner` where you can: the runner then asserts the owner **outranks** this skill, turning the negative into a real pairwise routing test instead of one that can pass vacuously when the prompt matches nothing.

Without `owner`, these six negatives were passing vacuously instead of exercising a real pairwise routing assertion.

## Changes

Added `owner` for the prompts where a real, unambiguous owner exists, verified against `scripts/run-evals.js` to outrank the tested skill with a non-zero score:

| File | Negative prompt | Owner added |
|---|---|---|
| `code-simplification.json` | "Add a feature flag system to the app" | `incremental-implementation` |
| `deprecation-and-migration.json` | "Add dark mode to the settings page" | `frontend-ui-engineering` |
| `doubt-driven-development.json` | "Write the changelog entry for the release" | `git-workflow-and-versioning` |
| `frontend-ui-engineering.json` | "Tag and publish the release" | `git-workflow-and-versioning` |
| `planning-and-task-breakdown.json` | "Encode the output so it is safe against XSS" | `security-and-hardening` |
| `using-agent-skills.json` | "Make the modal accessible for keyboard users" | `frontend-ui-engineering` |

## Deliberately left untouched

Four other owner-less negatives weren't given an `owner`, because no skill in the catalog scores above zero against them under the current TF-IDF scorer — declaring one would either fail CI or force a misleading pick:

- `doubt-driven-development.json`: "Format this file with prettier"
- `git-workflow-and-versioning.json`: "Add a loading spinner to the submit button"
- `observability-and-instrumentation.json`: "Draft the PRD for the referral program"
- `shipping-and-launch.json`: "Why is this function so slow on large inputs?"

Happy to revisit these if there's appetite for enriching the relevant skill descriptions so the scorer can pick up a genuine match, but that felt like a separate, larger change.

## Verification

```
node scripts/run-evals.js
# 127 checks passed — 0 error(s), 0 warning(s)
# trigger rank-1 rate: 86% (67/78 positive prompts rank their skill first)
# PASSED

node scripts/validate-commands.js
# 8 commands checked — 0 error(s) — PASSED
```

Checked against every currently open PR touching `evals/cases/` for overlap — none of the six files above are touched by an open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)