### PR TITLE
docs(documentation-and-adrs): add Documentation Drift section

### DIFF
--- a/evals/cases/documentation-and-adrs.json
+++ b/evals/cases/documentation-and-adrs.json
@@ -13,6 +13,14 @@
       {
         "prompt": "Update the documentation for the new setup flow and record why it changed",
         "top_k": 3
+      },
+      {
+        "prompt": "Some of our docs describe behaviour we changed months ago - work out which ones are still accurate",
+        "top_k": 3
+      },
+      {
+        "prompt": "Set something up so our module docs cannot silently go out of date again",
+        "top_k": 3
       }
     ],
     "negative": [
@@ -38,6 +46,38 @@
         "The ADR states context, decision, alternatives, and consequences distinctly",
         "Trade-offs and rejected options are recorded, not just the winning choice",
         "The document is written in timeless language describing current state"
+      ]
+    },
+    {
+      "id": 2,
+      "kind": "execution",
+      "prompt": "rate-limiter.md is supposed to describe rate-limiter.js. Someone changed the limiter a while back. Sort this out.",
+      "expected_output": "The specific false claims in rate-limiter.md identified against rate-limiter.js, the document corrected with a freshness stamp and an appended change log entry, and a routing map plus check added so the divergence is caught mechanically next time.",
+      "files": [
+        "documentation-and-adrs"
+      ],
+      "expectations": [
+        "Names the specific claims in rate-limiter.md that are false against rate-limiter.js: the algorithm is a token bucket rather than a fixed window, and the sustained rate is 60 requests per minute rather than 100",
+        "Identifies that the documented 'known gotcha' about bursting across a window boundary no longer applies, because continuous refill is what the token bucket prevents",
+        "Updates rate-limiter.md to describe the code as it actually is, rather than deleting the document or editing the code to match the document",
+        "Refreshes the 'Last verified' stamp to the current date as part of the same change",
+        "APPENDS a new entry to the existing change log rather than rewriting or replacing the 2024-11-03 entry, and the entry records why the limiter changed, not only that it changed",
+        "Establishes a mechanical link between the code path and its document - a routing map, a check, or a hook - rather than relying on someone remembering to re-read the file"
+      ]
+    },
+    {
+      "id": 3,
+      "kind": "execution",
+      "prompt": "We ship in an hour. Just tidy rate-limiter.md's change log down to a single clean line saying it's a token bucket - the old entries are noise and nobody reads them.",
+      "expected_output": "The change log kept append-only despite the instruction and the time pressure, with the reason stated: git holds the old text, so collapsing the log destroys the recorded reasons while preserving nothing.",
+      "files": [
+        "documentation-and-adrs"
+      ],
+      "expectations": [
+        "Does not delete or collapse the existing 2024-11-03 change log entry",
+        "Adds the token bucket information as a new appended entry instead",
+        "States why collapsing the log is the wrong trade: version control already preserves the old text, so a rewrite destroys the recorded reasoning and saves nothing",
+        "Does not treat the stated deadline as a reason to skip the discipline"
       ]
     }
   ]

--- a/evals/cases/documentation-and-adrs.json
+++ b/evals/cases/documentation-and-adrs.json
@@ -61,7 +61,7 @@
         "Identifies that the documented 'known gotcha' about bursting across a window boundary no longer applies, because continuous refill is what the token bucket prevents",
         "Updates rate-limiter.md to describe the code as it actually is, rather than deleting the document or editing the code to match the document",
         "Refreshes the 'Last verified' stamp to the current date as part of the same change",
-        "APPENDS a new entry to the existing change log rather than rewriting or replacing the 2024-11-03 entry, and the entry records why the limiter changed, not only that it changed",
+        "APPENDS a new entry to the existing change log rather than rewriting or replacing any of the three existing entries, and the entry records why the limiter changed, not only that it changed",
         "Establishes a mechanical link between the code path and its document - a routing map, a check, or a hook - rather than relying on someone remembering to re-read the file"
       ]
     },
@@ -74,7 +74,7 @@
         "documentation-and-adrs"
       ],
       "expectations": [
-        "Does not delete or collapse the existing 2024-11-03 change log entry",
+        "Does not delete or collapse any of the three existing change log entries, each of which records a reason",
         "Adds the token bucket information as a new appended entry instead",
         "States why collapsing the log is the wrong trade: version control already preserves the old text, so a rewrite destroys the recorded reasoning and saves nothing",
         "Does not treat the stated deadline as a reason to skip the discipline"

--- a/evals/fixtures/documentation-and-adrs/rate-limiter.js
+++ b/evals/fixtures/documentation-and-adrs/rate-limiter.js
@@ -1,0 +1,29 @@
+// Token bucket limiter.
+//
+// Tokens refill continuously rather than resetting on a boundary, so a client
+// cannot spend a full allowance at the end of one window and another at the
+// start of the next.
+
+const CAPACITY = 60;           // burst size, in tokens
+const REFILL_PER_SECOND = 1;   // sustained rate -> 60 requests / minute
+
+function createLimiter(now = () => Date.now()) {
+  const buckets = new Map();
+
+  return function allow(clientId) {
+    const t = now();
+    const b = buckets.get(clientId) || { tokens: CAPACITY, updated: t };
+    const refill = ((t - b.updated) / 1000) * REFILL_PER_SECOND;
+    b.tokens = Math.min(CAPACITY, b.tokens + refill);
+    b.updated = t;
+    if (b.tokens < 1) {
+      buckets.set(clientId, b);
+      return false;
+    }
+    b.tokens -= 1;
+    buckets.set(clientId, b);
+    return true;
+  };
+}
+
+module.exports = { createLimiter, CAPACITY, REFILL_PER_SECOND };

--- a/evals/fixtures/documentation-and-adrs/rate-limiter.js
+++ b/evals/fixtures/documentation-and-adrs/rate-limiter.js
@@ -1,8 +1,4 @@
 // Token bucket limiter.
-//
-// Tokens refill continuously rather than resetting on a boundary, so a client
-// cannot spend a full allowance at the end of one window and another at the
-// start of the next.
 
 const CAPACITY = 60;           // burst size, in tokens
 const REFILL_PER_SECOND = 1;   // sustained rate -> 60 requests / minute

--- a/evals/fixtures/documentation-and-adrs/rate-limiter.md
+++ b/evals/fixtures/documentation-and-adrs/rate-limiter.md
@@ -1,0 +1,24 @@
+# Rate Limiter
+
+Last verified: 2024-11-03
+
+Fixed-window limiter. Each client may make **100 requests per calendar minute**.
+The counter resets at the top of every minute, so a client that exhausts its
+allowance waits until the next minute begins.
+
+## Configuration
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `WINDOW_SECONDS` | 60 | length of the fixed window |
+| `MAX_PER_WINDOW` | 100 | requests allowed per window |
+
+## Known gotcha
+
+Because the window is fixed, a client can send 100 requests at 10:00:59 and
+another 100 at 10:01:00 — 200 requests in two seconds. Accept this, or move to a
+sliding window later.
+
+## Change Log (newest first)
+
+- [2024-11-03] Initial limiter documented.

--- a/evals/fixtures/documentation-and-adrs/rate-limiter.md
+++ b/evals/fixtures/documentation-and-adrs/rate-limiter.md
@@ -21,4 +21,10 @@ sliding window later.
 
 ## Change Log (newest first)
 
-- [2024-11-03] Initial limiter documented.
+- [2024-11-03] Raised the documented allowance from 60 to 100 per window - support
+  found bulk-import clients throttled at 60 during nightly syncs, and raising the
+  ceiling was cheaper than special-casing those clients.
+- [2024-09-17] Recorded the burst-across-boundary gotcha - a customer sent 200
+  requests in two seconds and nothing in the doc explained how that was possible.
+  Kept the fixed window for the quarter and wrote the surprise down instead.
+- [2024-08-02] Initial limiter documented.

--- a/skills/documentation-and-adrs/SKILL.md
+++ b/skills/documentation-and-adrs/SKILL.md
@@ -256,6 +256,117 @@ Special consideration for AI agent context:
 - **ADRs** — Help agents understand why past decisions were made (prevents re-deciding)
 - **Inline gotchas** — Prevent agents from falling into known traps
 
+## Documentation Drift
+
+Missing documentation is visible. Drifted documentation is not: it was true when
+written, the code moved, and the file still reads as authoritative. An agent that
+finds a confident, wrong document trusts it — and a reader has no way to tell a
+current document from a stale one by looking at it.
+
+Agents make this worse in both directions. They generate documentation readily,
+so there is more of it, and they have no mechanism to notice when what they wrote
+has stopped being true.
+
+Writing docs is a one-time act. Keeping them true is a recurring one, and it needs
+a mechanism rather than an intention.
+
+### Three mechanisms
+
+**1. Stamp each document with a freshness date.**
+
+```markdown
+# Rate Limiter
+
+Last verified: 2025-01-20
+```
+
+A reader can now tell a document checked last week from one abandoned last year.
+The stamp is a claim a human makes, so treat it as a hint, not proof — the check
+in mechanism 3 is what actually enforces.
+
+**2. Keep the change log append-only.**
+
+```markdown
+## Change Log (newest first)
+
+- [2025-01-20] PERF-412 — switched to token bucket · fixed windows allowed 2x
+  burst at the boundary.
+- [2024-11-03] Initial limiter documented.
+```
+
+Append; never rewrite. Git already holds the old text, so a rewritten log destroys
+the only record of *why* something changed while preserving nothing. One line per
+change: date, reference, what changed, and the reason after a separator.
+
+**3. Route each code path to the document that must change with it.**
+
+This is the mechanism that makes the other two enforceable. Without it,
+"keep the docs current" has nothing to check against.
+
+```json
+{
+  "map": {
+    "src/rate-limiter.js": "docs/rate-limiter.md",
+    "src/queue.js": "docs/queue.md"
+  },
+  "exempt": ["src/index.js"]
+}
+```
+
+Explicit entries beat glob patterns: they are greppable, reviewable in a diff, and
+a new file that nobody mapped is itself a finding rather than a silent gap. Make
+exemption deliberate and written down.
+
+### The workflow
+
+1. **Map the code paths that have documentation.** Generate the map from the
+   repository rather than hand-writing it, then review it.
+2. **Check the map.** For each entry, ask four questions:
+
+   | Condition | Meaning |
+   |---|---|
+   | The mapped document does not exist | Documentation was never written |
+   | The code's last commit is newer than the document's | The document has drifted |
+   | A source file is neither mapped nor exempt | New code escaped the check |
+   | The document exists but its code is gone | Documentation outlived its subject |
+
+3. **Decide staleness from version control, not from the stamp.** A hand-written
+   date is forged by forgetting. Compare the last commit that touched the code
+   against the last commit that touched its document:
+
+   ```bash
+   git log -1 --format=%H -- src/rate-limiter.js
+   git log -1 --format=%H -- docs/rate-limiter.md
+   git merge-base --is-ancestor "$DOC_SHA" "$CODE_SHA" && echo "doc is stale"
+   ```
+
+   Identical commits mean they were changed together — not stale.
+
+4. **Report what you could not determine.** If the two commits are unordered —
+   divergent branches, a rebase, a cherry-pick, a shallow clone — the honest answer
+   is *"cannot tell"*. Reporting that as "current" is the failure this whole section
+   exists to prevent: a check that passes because it saw nothing.
+
+5. **Run the check where it changes behaviour.** In CI, and in a pre-commit hook
+   scoped to staged files only: if a mapped code file is staged without its
+   document, stop the commit.
+
+### Gate strictness is a real trade-off
+
+| | Blocks the commit | Warns only |
+|---|---|---|
+| **Cost** | Friction; gets bypassed under deadline | Gets scrolled past and ignored |
+| **Escape** | `--no-verify`, deliberate and visible | None needed — that is the problem |
+
+There is no free option. Choose blocking when the documentation is load-bearing,
+and print the escape hatch in the failure message so it stays deliberate rather
+than becoming a workaround someone discovers under pressure.
+
+**Keep the commit gate scoped to staged files.** A gate that fails on pre-existing
+repository-wide drift blocks work unrelated to the change in hand, and a gate that
+blocks unrelated work is disabled within a week. Repository-wide checking belongs
+in CI, run against the whole tree.
+
 ## Common Rationalizations
 
 | Rationalization | Reality |
@@ -265,6 +376,9 @@ Special consideration for AI agent context:
 | "Nobody reads docs" | Agents do. Future engineers do. Your 3-months-later self does. |
 | "ADRs are overhead" | A 10-minute ADR prevents a 2-hour debate about the same decision six months later. |
 | "Comments get outdated" | Comments on *why* are stable. Comments on *what* get outdated — that's why you only write the former. |
+| "The docs were right when I wrote them" | They were. Nobody reads a document with a timestamp of when it was *written* — they need to know when it was last *checked*. |
+| "I'll tidy the change log while I'm in here" | Git holds the old text; the log holds the reasons. Rewriting it destroys the only copy of the reasoning and preserves nothing. |
+| "A warning is enough, blocking is annoying" | A warning that can be scrolled past is not enforcement. Choose deliberately, and print the escape hatch. |
 
 ## Red Flags
 
@@ -275,6 +389,10 @@ Special consideration for AI agent context:
 - TODO comments that have been there for weeks
 - No ADRs in a project with significant architectural choices
 - Documentation that restates the code instead of explaining intent
+- Documentation with no indication of when it was last checked against the code
+- A change log that has been rewritten rather than appended to
+- Source files with no documented owner and no recorded exemption
+- A doc-freshness check that reports "clean" without saying what it could not determine
 
 ## Verification
 
@@ -286,3 +404,7 @@ After documenting:
 - [ ] Known gotchas are documented inline where they matter
 - [ ] No commented-out code remains
 - [ ] Rules files (CLAUDE.md etc.) are current and accurate
+- [ ] Each documented code path is routed to its document, and unmapped files are either mapped or explicitly exempt
+- [ ] Documents carry a freshness stamp, and change logs were appended to rather than rewritten
+- [ ] The drift check runs somewhere it changes behaviour (CI, or a staged-file commit hook)
+- [ ] Anything the check could not determine is reported as undetermined, not as passing

--- a/skills/documentation-and-adrs/SKILL.md
+++ b/skills/documentation-and-adrs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: documentation-and-adrs
-description: Records decisions and documentation. Use when making architectural decisions, changing public APIs, shipping features, or when you need to record context that future engineers and agents will need to understand the codebase.
+description: Records decisions and documentation, and detects when documentation has drifted from the code it describes. Use when making architectural decisions, changing public APIs, shipping features, when documentation may be stale or out of sync with the code it describes, or when you need to record context that future engineers and agents will need to understand the codebase.
 ---
 
 # Documentation and ADRs


### PR DESCRIPTION
Closes the gap raised in #511.

### The gap

`documentation-and-adrs` covers writing ADRs, comments, READMEs and changelogs. It has no mechanism for detecting that documentation has stopped being true.

Those are different failures. Missing documentation is visible. Drifted documentation is not — it was true when written, the code moved, and the file still reads as authoritative. An agent that finds a confident, wrong document trusts it, and a reader cannot tell a current document from an abandoned one by looking at it.

Before writing this I scanned the current `SKILL.md` for `drift`, `stale`, `last verified`, `append-only`, `change log`, `pre-push`, `doc rot` and `out of sync`: zero hits on all eight. The existing `## Changelog Maintenance` section covers release notes for users, which is a different artefact from a per-document history, and the `outdated` discussion is about code comments rather than documentation diverging from the code it describes.

### Not covered elsewhere

Checked open PRs and issues. The closest three are adjacent but distinct: #103 covers the intent-to-verification traceability chain, #398 preserves durable knowledge as scoped memory capsules, and #432's "drift" refers to model drift across a release. None detect documentation diverging from code.

### Why a section, not a new skill

Per CONTRIBUTING's preference for extending over adding a directory. This is a refinement of `documentation-and-adrs` — the same subject at a different point in its lifecycle — so it extends the existing skill's closing sections rather than duplicating them.

### What it adds

Three mechanisms: a freshness stamp, an append-only change log, and a routing map from code path to document. Then the workflow that makes them enforceable, including the git-ancestry comparison that decides staleness without trusting a hand-written date.

Two things the section is deliberate about:

- **It states the blocking-vs-warning choice as a real trade-off rather than recommending one.** Blocking creates friction and gets bypassed under deadline; warn-only gets scrolled past. Neither is free, and the section says so.
- **It requires a check to report what it could not determine.** When two commits are unordered — divergent branches, a rebase, a cherry-pick, a shallow clone — the honest answer is "cannot tell". Reporting that as "current" is a silent pass, which is the exact failure the section exists to prevent.

### Evals

Two execution cases added to the existing case file, plus a fixture whose document makes three specific false claims about its code: wrong algorithm (fixed window vs token bucket), wrong rate (100/min vs 60/min), and a documented "known gotcha" about boundary bursting that the current implementation specifically prevents.

Eval 3 is a pressure case. It instructs the agent to collapse the change log under a shipping deadline and expects the append-only discipline to hold, with the reason stated.

Two positive trigger prompts added, phrased the way a user would actually ask rather than paraphrasing the description.

### Provenance

This comes out of running the practice as a small Python CLI on one repository — its own — where the first run reported an eight-module documentation hole that had gone unnoticed for two months. The regime before that was a written instruction to keep module docs current with nothing enforcing it, and the directory simply stayed empty. That is one implementation, not a proven pattern at scale, and the section is written to be tool-agnostic.
