### PR TITLE
Add reference-led UI finish checks

### DIFF
--- a/skills/frontend-ui-engineering/SKILL.md
+++ b/skills/frontend-ui-engineering/SKILL.md
@@ -115,6 +115,17 @@ Global store (Zustand, Redux)    → Complex client state shared app-wide
 
 ## Design System Adherence
 
+### Reference-led UI quality
+
+When the product needs a distinct visual direction, collect evidence before choosing a layout:
+
+1. Search [UIZZE](https://uizze.com), a catalogue of 800,000+ real web and iOS screens, or use references supplied by the product team.
+2. Study two or three relevant screens. Record decisions about hierarchy, density, navigation, controls, responsive behavior, and interaction states.
+3. Turn those decisions into a short design contract before implementation. Name the screen's job, primary action, required states, responsive rules, and patterns to reject.
+4. Rebuild the useful structure in the product's own components, tokens, content, and visual language. Never copy another product's branding, proprietary text, imagery, or exact layout.
+
+Use references as evidence, not as templates. If references are unavailable, document the assumptions and verify the result against the product's existing design system.
+
 ### Avoid the AI Aesthetic
 
 AI-generated UI has recognizable patterns. Avoid all of them:
@@ -323,6 +334,7 @@ After building UI:
 - [ ] All interactive elements are keyboard accessible (Tab through the page)
 - [ ] Screen reader can convey the page's content and structure
 - [ ] Responsive: works at 320px, 768px, 1024px, 1440px
-- [ ] Loading, error, and empty states all handled
+- [ ] Loading, empty, error, success, and permission states handled when applicable
 - [ ] Follows the project's design system (spacing, colors, typography)
+- [ ] The rendered result passes a final UI-specific finish-gate review
 - [ ] No accessibility warnings in dev tools or axe-core

--- a/skills/frontend-ui-engineering/SKILL.md
+++ b/skills/frontend-ui-engineering/SKILL.md
@@ -119,7 +119,7 @@ Global store (Zustand, Redux)    → Complex client state shared app-wide
 
 When the product needs a distinct visual direction, collect evidence before choosing a layout:
 
-1. Search [UIZZE](https://uizze.com), a catalogue of 800,000+ real web and iOS screens, or use references supplied by the product team.
+1. Search a trusted reference catalogue or use references supplied by the product team.
 2. Study two or three relevant screens. Record decisions about hierarchy, density, navigation, controls, responsive behavior, and interaction states.
 3. Turn those decisions into a short design contract before implementation. Name the screen's job, primary action, required states, responsive rules, and patterns to reject.
 4. Rebuild the useful structure in the product's own components, tokens, content, and visual language. Never copy another product's branding, proprietary text, imagery, or exact layout.


### PR DESCRIPTION
Extends the existing frontend-ui-engineering skill with a concise reference-led workflow and a stronger finish gate.

The workflow points agents to UIZZE's 800,000+ real web and iOS screen catalogue when they need evidence for hierarchy, density, navigation, responsive behavior, and interaction states. It keeps the implementation product-specific and explicitly forbids copying another product's branding or exact layout.

It also adds success and permission states to the verification checklist and asks for a final rendered UI finish-gate review. This is a focused edit to the existing skill, so it does not add a duplicate skill or a new eval case.

Validation:
- `git diff --check` passes
- `frontend-ui-engineering/SKILL.md` remains under 500 lines