### PR TITLE
docs: add authoring rule against model-specific workarounds (#534)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ This pack already covers most of the development lifecycle, and many proposals o
 3. **Check rejected proposals.** Search the [skill-change rejection ledger](evals/skill-impact.md) for earlier proposals that overlap with your idea and review their eval evidence before repeating the work.
 4. **Read the anatomy.** Confirm your idea fits the format in [docs/skill-anatomy.md](docs/skill-anatomy.md), an actionable workflow with verification, not vague advice.
 5. **Justify the gap in your PR description.** State explicitly why this isn't covered by an existing skill, open PR, or previously rejected proposal. If it overlaps, propose extending the existing skill instead of adding a new one.
+6. **Strip model-specific workarounds.** If a step can't be justified without naming a model, a model version, or one agent's private tool name, it doesn't belong in a skill — describe the capability instead (see [Write the Procedure, Not the Workaround](docs/skill-anatomy.md#write-the-procedure-not-the-workaround)).
 
 If your idea is a refinement of an existing skill, prefer a focused edit to that skill over a new directory.
 

--- a/docs/skill-anatomy.md
+++ b/docs/skill-anatomy.md
@@ -147,6 +147,20 @@ When a skill ships runnable helpers under `scripts/`, each script follows these 
 4. **Anti-rationalization.** Every skip-worthy step needs a counter-argument in the rationalizations table.
 5. **Progressive disclosure.** Main SKILL.md is the entry point. Supporting files are loaded only when needed.
 6. **Token-conscious.** Every section must justify its inclusion. If removing it wouldn't change agent behavior, remove it.
+7. **Model-neutral.** Write the procedure, not the workaround. See [Write the Procedure, Not the Workaround](#write-the-procedure-not-the-workaround).
+
+## Write the Procedure, Not the Workaround
+
+Skills in this pack run on many agents and model generations. A step that exists because one model gets a specific call wrong is a liability on every other model: it constrains agents that would have solved the task directly, and it spends turns that stronger models need for the actual work. Cross-model transfer measurements ([WikiSkill, arXiv:2608.27454](https://arxiv.org/abs/2608.27454)) show skills authored against one model's execution failures can leave a stronger model performing *worse than with no skill at all*.
+
+**The rule:** if a step cannot be justified without naming a model, a model version, or one agent's private tool name, it belongs in an issue, not in a skill. Describe the capability ("run the focused test command", "write the file"), not the mechanism one runtime happens to expose (`run_command`, `write_to_file`).
+
+Two smells to check for before proposing skill content:
+
+- **Over-specified mechanics.** Prescribing an exact command form or serialization detail where stating the goal alone would do. If the justification is "model X gets this wrong otherwise", it's a workaround, not a procedure.
+- **Fragmented diagnostics.** A multi-step inspection sequence where one step would confirm the same thing. Every extra step spends turns, and turn budget is finite.
+
+This is about skill *content*; the portability of `references/` *paths* is a separate concern (see [Shared References](#shared-references)).
 
 ## Naming Conventions
 


### PR DESCRIPTION
Implements #534, which @addyosmani endorsed ("Writing it into skill-anatomy and CONTRIBUTING is the right move… I'd take this"). Checked before starting: no open or closed PR references the issue, and no commits touch these sections for it.

## What changed

**`docs/skill-anatomy.md`**
- New section **Write the Procedure, Not the Workaround**: the rule (a step that can't be justified without naming a model, a model version, or one agent's private tool name belongs in an issue, not a skill — describe the capability, not the mechanism one runtime exposes), the two smells from #534's evidence (**over-specified mechanics**, **fragmented diagnostics**), and the WikiSkill citation for the cross-model transfer failure mode. Explicitly scoped to skill *content*, with a pointer distinguishing it from the `references/` *path* portability concern (#361).
- Writing Principles gains **7. Model-neutral** linking to the section.

**`CONTRIBUTING.md`**
- Pre-flight check 5: **Strip model-specific workarounds**, one line, linking to the anatomy section.

## Framing choices

- Kept tight per the review guidance on #534 — the rule is stated in terms of capability vs. mechanism, and the tool-name half encodes the #497 review precedent (hardcoded `run_command`/`write_to_file`) so the ad-hoc review position is now written down.
- Per the issue's own caveats, the citation is used for the *mechanism and direction* of the effect, not the percentages.
- Docs only; auditing existing skills against the rule stays follow-up work with #432, as the issue scoped it.

## Verification

- `node scripts/validate-skills.js` — 25 skills, 0 errors
- `node scripts/validate-reference-links.js` — 0 errors
- Anchors checked: both new links resolve (`#write-the-procedure-not-the-workaround`, `#shared-references`)

Closes #534.