### PR TITLE
docs(security): destructive path targets need an allowlist, a depth floor, and an owner check

### DIFF
--- a/references/security-checklist.md
+++ b/references/security-checklist.md
@@ -22,7 +22,7 @@ Quick reference for web application security. Use alongside the `security-and-ha
 
 Before reaching for controls, spend five minutes thinking like an attacker:
 
-- [ ] Trust boundaries mapped (requests, uploads, webhooks, third-party APIs, LLM output)
+- [ ] Trust boundaries mapped (requests, uploads, webhooks, third-party APIs, LLM output, and local values written by processes you don't control)
 - [ ] Assets named (credentials, PII, payment data, admin actions, money movement)
 - [ ] STRIDE run per boundary (Spoofing, Tampering, Repudiation, Info disclosure, DoS, Elevation)
 - [ ] Abuse cases written next to use cases ("how would I misuse this?")
@@ -63,6 +63,46 @@ Before reaching for controls, spend five minutes thinking like an attacker:
 - [ ] HTML output encoded (use framework auto-escaping)
 - [ ] URLs validated before redirect (prevent open redirect)
 - [ ] Server-side URL fetches allowlisted; private/reserved IPs blocked (prevent SSRF)
+- [ ] Destructive path operations (delete/move/overwrite): symlinks resolved, allowlisted root, minimum depth, ownership evidence read before the call
+
+### Destructive Path Operations
+
+Containment for a target named by data. Resolve first, then decide — and treat the
+result as a candidate, not as authorization:
+
+```typescript
+import { realpath, readFile } from 'node:fs/promises';
+import { resolve, relative, isAbsolute, join, sep } from 'node:path';
+
+const ALLOWED_ROOTS = ['/var/lib/myapp/sessions']; // an allowlist, not a pattern
+const MIN_DEPTH = 1;                               // so a root is never the target
+
+async function resolveDeletable(candidate: string, expectedOwner: string) {
+  const target = await realpath(resolve(candidate)); // symlinks resolved BEFORE the check
+  const inRoot = ALLOWED_ROOTS.some((root) => {
+    const rel = relative(root, target);
+    // `rel === '..'` / `'../'` only — a plain `startsWith('..')` would also
+    // reject a legitimate child named `..cache`.
+    if (rel === '' || rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) return false;
+    return rel.split(sep).length >= MIN_DEPTH;
+  });
+  if (!inRoot) throw new Error(`refusing: outside allowed roots (${target})`);
+
+  const owner = await readFile(join(target, '.owner'), 'utf8').catch(() => null);
+  if (owner?.trim() !== expectedOwner) throw new Error(`refusing: unproven owner (${target})`);
+  return target;
+}
+```
+
+What this does not do, and must be said where the snippet is copied from:
+
+- **The marker is self-attestation.** Anything that can write inside the root can write
+  `.owner`. `expectedOwner` has to come from authenticated state, and the marker needs
+  integrity protection (restrictive ownership, or a MAC) before it is authorization
+  rather than a consistency check against a misderived target.
+- **Returning a path leaves a check/use race.** Where an untrusted process can swap an
+  ancestor between the check and the call, operate on a descriptor with no-follow,
+  beneath-the-root semantics, or guarantee the hierarchy is immutable for the duration.
 
 ## Security Headers
 

--- a/skills/security-and-hardening/SKILL.md
+++ b/skills/security-and-hardening/SKILL.md
@@ -22,7 +22,7 @@ Security-first development practices for web applications. Treat every external 
 
 Controls bolted on without a threat model are guesses. Before hardening, spend five minutes thinking like an attacker:
 
-1. **Map the trust boundaries.** Where does untrusted data cross into your system? HTTP requests, form fields, file uploads, webhooks, third-party APIs, message queues, and **LLM output**. Every boundary is attack surface.
+1. **Map the trust boundaries.** Where does untrusted data cross into your system? HTTP requests, form fields, file uploads, webhooks, third-party APIs, message queues, and **LLM output** — plus the local values that look internal because the OS handed them to you: another process's command line or environment, filenames on a shared volume, a path in a job payload. Trust follows who *wrote* a value, not which channel delivered it. Every boundary is attack surface.
 2. **Name the assets.** What's worth stealing or breaking? Credentials, PII, payment data, admin actions, money movement.
 3. **Run STRIDE over each boundary** — a quick lens, not a ceremony:
 
@@ -269,6 +269,14 @@ function validateUpload(file: UploadedFile) {
 }
 ```
 
+### Destructive Operations on Derived Paths
+
+A delete, move, or overwrite is only as safe as the value that names its target. Reading that value from the kernel, a job payload, or a sibling service proves where it *arrived from*, not who *wrote* it — another process's command line is as attacker-controlled as a form field. A shape check ("absolute path, at least one directory deep") proves well-formedness and gets mistaken for authorization; that is how a cleanup routine deletes the root instead of the leaf.
+
+Before a destructive call, require all three: the resolved target sits under an **allowlisted root** (compare after resolving symlinks, never on the raw string); it is at least one level **below** that root, so a root is never itself the target; and it carries **evidence that it is yours**, read *before* the operation and before any teardown that removes it — otherwise "absent" and "not mine" are indistinguishable. On refusal, log the rejected target and stop: a cleanup that falls back to a broader default path is the failure this guards against. Worked example in `../../references/security-checklist.md`.
+
+Two limits, because the check reads stronger than it is. A marker inside the tree is self-attestation — anything that can write there can write the marker — so the expected owner has to come from authenticated state, and the marker needs integrity protection (restrictive ownership, or a MAC) before it counts as authorization. And resolving a path and then operating on the *name* is a check/use race wherever an untrusted process can swap an ancestor: on a shared volume, hold the target by descriptor and use no-follow, beneath-the-root operations, or make sure the hierarchy cannot change for the duration.
+
 ## Triaging Dependency Audit Results
 
 Package-manager audits report known advisories; they do not prove a package is trustworthy or that vulnerable code is reachable. Use this decision tree:
@@ -435,6 +443,7 @@ container.textContent = await llm.reply(userMessage);
 - [ ] SQL queries are parameterized
 - [ ] HTML output is encoded/escaped
 - [ ] Server-side URL fetches are allowlisted (no SSRF to internal services)
+- [ ] Delete/move/overwrite targets built from data are checked against an allowlisted root, a minimum depth, and ownership evidence read before the operation
 
 ### Data
 - [ ] No secrets in code or version control
@@ -483,6 +492,7 @@ For detailed security checklists and pre-commit verification steps, see `../../r
 ## Red Flags
 
 - User input passed directly to database queries, shell commands, or HTML rendering
+- A delete, move, or overwrite whose target comes from a payload, a config value, or another process's command line, guarded only by a shape check on the path
 - Secrets in source code or commit history
 - API endpoints without authentication or authorization checks
 - Missing CORS configuration or wildcard (`*`) origins
@@ -503,6 +513,7 @@ After implementing security-relevant code:
 - [ ] The native audit has no unmitigated reachable critical/high findings; CI preserves the authoritative lockfile and blocks unreviewed dependency scripts
 - [ ] No secrets in source code or git history
 - [ ] All user input validated at system boundaries
+- [ ] Destructive filesystem operations resolve symlinks, then verify allowlisted root, minimum depth, and ownership before running
 - [ ] Authentication and authorization checked on every protected endpoint
 - [ ] Security headers present in response (check with browser DevTools)
 - [ ] Error responses don't expose internal details


### PR DESCRIPTION
## What

Two places in `security-and-hardening` leave a hole between them.

**The trust-boundary list names only remote channels.** Step 1 of *Threat Model First* asks *"Where does untrusted data cross into your system?"* and answers: *"HTTP requests, form fields, file uploads, webhooks, third-party APIs, message queues, and **LLM output**."* Everything the OS hands you locally — another process's command line or environment, a filename on a shared volume, a path inside a job payload — is absent, so it reads as inside the boundary. It isn't: trust follows who *wrote* a value, not which channel delivered it.

**The one rule about destructive actions governs the actor, not the target.** *"Constrain tool and agent permissions (LLM06: Excessive Agency) … require confirmation for destructive or irreversible actions"* answers **who may act**. It does not answer **what gets hit**. A confirmed call with a wrongly derived target deletes the root just the same.

What fills the gap in practice is a shape check — *"absolute path, at least one directory deep"* — which proves well-formedness and gets mistaken for authorization. That is how a cleanup routine deletes the root instead of the leaf.

This PR extends the boundary list by one clause and adds `### Destructive Operations on Derived Paths` next to *File Upload Safety*: an allowlisted root, a minimum depth, and ownership evidence read **before** the operation, with symlinks resolved first. Plus one line each in the Input checklist, Red Flags and Verification. The section in `SKILL.md` is prose only; the worked example lives in `references/security-checklist.md`, which is what `docs/skill-anatomy.md` asks for and what keeps the per-activation cost to eleven lines.

## Why here, and why not a new skill

- The skill already reaches past HTTP: *Injection (SQL, NoSQL, **OS Command**)*, File Upload Safety, Secrets Management, Supply-Chain Hygiene. A worker deleting a tenant's upload directory named by a queue payload is the same shape as an upload path validated on the way in — one is covered today, the other is not.
- Path validation is genuinely absent, not implied: `grep -ci traversal` over `SKILL.md` at HEAD returns **0**, and the seven occurrences of `allowlist` cover SSRF hosts, field allowlists, a dependency exception list and an agent-action allowlist — never a filesystem path.
- Repo-wide, no skill states a rule about the *target* of a destructive filesystem operation. `destructive` appears seven times in the whole pack: three in `deprecation-and-migration` about database migrations, and four that are the LLM06 permission rule above plus its checklist and OWASP-table mirrors.
- Placement follows the local pattern rather than breaking it: the new `###` is the third sibling under `## Input Validation Patterns`, next to `### Schema Validation at Boundaries` and `### File Upload Safety`. No numbered step is disturbed.
- CONTRIBUTING, *Modifying Existing Skills*, and your own closing note on #129 — *"a focused addition to that skill would be welcome"* — point here. No new directory, frontmatter untouched.

## Pre-flight (per CONTRIBUTING)

- **Catalog.** All 527 issues and PRs listed via `issues?state=all` (86 issues closed, 67 open, 312 PRs closed, 62 open); every title read.
- **Bodies** grepped locally: `rm -rf` 0, `/proc/` 0, `cmdline` 0, `pid file` 0, `process metadata` 0, `os command` 0, `deletion target` 0, `minimum depth` 0, `ownership proof` 0. `path traversal` 2 — both about this repo's own eval pipeline (#454, #456). **Comments:** `cmdline` 0, `pidfile` 0, `deletion target` 0; the single `rm -rf` hit is #124 (a CI linter for dangerous command patterns *in skill text*).
- **Nearest neighbours, all read:** #294/#295 harden this repo's own opt-in hooks, not skill doctrine; #533 and #520 wanted a *new* runtime skill and were closed; #219/#392/#470/#536 extend this skill on other topics.
- **Rejected proposals:** `evals/skill-impact.md` at HEAD (added by #544) carries its intro and table header and no rows — no earlier attempt at this.
- **Open PRs on this file:** only #434, which changes the frontmatter `description` and none of the six anchors here. (It predates the description clause that landed via #537, so it will need a rebase regardless.)

## Scope and size, and the line budget

Two files, **+53 / −2**. `skills/security-and-hardening/SKILL.md` 513 → **524** (+11). `references/security-checklist.md` 205 → 245 (+40, of which 28 are the fenced example and its two caveats).

`docs/skill-anatomy.md` says *"Keep `SKILL.md` under 500 lines. Move detailed reference material into supporting files."* This file is the longest in the pack and was already over at 513, so rather than flag the overage and offer to fix it later, the split is already done: the rule stays in the workflow, the code moves to the companion file. If you would rather this cost nothing at all in `SKILL.md`, the *Two limits* paragraph can also move to the reference (−4 more), leaving +7.

## Verification

Patched tree, node v24.16.0:

- `node scripts/validate-skills.js` → 25 skills checked — 0 error(s), 0 warning(s) — PASSED
- `node scripts/validate-versions.js` → All plugin manifests use version 0.6.8
- `node scripts/validate-reference-links.js` → 25 skills checked — 0 error(s) — PASSED
- `node scripts/validate-commands.js` → 9 commands checked — 0 error(s) — PASSED
- `node scripts/validate-artifact-paths.js` → 7 files checked — 0 error(s) — PASSED
- `node scripts/run-evals.js --min-rank1 80` → 140 checks passed — 0 error(s), 0 warning(s); trigger rank-1 rate 86 % (76/88) — PASSED, identical to the unpatched baseline (the frontmatter `description` is untouched).

The snippet type-checks under `tsc --strict` (TypeScript 5.9.3, `@types/node`) and was run as an ESM equivalent against ten cases in a throwaway fixture: an allowed target with a matching marker → accepted; a legitimate child named `..cache` → accepted; `<root>/abc/./` → accepted; the root itself → refused; `<root>/../../..` → refused; the prefix sibling `<root>X/abc` → refused; an unrelated absolute path → refused; a target with no marker → refused; a marker naming a different owner → refused; a symlink pointing out of the root → refused, because `realpath` runs before the check.

## What the check does not claim

Both limits are in the patch, next to the snippet, rather than implied away — a containment check that reads like authorization is the failure mode this section is about, so overselling it here would be self-defeating:

- **A marker inside the tree is self-attestation.** Anything that can write under the allowlisted root can write `.owner`, or make it a symlink. The expected owner has to come from authenticated state, and the marker needs integrity protection (restrictive ownership, or a MAC), before it is authorization rather than a consistency check against a misderived target.
- **Resolving a path and then operating on the name is a check/use race.** Where an untrusted process can swap an ancestor between `realpath` and the call, the operation has to run against a descriptor with no-follow, beneath-the-root semantics, or the hierarchy has to be immutable for the duration.

The containment predicate is also written as `rel === '..' || rel.startsWith('..' + sep)` rather than `rel.startsWith('..')`, with a comment saying why: the short form rejects a legitimate child named `..cache`, which hands an untrusted naming source a way to make cleanup refuse forever.

---

This contribution was researched and drafted with Claude Code (an AI coding agent), then independently reviewed with OpenAI Codex (GPT-5.6-Sol, reasoning effort `max`) — the two stated limits, the `..cache` correction in the containment predicate, and moving the worked example out of `SKILL.md` all come out of that review; a human reviewed the result and approved the submission.
