### PR TITLE
fix(planning): never overwrite an incomplete plan without asking

### DIFF
--- a/.gemini/commands/planning.toml
+++ b/.gemini/commands/planning.toml
@@ -13,4 +13,6 @@ Read the existing spec (SPEC.md or equivalent) and the relevant codebase section
 6. Present the plan for human review
 
 Save the plan to tasks/plan.md and task list to tasks/todo.md.
+
+If tasks/plan.md or tasks/todo.md already exists with unchecked tasks for different work, stop and ask before writing — never silently overwrite an incomplete plan.
 """

--- a/commands/planning.toml
+++ b/commands/planning.toml
@@ -13,4 +13,6 @@ Read the existing spec (SPEC.md or equivalent) and the relevant codebase section
 6. Present the plan for human review
 
 Save the plan to tasks/plan.md and task list to tasks/todo.md.
+
+If tasks/plan.md or tasks/todo.md already exists with unchecked tasks for different work, stop and ask before writing — never silently overwrite an incomplete plan.
 """


### PR DESCRIPTION
## Summary

- guard planning outputs against silently overwriting unchecked work
- allow same-work replanning while requiring a user decision for different work
- apply the protection to external task trackers and all three command integrations

Closes #518.

## Verification

- node scripts/validate-skills.js
- node scripts/validate-commands.js
- node scripts/run-evals.js --min-rank1 80
- git diff --check

All relevant checks pass: 24 skills, 8 command families, and 127 routing checks; trigger rank-1 rate remains 86%.