### PR TITLE
docs(observability): name the entry point when several write to one log

### DIFF
--- a/references/observability-checklist.md
+++ b/references/observability-checklist.md
@@ -26,6 +26,7 @@ Telemetry without a question is noise. Before instrumenting anything:
 - [ ] Logs are structured (JSON) with stable event names — not free-form strings
 - [ ] Every log line carries a correlation/request ID, generated or accepted at the system boundary
 - [ ] Correlation ID is propagated on every outbound call and async boundary (HTTP headers, queue metadata)
+- [ ] Any log stream written by more than one entry point (scheduler, replay endpoint, manual run) carries an entry-point field, set where the run starts and propagated alongside the correlation ID
 - [ ] Log levels are consistent: `error` = invariant broken, someone may act; `warn` = degraded but handled; `info` = significant business event; `debug` = off in production
 - [ ] No secrets, tokens, passwords, or unredacted PII in any log line (hard rule from `security-and-hardening`)
 - [ ] Fields are allowlisted — no whole request/response bodies, no auth headers

--- a/skills/observability-and-instrumentation/SKILL.md
+++ b/skills/observability-and-instrumentation/SKILL.md
@@ -88,6 +88,21 @@ app.use((req, res, next) => {
 });
 ```
 
+**When several entry points write to one log, name the entry point.** A correlation ID identifies a run; it does not say which code path started it. The same job reached by a scheduler, by a replay endpoint, and by a manual CLI run produces interchangeable lines in one sink, so attributing a line falls back to elimination — cross-reading the scheduler's history, the process table, a deploy log — and that argument holds only as long as those external records happen to still exist. Stamp the entry point where the run starts, next to the correlation ID, and propagate both the same way:
+
+```typescript
+// One helper for every entry point: the run's own logger carries both fields.
+// `entryPoint`, not `source` — ECS reserves `source.*` for network fields.
+export const runLog = (entryPoint: 'scheduler' | 'replay_endpoint' | 'cli', runId: string) =>
+  logger.child({ entryPoint, requestId: runId });
+
+// scheduler tick        -> runLog('scheduler', crypto.randomUUID())
+// POST /jobs/:id/replay -> runLog('replay_endpoint', req.id)
+// CLI invocation        -> runLog('cli', process.env.RUN_ID ?? crypto.randomUUID())
+```
+
+Both fields have to cross the same boundaries as the correlation ID — queue metadata, HTTP headers — or a worker re-derives the entry point and guesses. A field that merely correlates with an entry point is a hint, not an attribution: anything that can invoke the job can reproduce it.
+
 **Never log secrets, tokens, passwords, or full PII.** This is a hard rule from the `security-and-hardening` skill — telemetry pipelines are a classic data-leak path. Allowlist fields; don't log whole request bodies.
 
 ### 4. Metrics
@@ -180,6 +195,7 @@ Instrumentation is code; it can be wrong. Before calling the work done, trigger 
 - A feature PR with retries, queues, or external calls and zero new telemetry
 - Log lines built by string interpolation instead of structured fields
 - No correlation/request ID — each log line is an orphan
+- One log stream fed by a scheduler, a webhook, and manual runs, with no field naming which one produced the line
 - Metrics labeled with user IDs, raw URLs, or error message text (cardinality bomb)
 - Latency tracked as an average with no percentiles
 - Alerts that fire daily and get acknowledged without action
@@ -193,6 +209,7 @@ After instrumenting a feature, confirm:
 
 - [ ] The on-call questions for this feature are written down, and each signal maps to one
 - [ ] All log output is structured (JSON), with stable event names and a correlation ID on every line
+- [ ] Every log sink written by more than one entry point carries an entry-point field, set where the run starts and propagated with the correlation ID rather than inferred downstream
 - [ ] No secrets, tokens, or unredacted PII in any log line (spot-check actual output)
 - [ ] RED metrics exist for every new endpoint and every external dependency, with bounded label sets
 - [ ] Latency is a histogram; p95/p99 are queryable


### PR DESCRIPTION
## What

`### 3. Structured logging` makes correlation IDs mandatory and says why: *"Without it, you cannot reconstruct a single request from interleaved logs."* That answers **which run**. It does not answer **which code path started the run**.

When one job is reachable from a scheduler, from a replay endpoint and from a manual CLI run, all three write interchangeable lines into the same sink. Attributing a line then falls back to elimination — cross-reading the scheduler's history, the process table, a deploy log — and that argument holds only as long as those external records happen to still exist. The failure is quiet: every checkbox this skill already has still passes while the question *"who wrote this line?"* has no answer inside the line.

This adds one paragraph and a short example to step 3 — stamp the entry point where the run starts, next to the correlation ID, and propagate both the same way — plus matching one-liners in Red Flags, Verification, and `references/observability-checklist.md`. It also names the trap that makes the gap look closed: a field that merely *correlates* with an entry point (a PID, a hostname, a CLI argument) is a hint, not an attribution, because anything that can invoke the job can reproduce it.

Two details are deliberate. The example creates the child from the **run's** logger, so the entry point rides next to the mandatory `requestId` instead of replacing it — a process-wide `logger.child({ … })` at module scope would be source-only and would leave concurrent runs uncorrelated. And both fields have to cross the same boundaries as the correlation ID (queue metadata, HTTP headers), or a worker re-derives the entry point and guesses.

## Why here, and why not a new skill

- The skill already owns the ground: *"Log events, not prose"*, the mandatory correlation ID, the Red Flag *"each log line is an orphan"*, the Verification line on structured output. The new rule sits in the same step, in the same voice, and reuses the existing `logger.child` idiom.
- `When to Use` already claims background jobs, so multi-entry-point workloads are in scope today.
- No other skill in the pack covers it. `debugging-and-error-recovery` mentions logs twelve times but only as evidence to preserve; `shipping-and-launch` only as a launch checkbox (*"Logging and error reporting configured"*). A repo-wide grep across `skills/`, `references/` and `agents/` for `who (wrote|emitted)|which (writer|trigger|caller)|log source|entry ?point|provenance|emitter|invocation source|triggered by` returns only the supply-chain provenance lines in `security-and-hardening` and their mirror in `references/security-checklist.md` — plus one unrelated *“long tasks triggered by clicks”* in `references/performance-checklist.md`.
- CONTRIBUTING, *Modifying Existing Skills*: *"If your idea is a refinement of an existing skill, prefer a focused edit to that skill over a new directory."* No new directory, no new heading, frontmatter untouched.

## Pre-flight (per CONTRIBUTING)

- **Catalog.** All 527 issues and PRs listed via `issues?state=all` (398 closed / 129 open) and every title read, plus 974 issue comments. The 18 gaps in the number range 1–545 were each queried individually and are all HTTP 404 (deleted), so nothing is hidden behind them.
- **Searched** titles, bodies and comments for `emitter`, `who wrote`, `which trigger`, `trigger field`, `invocation source`, `source field`, `shared log`, `same log`, `multiple writers`, `event source`, `log line`, `which writer` — no hits. The six `provenance` hits (#222, #251, #18, #386, #429, #430) and #52 are about skill/agent provenance, not log fields.
- **Adjacent, read in full:** #223 (created this skill), #240 (created the checklist), #59 and #61 (older observability proposals — diffs grepped, no source/trigger field), #308, #312, #414, #448.
- **Rejected proposals:** `evals/skill-impact.md` at HEAD carries its intro and table header and no rows — no earlier attempt at this.
- Extends rather than adds.

## Scope and size

Two files, **+18 / −0**. `skills/observability-and-instrumentation/SKILL.md` 203 → 220 lines, well inside the 500-line budget in `docs/skill-anatomy.md`. `references/observability-checklist.md` +1 line. No existing prose reworded, frontmatter `description` untouched — so the routing surface is unchanged.

If you would rather keep this to `SKILL.md` only, say the word and I will drop the checklist line; #536 named the identical gap in `references/security-checklist.md` and deliberately left it out, so precedent points both ways.

## Verification

Patched tree, node v24.16.0:

- `node scripts/validate-skills.js` → 25 skills checked — 0 error(s), 0 warning(s) — PASSED
- `node scripts/validate-versions.js` → All plugin manifests use version 0.6.8
- `node scripts/validate-reference-links.js` → 25 skills checked — 0 error(s) — PASSED
- `node scripts/validate-commands.js` → 9 commands checked — 0 error(s) — PASSED
- `node scripts/validate-artifact-paths.js` → 7 files checked — 0 error(s) — PASSED
- `node scripts/run-evals.js --min-rank1 80` → 140 checks passed — 0 error(s), 0 warning(s); trigger rank-1 rate 86 % (76/88) — PASSED, byte-identical to the unpatched baseline at the same HEAD.
- The snippet type-checks under `tsc --strict` (TypeScript 5.9.3), including the three call forms in the trailing comments.

## Relationship to open work

#422 (*docs(observability): expand runbook guidance in alerting section*) is open and approved on the same file. No overlap and no textual conflict: it edits step 6 (Alerting and runbooks), this edits step 3 (Structured logging).

## On the field name

The field is `entryPoint`, not `source`. Elastic Common Schema reserves `source.*` as a field set for network attributes (`source.ip`, `source.port`, …), so emitting a scalar `source` into an ECS-mapped index is a mapping conflict that can get documents rejected — a bad default for guidance this general. `invocationSource` would work equally well; if you prefer it, that is a one-line change in three places.

---

This contribution was researched and drafted with Claude Code (an AI coding agent), then independently reviewed with OpenAI Codex (GPT-5.6-Sol, reasoning effort `max`) — the per-run logger and the `entryPoint` field name both come out of that review; a human reviewed the result and approved the submission.
