### PR TITLE
Add pull-request vocabulary to git-workflow-and-versioning description

### DIFF
--- a/evals/cases/git-workflow-and-versioning.json
+++ b/evals/cases/git-workflow-and-versioning.json
@@ -13,6 +13,10 @@
       {
         "prompt": "How should we tag and version this release?",
         "top_k": 3
+      },
+      {
+        "prompt": "Commit this work and open a pull request",
+        "top_k": 3
       }
     ],
     "negative": [

--- a/skills/git-workflow-and-versioning/SKILL.md
+++ b/skills/git-workflow-and-versioning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow-and-versioning
-description: Structures git workflow practices. Use when making any code change. Use when committing, branching, resolving conflicts, or when you need to organize work across multiple parallel streams. Use when cutting a release, choosing a semantic version bump, tagging, or writing a changelog.
+description: Structures git workflow practices. Use when making any code change. Use when committing, branching, resolving conflicts, opening or reviewing a pull request (PR), pushing to a remote, or when you need to organize work across multiple parallel streams. Use when cutting a release, choosing a semantic version bump, tagging, or writing a changelog.
 ---
 
 # Git Workflow and Versioning


### PR DESCRIPTION
## What

Adds "opening or reviewing a pull request (PR), pushing to a remote" to the `git-workflow-and-versioning` frontmatter description, plus a trigger case covering it.

## Why

The skill body already treats pull requests as in scope:

- "Each type of change should be a separate commit — and ideally a separate PR"
- "Target ~100 lines per commit/PR"

But the description never contains the words "pull request" or "PR", and none of the existing trigger cases use them. So a prompt like *"Commit this work and open a pull request"* — probably one of the most common ways this skill gets reached for — doesn't rank it first, and the eval suite can't see the gap because no case tests for it.

I noticed this while running a lexical routing check over a mixed corpus of local and built-in skills: the git skill lost that prompt to an unrelated code-review skill. It reproduces here against this repo's own Tier-2 eval.

## Evidence

`node scripts/run-evals.js`:

| | rank-1 rate | |
|---|---|---|
| baseline, unmodified | 86% | 67/78 |
| new trigger case added, description unchanged | 85% | 67/79 |
| new trigger case + description fix | 86% | 68/79 |

The middle row is the point: adding the case moves the denominator but not the numerator, so the skill demonstrably does not rank first for a PR prompt. The third row shows the description change fixing exactly that, with no other case changing rank.

`node scripts/validate-skills.js` — 24 skills checked, 0 errors, 0 warnings. YAML frontmatter valid.

## Scope

Two files, 5 insertions, 1 deletion. No structural or tonal changes, no version bump, no changes to the meta-skill or hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
