### PR TITLE
docs: add a rejected skill-change ledger

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,9 @@ This pack already covers most of the development lifecycle, and many proposals o
 
 1. **Search the catalog.** Browse [the skill list in the README](README.md) and skim `skills/` for an existing skill that covers your idea, whole or in part.
 2. **Check open PRs.** Run `gh pr list --state open` (or browse the PRs tab) and look for proposals on the same topic. Clusters of near-duplicate skills already exist; don't add to them.
-3. **Read the anatomy.** Confirm your idea fits the format in [docs/skill-anatomy.md](docs/skill-anatomy.md), an actionable workflow with verification, not vague advice.
-4. **Justify the gap in your PR description.** State explicitly why this isn't covered by an existing skill or open PR. If it overlaps, propose extending the existing skill instead of adding a new one.
+3. **Check rejected proposals.** Search the [skill-change rejection ledger](evals/skill-impact.md) for earlier proposals that overlap with your idea and review their eval evidence before repeating the work.
+4. **Read the anatomy.** Confirm your idea fits the format in [docs/skill-anatomy.md](docs/skill-anatomy.md), an actionable workflow with verification, not vague advice.
+5. **Justify the gap in your PR description.** State explicitly why this isn't covered by an existing skill, open PR, or previously rejected proposal. If it overlaps, propose extending the existing skill instead of adding a new one.
 
 If your idea is a refinement of an existing skill, prefer a focused edit to that skill over a new directory.
 
@@ -62,9 +63,13 @@ The frontmatter fields above are required. The section anatomy is a recommended 
 
 ## Modifying Existing Skills
 
+Before proposing a change, search the [skill-change rejection ledger](evals/skill-impact.md) for previous attempts affecting the same skill and review their eval evidence.
+
 - Keep changes focused and minimal
 - Preserve the existing structure and tone
 - Test that YAML frontmatter remains valid after edits
+
+If a skill or description change is rejected based on eval results, add one row to the ledger with the date, affected skill, concise attempted change, before-to-after rank-1 score, and rejected PR link and outcome. Land that ledger-only update separately on the default branch; do not leave it only on the rejected proposal branch, where closing or force-pushing the proposal could discard the record.
 
 ## Repo-scoped files
 

--- a/evals/skill-impact.md
+++ b/evals/skill-impact.md
@@ -1,0 +1,6 @@
+# Rejected Skill Changes
+
+This append-only ledger records skill and description changes rejected on eval evidence so contributors can review prior attempts before proposing overlapping work. Add one concise row per rejected proposal; do not record accepted changes here.
+
+| Date | Affected skill | Attempted change | Rank-1 score (before → after) | Rejected PR and outcome |
+|---|---|---|---:|---|


### PR DESCRIPTION
## Verification

- A contributor considering a new or revised skill can follow `CONTRIBUTING.md` to find both existing/open work and previously rejected proposals in `evals/skill-impact.md`.
- A rejected description change can be recorded in one table row containing the date, affected skill, concise attempted change, before-to-after rank-1 receipt, and a working link to the rejected PR.
- The instructions make clear that the ledger-only row must land independently of the rejected proposal, so closing or force-pushing that proposal cannot discard the historical record.
- Markdown renders with a valid table and relative ledger link, and the existing deterministic eval command `node scripts/run-evals.js --min-rank1 80` remains green because the eval runner and skill descriptions are unchanged.

## Summary

Add `evals/skill-impact.md` as a rejection-only ledger, with a brief purpose statement and a compact table whose columns capture date, affected skill, attempted change, before-to-after rank-1 score, and rejected PR link/outcome. Keep entries hand-written and append-only: automation in `run-evals.js` would write onto the proposal branch that is about to be closed or force-pushed, so it would not make the rejection durable without substantially broader workflow automation. Update the new-skill and existing-skill pre-flight guidance in `CONTRIBUTING.md` to search the ledger before proposing overlapping work, and document the closeout step: after an eval-driven rejection, land the single ledger row separately from the rejected change so it reaches the default branch.

## Why

The catalog's deterministic eval runner reports routing quality, but rejected skill and description changes leave no durable record once their PR is closed or rewritten. That makes contributors repeat proposals whose rationale and failed eval receipt are scattered across old review threads. The owner approved a catalog-scoped, append-only register and narrowed the desired interaction to one short entry per rejection with a PR link and eval evidence. There are no prior closed implementation PRs for this issue, and the bundled open PR #537 is an unrelated description-vocabulary change rather than a competing ledger implementation.

Closes #535

AI was used for assistance.
