### PR TITLE
fix(interview-me): enforce terminal turn stop rule upon intent confirmation

### DIFF
--- a/skills/interview-me/SKILL.md
+++ b/skills/interview-me/SKILL.md
@@ -126,7 +126,7 @@ If they correct you, fold the correction in and restate. Loop until you get an e
 When the user confirms the statement of intent with an explicit "yes":
 
 1. **Deliver the confirmed Statement of Intent.**
-2. **Offer downstream paths** (saving to `docs/intent/[topic].md`, drafting a spec with `spec-driven-development`, or moving to task planning).
+2. **Offer downstream paths** (offer to save it to `docs/intent/[topic].md`, draft a spec with `spec-driven-development`, or move to task planning *after* the spec).
 3. **STOP YOUR TURN IMMEDIATELY.** Do NOT invoke any tools (`run_command`, `write_to_file`, directory listings, or planning tools) in this turn. Hand control back to the user to choose the downstream path.
 
 ### The 95% Confidence Stop

--- a/skills/interview-me/SKILL.md
+++ b/skills/interview-me/SKILL.md
@@ -126,8 +126,8 @@ If they correct you, fold the correction in and restate. Loop until you get an e
 When the user confirms the statement of intent with an explicit "yes":
 
 1. **Deliver the confirmed Statement of Intent.**
-2. **Offer downstream paths** (offer to save it to `docs/intent/[topic].md`, draft a spec with `spec-driven-development`, or move to task planning *after* the spec).
-3. **STOP YOUR TURN IMMEDIATELY.** Do NOT invoke any tools (`run_command`, `write_to_file`, directory listings, or planning tools) in this turn. Hand control back to the user to choose the downstream path.
+2. **Offer downstream paths** (offer to save it to `docs/intent/[topic].md`, draft a spec with `spec-driven-development`, or move to task planning after the spec).
+3. **STOP YOUR TURN IMMEDIATELY.** Do NOT invoke tools or start downstream work in this turn. Hand control back to the user to choose the next step.
 
 ### The 95% Confidence Stop
 
@@ -142,8 +142,6 @@ This is a checkable test, not a vibe. It also has a floor: if you've gone severa
 ## Output
 
 The output of this skill is a **confirmed statement of intent**: the restate from Step 4, with an explicit yes from Step 5. That's the deliverable. Specs, plans, and task lists are downstream; they consume the intent this skill produces.
-
-When intent is confirmed, the turn ends. Do not begin downstream work (research, planning, file generation, or tool execution) in the same turn.
 
 If the user wants the intent to persist (a multi-session project, a handoff to another collaborator), offer to save it to `docs/intent/[topic].md`. Only save if they confirm.
 
@@ -214,7 +212,7 @@ Two questions in, the agent has discovered the actual ask isn't "a dashboard." I
 - A question without your hypothesis attached: that's surveying, not committing
 - Accepting "whatever you think is best" as a terminal answer
 - Producing a spec, plan, or task list before the user has explicitly confirmed your restate
-- Calling ANY tool (shell commands, file modifications, planning tools) immediately upon intent confirmation instead of stopping the turn
+- Invoking tools or starting downstream work immediately upon intent confirmation instead of stopping the turn
 - Questions framed as "what would be best practice?" instead of "what do you actually want?"
 - The user gives a sophistication-signaling answer ("scalable", "clean", "modern") and you accept it without probing whether it's what they actually want
 - Three or more rounds without your confidence visibly rising: you're asking the wrong questions, step back and reframe
@@ -233,5 +231,5 @@ After applying interview-me:
 - [ ] A concrete restate (Outcome / User / Why now / Success / Constraint / Out of scope) was written back to the user
 - [ ] The user confirmed the restate with an explicit yes (not "whatever you think," not "sounds good," not silence)
 - [ ] At the stop point, the agent could predict reactions to the next three questions it would ask
-- [ ] Upon receiving explicit confirmation, stopped the turn immediately without calling tools or starting downstream execution
+- [ ] Upon receiving explicit confirmation, stopped the turn immediately without invoking tools or starting downstream work
 - [ ] Any handoff to a downstream skill (`idea-refine`, `spec-driven-development`) was framed in terms of the confirmed intent, not the original underspecified ask

--- a/skills/interview-me/SKILL.md
+++ b/skills/interview-me/SKILL.md
@@ -121,6 +121,14 @@ The gate is an explicit "yes." The following are **not** yes:
 
 If they correct you, fold the correction in and restate. Loop until you get an explicit yes.
 
+### Step 6: Terminal Turn & Stop Rule (CRITICAL)
+
+When the user confirms the statement of intent with an explicit "yes":
+
+1. **Deliver the confirmed Statement of Intent.**
+2. **Offer downstream paths** (saving to `docs/intent/[topic].md`, drafting a spec with `spec-driven-development`, or moving to task planning).
+3. **STOP YOUR TURN IMMEDIATELY.** Do NOT invoke any tools (`run_command`, `write_to_file`, directory listings, or planning tools) in this turn. Hand control back to the user to choose the downstream path.
+
 ### The 95% Confidence Stop
 
 You're done when you can answer yes to this:
@@ -134,6 +142,8 @@ This is a checkable test, not a vibe. It also has a floor: if you've gone severa
 ## Output
 
 The output of this skill is a **confirmed statement of intent**: the restate from Step 4, with an explicit yes from Step 5. That's the deliverable. Specs, plans, and task lists are downstream; they consume the intent this skill produces.
+
+When intent is confirmed, the turn ends. Do not begin downstream work (research, planning, file generation, or tool execution) in the same turn.
 
 If the user wants the intent to persist (a multi-session project, a handoff to another collaborator), offer to save it to `docs/intent/[topic].md`. Only save if they confirm.
 
@@ -204,6 +214,7 @@ Two questions in, the agent has discovered the actual ask isn't "a dashboard." I
 - A question without your hypothesis attached: that's surveying, not committing
 - Accepting "whatever you think is best" as a terminal answer
 - Producing a spec, plan, or task list before the user has explicitly confirmed your restate
+- Calling ANY tool (shell commands, file modifications, planning tools) immediately upon intent confirmation instead of stopping the turn
 - Questions framed as "what would be best practice?" instead of "what do you actually want?"
 - The user gives a sophistication-signaling answer ("scalable", "clean", "modern") and you accept it without probing whether it's what they actually want
 - Three or more rounds without your confidence visibly rising: you're asking the wrong questions, step back and reframe
@@ -222,4 +233,5 @@ After applying interview-me:
 - [ ] A concrete restate (Outcome / User / Why now / Success / Constraint / Out of scope) was written back to the user
 - [ ] The user confirmed the restate with an explicit yes (not "whatever you think," not "sounds good," not silence)
 - [ ] At the stop point, the agent could predict reactions to the next three questions it would ask
+- [ ] Upon receiving explicit confirmation, stopped the turn immediately without calling tools or starting downstream execution
 - [ ] Any handoff to a downstream skill (`idea-refine`, `spec-driven-development`) was framed in terms of the confirmed intent, not the original underspecified ask


### PR DESCRIPTION
## Summary
Prevents proactive agent momentum from overshooting the interview lifecycle boundary when the user provides an explicit intent confirmation.

### Motivation
Across frontier models (Claude 3.5/3.7, GPT-4o, Gemini 3.7), agentic post-training strongly biases agents toward proactivity. When a user replies with an explicit "yes" confirming the restated Statement of Intent, agents frequently misinterpret the confirmation as a green light to immediately start running environment commands, inspecting codebases, drafting task plans, or writing implementation code in the same turn, bypassing the user's decision on downstream direction.

### Changes
- Added **Step 6: Terminal Turn & Stop Rule (CRITICAL)** instructing agents to deliver the confirmed Statement of Intent and immediately stop the turn without calling tools.
- Clarified under **Output** that the turn ends upon intent confirmation and downstream work must not start in the same turn.
- Added a new item under **Red Flags** for calling any tool (commands, file modifications, planning tools) immediately after intent confirmation.
- Added a **Verification** checklist item ensuring the turn was stopped immediately without tool invocations.