### PR TITLE
fix(hooks): run SessionStart without a shell so it works on Windows

### DIFF
--- a/.github/workflows/test-plugin-install.yml
+++ b/.github/workflows/test-plugin-install.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Test reference-link validator
         run: node --test scripts/validate-reference-links-test.js
 
+      - name: Test SessionStart hook
+        run: node --test hooks/session-start-node-test.js
+
   validate-commands:
     name: Validate command parity and description sync
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,14 +76,16 @@ We don't accept translations of the documentation (README, `docs/`) or of skills
 
 ## Testing Hooks
 
-The session-start hook (`hooks/session-start.sh`) injects the `using-agent-skills` meta-skill into every new Claude Code session. A regression test at `hooks/session-start-test.sh` validates the hook's JSON payload — both when `jq` is available and when it isn't.
+The session-start hook (`hooks/session-start.mjs`) injects the `using-agent-skills` meta-skill into every new Claude Code session. It is Node rather than bash + `jq` so it runs unchanged on Windows, where Claude Code falls back to PowerShell when Git Bash is absent (#488); `hooks/session-start.sh` is kept for direct invocation. A regression test at `hooks/session-start-test.sh` validates the hook's JSON payload — both when `jq` is available and when it isn't.
 
 Run it before opening any PR that touches:
 
-- `hooks/session-start.sh`
+- `hooks/session-start.mjs` or `hooks/session-start.sh`
+- `hooks/hooks.json`
 - `skills/using-agent-skills/SKILL.md` (the meta-skill content embedded by the hook)
 
 ```bash
+node --test hooks/session-start-node-test.js
 bash hooks/session-start-test.sh
 ```
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "SCRIPT=\"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"; [ -f \"$SCRIPT\" ] || SCRIPT=\"${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.sh\"; [ -f \"$SCRIPT\" ]&& bash \"$SCRIPT\" || true"
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/session-start.mjs"]
           }
         ]
       }

--- a/hooks/session-start-node-test.js
+++ b/hooks/session-start-node-test.js
@@ -1,0 +1,87 @@
+// Tests for the Node SessionStart hook (#488).
+//
+// The hook used to be a bash one-liner in hooks.json calling a bash+jq script.
+// On Windows, Claude Code runs hook commands through Git Bash or — when that is
+// absent — PowerShell, where `[ -f "$SCRIPT" ]` is a parse error, so the hook
+// failed on every session start. These pin the two properties that fix depends
+// on: the config no longer goes through a shell, and the payload is unchanged.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { execFileSync, spawnSync } = require("node:child_process");
+const { readFileSync, mkdtempSync, mkdirSync, copyFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join, resolve } = require("node:path");
+
+const REPO = resolve(__dirname, "..");
+const HOOK = join(REPO, "hooks", "session-start.mjs");
+
+function runHook(cwd = REPO, env = {}) {
+  return execFileSync(process.execPath, [HOOK], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+test("emits the SessionStart envelope with the meta-skill body", () => {
+  const payload = JSON.parse(runHook());
+  assert.equal(payload.hookSpecificOutput.hookEventName, "SessionStart");
+  const context = payload.hookSpecificOutput.additionalContext;
+  assert.ok(context.includes("agent-skills loaded."), "missing startup preface");
+  assert.ok(context.includes("# Using Agent Skills"), "missing meta-skill content");
+});
+
+test("payload is byte-identical to the bash hook it replaces", (t) => {
+  // The point of #488 is a platform fix, not a behaviour change. Skipped where
+  // bash or jq is unavailable — which is exactly the environment that made the
+  // old hook unusable.
+  const probe = spawnSync("bash", ["-c", "command -v jq"], { encoding: "utf8" });
+  if (probe.status !== 0) {
+    t.skip("bash or jq unavailable");
+    return;
+  }
+  const fromBash = execFileSync("bash", [join(REPO, "hooks", "session-start.sh")], {
+    cwd: REPO,
+    encoding: "utf8",
+  });
+  assert.equal(runHook(), fromBash);
+});
+
+test("reports a notice, not a failure, when the meta-skill is absent", () => {
+  const dir = mkdtempSync(join(tmpdir(), "agent-skills-hook-"));
+  mkdirSync(join(dir, "hooks"));
+  copyFileSync(HOOK, join(dir, "hooks", "session-start.mjs"));
+
+  const result = spawnSync(process.execPath, [join(dir, "hooks", "session-start.mjs")], {
+    cwd: dir,
+    encoding: "utf8",
+    env: (({ CLAUDE_PLUGIN_ROOT, CLAUDE_PROJECT_DIR, ...rest }) => rest)(process.env),
+  });
+
+  assert.equal(result.status, 0, "a missing meta-skill must not fail the session");
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.hookSpecificOutput.hookEventName, "SessionStart");
+  assert.ok(payload.hookSpecificOutput.additionalContext.includes("not found"));
+});
+
+test("hooks.json uses exec form so no shell parses the command", () => {
+  // This is the fix. In shell form the command string reaches PowerShell on a
+  // Windows box without Git Bash; with `args` present, Claude Code performs no
+  // shell tokenization on any platform.
+  const config = JSON.parse(readFileSync(join(REPO, "hooks", "hooks.json"), "utf8"));
+  const [entry] = config.hooks.SessionStart[0].hooks;
+
+  assert.equal(entry.command, "node");
+  assert.ok(Array.isArray(entry.args), "exec form requires args");
+  assert.equal(entry.args.length, 1);
+  assert.match(entry.args[0], /session-start\.mjs$/);
+  assert.ok(
+    entry.args[0].includes("${CLAUDE_PLUGIN_ROOT}"),
+    "the script path must stay anchored to the plugin root"
+  );
+  assert.ok(
+    !/[;&|]/.test(entry.command),
+    "the command must not carry shell operators"
+  );
+});

--- a/hooks/session-start.mjs
+++ b/hooks/session-start.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// agent-skills session start hook
+// Injects the using-agent-skills meta-skill into every new session.
+//
+// Every output path must emit the standard SessionStart envelope
+//   {"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}
+// Hosts that validate hook output (Codex CLI, Claude Code) reject other shapes.
+//
+// Node rather than bash + jq so the hook runs unchanged on Windows, where
+// neither is present by default (#488). JSON.stringify does the escaping jq
+// was doing, so there is no external dependency left to miss.
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PREFACE =
+  "agent-skills loaded. Use the skill discovery flowchart to find the right skill for your task.";
+
+function emit(additionalContext) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext,
+      },
+    }) + "\n"
+  );
+}
+
+// The shell hook picked between a plugin install and a `.claude/hooks` copy
+// before choosing a script; exec form passes one path, so the same choice is
+// made here instead. Claude Code exports both placeholders to the spawned
+// process, so this works however the hook was launched.
+const here = dirname(fileURLToPath(import.meta.url));
+const candidates = [
+  join(here, "..", "skills", "using-agent-skills", "SKILL.md"),
+  process.env.CLAUDE_PLUGIN_ROOT &&
+    join(process.env.CLAUDE_PLUGIN_ROOT, "skills", "using-agent-skills", "SKILL.md"),
+  process.env.CLAUDE_PROJECT_DIR &&
+    join(process.env.CLAUDE_PROJECT_DIR, ".claude", "skills", "using-agent-skills", "SKILL.md"),
+].filter(Boolean);
+
+function readMetaSkill() {
+  for (const candidate of candidates) {
+    try {
+      return readFileSync(candidate, "utf8");
+    } catch {
+      // Try the next location.
+    }
+  }
+  return null;
+}
+
+{
+  const content = readMetaSkill();
+  if (content === null) {
+    // Absent or unreadable: the individual skills still load, so this is a
+    // notice rather than a failure. Exiting non-zero would surface a hook
+    // error on every session start for a recoverable condition.
+    emit(
+      "agent-skills: using-agent-skills meta-skill not found. Skills may still be available individually."
+    );
+  } else {
+    // `$(cat …)` in the shell version strips trailing newlines; match that so
+    // the payload is byte-identical to what the bash hook has always produced.
+    emit(`${PREFACE}\n\n${content.replace(/\n+$/, "")}`);
+  }
+}


### PR DESCRIPTION
Closes #488.

## The failure

`hooks/hooks.json` ran a bash one-liner:

```
SCRIPT="${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"; [ -f "$SCRIPT" ] || SCRIPT="..."; [ -f "$SCRIPT" ]&& bash "$SCRIPT" || true
```

Per the hooks documentation, the command string is passed to `sh -c` on macOS and Linux, **Git Bash on Windows, or PowerShell when Git Bash isn't installed**. PowerShell cannot parse `[ -f "$SCRIPT" ]`, so @'s report of a `ParserError` on every session start is exactly what that path produces. The script it invoked then needs `bash` and `jq` as well, neither of which is present by default on Windows — so fixing only the syntax would still leave the hook broken.

## The fix

Switch `hooks.json` to the **exec form**. The docs are explicit that with `args` present *"no shell tokenization happens on any platform"* — so there is no shell to disagree about, rather than a shell we branch on:

```json
{
  "type": "command",
  "command": "node",
  "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/session-start.mjs"]
}
```

The script becomes Node. That is not a new dependency — the repo's entire `scripts/` tree, its tests and Claude Code itself already require it — and `JSON.stringify` does the escaping `jq` was doing, so the last external dependency goes with it. Placeholders are still exported to the spawned process, so the plugin-root / project-dir choice the old command made in shell now happens inside the script.

I went this way rather than shipping the `.ps1` the issue suggests: a `.ps1` needs `hooks.json` to branch on OS, and the command string that does the branching is itself parsed by the shell we are trying to avoid. Removing the shell removes the whole class.

## Behaviour is unchanged

The point is portability, not a new payload. The output is **byte-identical** to the bash hook's — which took two rounds to get right, and both are pinned by tests:

- `jq -cn` emits a trailing newline; `process.stdout.write` did not.
- `$(cat …)` strips trailing newlines from the meta-skill; `readFileSync` kept them.

```
$ bash hooks/session-start.sh   > a.json
$ node hooks/session-start.mjs  > b.json
$ diff a.json b.json && echo identical
identical          # 10814 bytes both
```

## Tests

`hooks/session-start-node-test.js`, wired into the `validate-skills` job:

| test | pins |
|---|---|
| emits the SessionStart envelope with the meta-skill body | the happy path |
| payload is byte-identical to the bash hook it replaces | no behaviour change (skips where bash/jq absent — i.e. the very environment #488 is about) |
| reports a notice, not a failure, when the meta-skill is absent | a missing skill must not fail the session |
| `hooks.json` uses exec form so no shell parses the command | **the fix itself** |

Each was mutation-tested; every mutation killed exactly one test:

| mutation | result |
|---|---|
| restore the old shell-form command | 1 fail |
| drop the trailing-newline match | 1 fail |
| exit non-zero when the meta-skill is missing | 1 fail |

Full local run on `d2c37ef`: all five validators OK, `node --test` **32/32**, `run-evals.js --min-rank1 80` passed at 86% (72/84).

## Reviewer notes

- **I cannot test this on Windows.** The reasoning rests on the documented shell-selection and exec-form behaviour plus the byte-identical payload, not on an observed Windows run. If @ (the reporter) can confirm against this branch, that would close the loop properly.
- **`session-start.sh` is deliberately left in place.** It still works invoked directly, and #510 is in flight against its test — I did not want to delete a file out from under an open PR. Once #510 lands I am happy to send a follow-up collapsing the two.
- **Overlap with #510**: it also touches `.github/workflows/test-plugin-install.yml` and `CONTRIBUTING.md`. Mine adds one CI step and edits one paragraph. #510 was opened first, so I will rebase behind it rather than the other way round — say the word.
