### PR TITLE
fix(planning): never overwrite an incomplete plan without asking (#518)

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -14,3 +14,5 @@ Read the existing spec (SPEC.md or equivalent) and the relevant codebase section
 6. Present the plan for human review
 
 Save the plan to tasks/plan.md and task list to tasks/todo.md.
+
+If tasks/plan.md or tasks/todo.md already exists with unchecked tasks for different work, stop and ask before writing — never silently overwrite an incomplete plan.

--- a/skills/planning-and-task-breakdown/SKILL.md
+++ b/skills/planning-and-task-breakdown/SKILL.md
@@ -147,6 +147,13 @@ If a task is L or larger, it should be broken into smaller tasks. An agent perfo
 
 Create the `tasks/` directory if it does not exist.
 
+**Never overwrite an incomplete plan.** Before writing `tasks/plan.md` or `tasks/todo.md`, check whether they already exist and still contain unchecked tasks:
+
+- Same work being replanned (the user asked to revise or extend this plan) → update the existing files in place.
+- Different work → **stop and ask.** The unchecked tasks may be mid-build in another session. Do not delete, overwrite, or rename the existing files on your own; present the conflict and let the user decide (finish the old plan first, explicitly discard it, or tell you where the new plan should go).
+
+The same rule applies to an external task list target: never bulk-close or delete another plan's open tracker items to make room for new ones.
+
 ### Task List Target
 
 The task list target is where tasks and checkpoints are recorded. It is defined once, here; every other reference in this skill defers to it.
@@ -219,10 +226,12 @@ When multiple agents or sessions are available:
 | "The tasks are obvious" | Write them down anyway. Explicit tasks surface hidden dependencies and forgotten edge cases. |
 | "Planning is overhead" | Planning is the task. Implementation without a plan is just typing. |
 | "I can hold it all in my head" | Context windows are finite. Written plans survive session boundaries and compaction. |
+| "The old `tasks/plan.md` is stale, I'll just replace it" | Unchecked tasks may be mid-build in another session. Overwriting them destroys work state that exists nowhere else. Stop and ask. |
 
 ## Red Flags
 
 - Starting implementation without a written task list
+- Overwriting a `tasks/plan.md` or `tasks/todo.md` that still has unchecked tasks for different work, without asking
 - Writing `tasks/todo.md` when the project has designated an external tracker (or scattering tasks across both)
 - Tasks that say "implement the feature" without acceptance criteria
 - No verification steps in the plan
@@ -238,6 +247,7 @@ Before starting implementation, confirm:
 - [ ] Every task has a verification step
 - [ ] Task dependencies are identified and ordered correctly
 - [ ] Tasks are recorded in the task list target (default `tasks/todo.md`)
+- [ ] No pre-existing incomplete plan was overwritten without explicit user confirmation
 - [ ] No task touches more than ~5 files
 - [ ] Checkpoints exist between major phases
 - [ ] The human has reviewed and approved the plan


### PR DESCRIPTION
The convention-neutral half of #518, as offered in [this comment](https://github.com/addyosmani/agent-skills/issues/518#issuecomment-5454672750). The reported failure has two parts: (1) the agent silently deletes an incomplete `tasks/plan.md`/`tasks/todo.md` when planning new work — data loss; (2) the tasks layout can't represent parallel lanes — the convention decision being deliberately held open. This PR fixes only (1) and forecloses nothing about (2): whatever layout lands, "don't destroy an in-flight plan's state" holds.

## Changes

**`skills/planning-and-task-breakdown/SKILL.md`**
- New guard in Output Files: before writing, check for existing files with unchecked tasks. Replanning the same work → update in place. Different work → stop and ask; never delete, overwrite, or rename on your own. Mirrored for external task list targets (no bulk-closing another plan's open tracker items).
- Matching Rationalization row ("the old plan is stale, I'll just replace it"), Red Flag, and Verification checklist item.

**`.claude/commands/plan.md`**
- One guard line after the save instruction, so the command carries the rule even when invoked without the full skill context.

## Verification

- `validate-skills`, `validate-commands`, `validate-artifact-paths` all pass (no artifact paths moved — the guard references only the canonical `tasks/plan.md`/`tasks/todo.md`).
- `run-evals`: 127 checks pass, trigger rank-1 rate unchanged at 86%.

Refs #518 (fixes the data-loss report; the parallel-layout decision stays open there).