### PR TITLE
test(hooks): assert SessionStart hookSpecificOutput envelope

### DIFF
--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -41,12 +41,7 @@ jobs:
         run: node --test scripts/validate-reference-links-test.js
 
       - name: Test session-start hook payload
-        run: |
-          if ! command -v jq >/dev/null 2>&1; then
-            echo "jq not found; skipping session-start hook test"
-            exit 0
-          fi
-          bash hooks/session-start-test.sh
+        run: bash hooks/session-start-test.sh
 
   validate-commands:
     name: Validate command parity and description sync

--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -40,6 +40,14 @@ jobs:
       - name: Test reference-link validator
         run: node --test scripts/validate-reference-links-test.js
 
+      - name: Test session-start hook payload
+        run: |
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "jq not found; skipping session-start hook test"
+            exit 0
+          fi
+          bash hooks/session-start-test.sh
+
   validate-commands:
     name: Validate command parity and description sync
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Expected output: `session-start JSON payload OK`. The script exits non-zero on a
 
 ### Reproducing the no-jq fallback
 
-The hook gracefully degrades to an `INFO`-priority payload when `jq` isn't on `PATH`. To exercise that branch locally, strip `jq`'s directory from `PATH` for the test invocation:
+The hook still emits the same `hookSpecificOutput` envelope when `jq` isn't on `PATH`, with `additionalContext` explaining that `jq` is required. To exercise that branch locally, strip `jq`'s directory from `PATH` for the test invocation:
 
 ```bash
 JQ_DIR=$(dirname "$(command -v jq)")
@@ -101,7 +101,7 @@ PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "^${JQ_DIR}$" | tr '\n' ':' | sed 's
 
 This works cleanly when `jq` lives in its own directory (e.g. `/opt/homebrew/bin` from Homebrew, `/usr/local/bin` from a manual install). If your `jq` shares a system bin with other tools the test depends on (such as `mktemp` in `/usr/bin`), the simpler approach is to install `jq` via a separate package manager so it has its own bin directory, then re-run.
 
-The hook's `command -v jq` check fails under the stripped `PATH`, the `INFO`-priority fallback runs, and the test asserts the `jq is required` guidance message instead of the normal payload.
+The hook's `command -v jq` check fails under the stripped `PATH`, the jq-missing fallback runs, and the test asserts the `jq is required` guidance in `additionalContext` instead of the meta-skill body.
 
 ## Reporting Issues
 

--- a/hooks/session-start-test.sh
+++ b/hooks/session-start-test.sh
@@ -19,27 +19,28 @@ const fs = require('fs');
 
 const payload = JSON.parse(fs.readFileSync(process.env.PAYLOAD_PATH, 'utf8'));
 const hasJq = process.env.HAS_JQ === '1';
+const out = payload.hookSpecificOutput;
 
+if (!out || typeof out !== 'object') {
+  throw new Error('payload is missing hookSpecificOutput (hosts reject other shapes)');
+}
+if (out.hookEventName !== 'SessionStart') {
+  throw new Error(`expected hookEventName SessionStart, got ${out.hookEventName}`);
+}
+if (typeof out.additionalContext !== 'string' || !out.additionalContext.trim()) {
+  throw new Error('additionalContext must be a non-empty string');
+}
+
+const ctx = out.additionalContext;
 if (hasJq) {
-  if (payload.priority !== 'IMPORTANT') {
-    throw new Error(`expected IMPORTANT priority, got ${payload.priority}`);
+  if (!ctx.includes('agent-skills loaded.')) {
+    throw new Error('additionalContext is missing startup preface');
   }
-
-  if (!payload.message.includes('agent-skills loaded.')) {
-    throw new Error('message is missing startup preface');
+  if (!ctx.includes('# Using Agent Skills')) {
+    throw new Error('additionalContext is missing using-agent-skills content');
   }
-
-  if (!payload.message.includes('# Using Agent Skills')) {
-    throw new Error('message is missing using-agent-skills content');
-  }
-} else {
-  if (payload.priority !== 'INFO') {
-    throw new Error(`expected INFO priority when jq is missing, got ${payload.priority}`);
-  }
-
-  if (!payload.message.includes('jq is required')) {
-    throw new Error('message is missing jq fallback guidance');
-  }
+} else if (!ctx.includes('jq is required')) {
+  throw new Error('additionalContext is missing jq fallback guidance');
 }
 
 console.log('session-start JSON payload OK');


### PR DESCRIPTION
## Problem

`hooks/session-start-test.sh` still asserts the pre-#474 payload shape (`priority` / `message`). After #474 the hook emits the host-required envelope:

```json
{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"..."}}
```

On current `main`, `bash hooks/session-start-test.sh` fails immediately:

```
Error: expected IMPORTANT priority, got undefined
```

CONTRIBUTING.md still tells contributors to run that test before any hook PR, so the documented regression check is red on a clean checkout. Hosts that validate hook output (Codex CLI, Claude Code) already reject the old shape; the test was the leftover.

## Root cause

#474 updated `session-start.sh` (and the no-jq fallback) to `hookSpecificOutput` so hosts stop rejecting the hook. `session-start-test.sh` and the CONTRIBUTING wording about an `INFO`-priority payload were not moved with it. Sibling: the jq-missing path uses the same envelope with different `additionalContext`; it was also untested against the new shape.

This is not a Windows SessionStart fix (#475 / PR #480) and does not change hook runtime.

## Fix

- Assert `hookSpecificOutput.hookEventName === "SessionStart"` and a non-empty `additionalContext`.
- With jq: require the startup preface and `# Using Agent Skills` in `additionalContext`.
- Without jq: require the `jq is required` guidance in `additionalContext`.
- CONTRIBUTING.md: describe the envelope fallback, not `INFO`-priority.

## Verification

```
$ bash hooks/session-start-test.sh
session-start JSON payload OK
```

jq-missing path (jq hidden from PATH) also prints `session-start JSON payload OK`.

Sabotage: restoring the old `payload.priority !== 'IMPORTANT'` assertion on this branch fails with `got undefined`.

## Risks

None to runtime. If a host still consumed `{priority, message}`, that already broke in #474; this only makes the test match what hosts accept.