### PR TITLE
fix(skills): add database-migration and dependency-audit vocabulary to two skill descriptions

### DIFF
--- a/evals/cases/deprecation-and-migration.json
+++ b/evals/cases/deprecation-and-migration.json
@@ -13,6 +13,14 @@
       {
         "prompt": "How do I remove this old feature safely for existing users?",
         "top_k": 3
+      },
+      {
+        "prompt": "Rename a database column without downtime",
+        "top_k": 3
+      },
+      {
+        "prompt": "How do I drop a column safely in production?",
+        "top_k": 3
       }
     ],
     "negative": [

--- a/evals/cases/security-and-hardening.json
+++ b/evals/cases/security-and-hardening.json
@@ -13,6 +13,14 @@
       {
         "prompt": "Harden the webhook endpoint that fetches user-supplied URLs",
         "top_k": 3
+      },
+      {
+        "prompt": "Run a dependency audit and triage the findings",
+        "top_k": 3
+      },
+      {
+        "prompt": "Is this new package safe to install? Check for typosquatting and supply chain risk",
+        "top_k": 3
       }
     ],
     "negative": [

--- a/skills/deprecation-and-migration/SKILL.md
+++ b/skills/deprecation-and-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deprecation-and-migration
-description: Manages deprecation and migration. Use when removing old systems, APIs, or features. Use when migrating users from one implementation to another. Use when deciding whether to maintain or sunset existing code.
+description: Manages deprecation and migration. Use when removing old systems, APIs, or features. Use when migrating users from one implementation to another. Use when migrating a database schema in production, such as renaming or dropping a column without downtime (expand/contract). Use when deciding whether to maintain or sunset existing code.
 ---
 
 # Deprecation and Migration

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-and-hardening
-description: Hardens code against vulnerabilities. Use when handling user input, authentication, data storage, or external integrations. Use when building any feature that accepts untrusted data, manages user sessions, or interacts with third-party services. Use when personal data or privacy compliance (GDPR, CCPA) is involved.
+description: Hardens code against vulnerabilities. Use when handling user input, authentication, data storage, or external integrations. Use when building any feature that accepts untrusted data, manages user sessions, or interacts with third-party services. Use when auditing dependencies for known vulnerabilities, triaging package-manager audit findings, or assessing supply-chain risk in a new package. Use when personal data or privacy compliance (GDPR, CCPA) is involved.
 ---
 
 # Security and Hardening


### PR DESCRIPTION
## Summary

Two skills carry substantial body content whose vocabulary never made it into their frontmatter `description`, so realistic prompts for exactly that content cannot reach them in the Tier-2 trigger evals (same failure class as #351, and the same shape of fix as #508):

- **`deprecation-and-migration`**: the *Database Schema Migrations (Expand/Contract)* section (added in #345) is a core part of the skill — "never rename in place" is one of its own rationalization rebuttals — but the description says nothing about databases, schemas, or columns.
- **`security-and-hardening`**: the skill owns *Triaging Dependency Audit Results* and *Supply-Chain Hygiene* (hardened in #392), and `code-review-and-quality` explicitly delegates to it ("For triaging `npm audit` findings and supply-chain risk … follow the `security-and-hardening` skill — this section covers the upgrade *workflow*, that one covers the security verdict"), but the description mentions neither dependencies, audits, nor supply chain.

Per the eval README ("a Tier-2 failure usually means *fix the description*"), this PR adds the missing vocabulary to both descriptions — keeping the what-then-"Use when…" format — and adds four positive trigger cases so the suite can see these gaps from now on.

## Evidence

With the four trigger cases added and the descriptions unchanged, `node scripts/run-evals.js` reports all four as hard misses, not merely low-ranked:

```
✗  deprecation-and-migration: description shares no vocabulary with a prompt users would say
     "Rename a database column without downtime"
✗  deprecation-and-migration: description shares no vocabulary with a prompt users would say
     "How do I drop a column safely in production?"
✗  security-and-hardening: description shares no vocabulary with a prompt users would say
     "Run a dependency audit and triage the findings"
✗  security-and-hardening: description shares no vocabulary with a prompt users would say
     "Is this new package safe to install? Check for typosquatting and supply chain risk"
```

Without a case to catch it, "Rename a database column without downtime" currently ranks `code-simplification` #1 and does not rank `deprecation-and-migration` at all.

| | rank-1 rate | checks |
|---|---|---|
| baseline (unmodified) | 86% (72/84) | 136 passed, 0 errors |
| new trigger cases only | 82% (72/88) | 4 errors (above) |
| cases + description fixes | 86% (76/88) | 140 passed, 0 errors, 0 warnings |

After the fix all four new prompts rank their skill #1. The +4 rank-1 gain is exactly the four new prompts — no pre-existing prompt lost rank 1 — and there are no new collision warnings. `scripts/validate-skills.js` also passes (25 skills, 0 errors).

One wording choice was deliberate: the deprecation clause says "migrating a database schema" (reusing the already-present *migrat* token) rather than "changing a database schema", because the latter shifted the IDF of *chang* and pushed an existing `incremental-implementation` prompt ("Ship this change behind a feature flag in thin slices") from top-3 to #4 — the edit-coupling effect #434 describes. The final wording leaves every pre-existing check green.

## What changed

- `skills/deprecation-and-migration/SKILL.md` — one added clause: *"Use when migrating a database schema in production, such as renaming or dropping a column without downtime (expand/contract)."*
- `skills/security-and-hardening/SKILL.md` — one added clause: *"Use when auditing dependencies for known vulnerabilities, triaging package-manager audit findings, or assessing supply-chain risk in a new package."*
- `evals/cases/deprecation-and-migration.json`, `evals/cases/security-and-hardening.json` — the four positive trigger cases quoted above, `top_k: 3`.

## Relationship to open work

- #434 closes vocabulary gaps in ten *other* skills; the two here are disjoint from that set, and this PR does not touch the CI floor or the README baseline.
- #492 (on hold for scoping) would move the expand/contract depth into a new `database-and-schema-design` skill. If that lands, the schema clause and its two trigger cases should travel with the content; at current HEAD, `deprecation-and-migration` owns this material and is unreachable by its vocabulary.
- The security clause stays on the security-verdict side of the boundary drawn when #399 was closed: upgrade *workflow* belongs to `code-review-and-quality`; audit triage and the supply-chain verdict belong to `security-and-hardening`.

---

This contribution was researched and drafted with Claude Code (an AI coding agent); a human reviewed the findings and approved the submission.