### PR TITLE
docs(security): rate limiting must count in a shared store across instances

### DIFF
--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -329,6 +329,20 @@ app.use('/api/auth/', rateLimit({
 }));
 ```
 
+**Count in a shared store once there is more than one process.** `express-rate-limit` keeps its counters in process memory by default. Behind a load balancer each instance holds its own count, so the effective limit is `max × instances`; on serverless or edge runtimes a fresh invocation starts from zero, so the auth limit above may never fire. Pass a shared `store` (Redis via `rate-limit-redis`), or use an HTTP-based limiter that works where a long-lived TCP connection does not (for example `@upstash/ratelimit`):
+
+```typescript
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+
+const authLimiter = new Ratelimit({
+  redis: Redis.fromEnv(),                       // UPSTASH_REDIS_REST_URL + _TOKEN
+  limiter: Ratelimit.slidingWindow(10, '15 m'), // 10 attempts per 15 minutes, across all instances
+});
+const { success } = await authLimiter.limit(`login:${req.ip}`);
+if (!success) return res.status(429).end();
+```
+
 ## Secrets Management
 
 ```
@@ -472,7 +486,7 @@ For detailed security checklists and pre-commit verification steps, see `../../r
 - Secrets in source code or commit history
 - API endpoints without authentication or authorization checks
 - Missing CORS configuration or wildcard (`*`) origins
-- No rate limiting on authentication endpoints
+- No rate limiting on authentication endpoints, or an in-memory limiter in front of more than one instance
 - Stack traces or internal errors exposed to users
 - Dependencies with known critical vulnerabilities, competing lockfiles at one installation boundary, non-reproducible installs, or blanket-approved scripts
 - Server fetches user-supplied URLs without an allowlist (SSRF)
@@ -492,7 +506,7 @@ After implementing security-relevant code:
 - [ ] Authentication and authorization checked on every protected endpoint
 - [ ] Security headers present in response (check with browser DevTools)
 - [ ] Error responses don't expose internal details
-- [ ] Rate limiting active on auth endpoints
+- [ ] Rate limiting active on auth endpoints, backed by a shared store when more than one instance serves traffic
 - [ ] Server-side URL fetches validated against an allowlist (no SSRF)
 - [ ] LLM/model output validated and encoded before use (if AI features present)
 - [ ] Personal data is classified, minimized to a stated purpose, and has a retention limit


### PR DESCRIPTION
## What

`## Rate Limiting` in `security-and-hardening` is a single `express-rate-limit` snippet with no prose. `express-rate-limit` counts in process memory by default, so the snippet as written enforces `max × instances` behind a load balancer and effectively nothing on serverless/edge, where each invocation can start from zero. The auth limiter (10 attempts / 15 min) is exactly the control that brute-force attackers spread across instances.

This adds one paragraph naming the failure mode and the fix (a shared `store` — Redis via `rate-limit-redis` — or an HTTP-based limiter for runtimes without a long-lived TCP connection), a short `@upstash/ratelimit` example for the auth endpoint, and matching one-line updates to the existing Red Flags and Verification entries.

## Why here, and why not a new skill

- The skill already owns rate limiting: STRIDE row "Denial of service → Rate limiting", the "Modifying rate limiting or throttling" Ask-First rule, checklist item "Login has rate limiting", Red Flag "No rate limiting on authentication endpoints", Verification "Rate limiting active on auth endpoints". None of them say the counter has to be shared, so an agent following the skill can add a limiter that passes every checkbox and does not work in production.
- `references/security-checklist.md` L41 has the same gap ("Rate limiting on login endpoint (≤10 attempts per 15 minutes)").
- Focused edit per CONTRIBUTING "Modifying Existing Skills"; no new directory, no frontmatter change, no routing surface added.

## Disclosure

I work at Upstash, which makes `@upstash/ratelimit`. The paragraph leads with the vendor-neutral fix (`store` + `rate-limit-redis`) and the example is there because an HTTP-based limiter is the only option on edge runtimes; if you would rather keep the file free of a named product, I'm happy to drop the second code block and keep the prose, or swap the example for `rate-limit-redis`.

## Pre-flight (per CONTRIBUTING)

- Searched the catalog: no other skill covers rate limiting; `performance-optimization` covers caching layers but not limiters.
- Checked open PRs: none touch `skills/security-and-hardening/SKILL.md` or rate limiting (#523 proposes a separate supply-chain auditor skill).
- Extends rather than adds.

## Scope and size

One file. Frontmatter description unchanged. The file was at 499 lines and this takes it to 513 (or 508 if the second express block is folded into the shared-store example, which I can do on request). The 500-line note in skill-anatomy.md is a guideline rather than a CI rule, but flagging it so you can decide.

## Verification

- `node scripts/validate-skills.js` → 25 skills checked, 0 errors, 0 warnings
- `node scripts/run-evals.js --min-rank1 80` → 136 checks passed, rank-1 86% (72/84) — unchanged from `main` (description untouched)
- `node scripts/validate-reference-links.js` → 25 skills checked, 0 errors
- `git diff --check` → clean
- Snippet checked against `@upstash/ratelimit` 2.0.8 / `@upstash/redis` 1.38.3 (`Redis.fromEnv()`, `Ratelimit.slidingWindow(10, '15 m')`, `limit()` → `{ success }`).
