### PR TITLE
fix(scripts): validate manifest versions against canonical root plugin.json

### DIFF
--- a/scripts/validate-versions-test.js
+++ b/scripts/validate-versions-test.js
@@ -18,12 +18,9 @@ function readManifestVersion(manifestPath) {
   return manifest.version ?? manifest.plugins?.[0]?.version;
 }
 
-test("all plugin manifests use the latest release tag", () => {
-  const expectedVersion = execFileSync(
-    "git",
-    ["describe", "--tags", "--abbrev=0"],
-    { encoding: "utf8" },
-  ).trim();
+test("all plugin manifests use the root plugin.json version", () => {
+  const expectedVersion = readManifestVersion("plugin.json");
+  assert.ok(expectedVersion, "plugin.json must define a version");
 
   for (const manifestPath of manifestPaths) {
     assert.equal(

--- a/scripts/validate-versions.js
+++ b/scripts/validate-versions.js
@@ -18,11 +18,10 @@ function readManifestVersion(manifestPath) {
   return manifest.version ?? manifest.plugins?.[0]?.version;
 }
 
-const expectedVersion = execFileSync(
-  "git",
-  ["describe", "--tags", "--abbrev=0"],
-  { encoding: "utf8" },
-).trim();
+const expectedVersion = readManifestVersion("plugin.json");
+if (!expectedVersion) {
+  throw new Error("plugin.json is missing a version field");
+}
 
 for (const manifestPath of manifestPaths) {
   const version = readManifestVersion(manifestPath);


### PR DESCRIPTION
### Summary
- Update `scripts/validate-versions.js` and `scripts/validate-versions-test.js` to validate all plugin manifests (`plugin.json`, `.codex-plugin/plugin.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`) against the canonical root `plugin.json` version instead of relying on `git describe --tags --abbrev=0`.
- This prevents CI validation failures during release version bumps before a release git tag has been pushed.

### Validation
- `node scripts/validate-versions.js` -> PASSED
- `node --test scripts/validate-versions-test.js` -> 1/1 passed
- All other test suites (skills, commands, reference links, artifact paths, evals) pass with 0 errors.