### PR TITLE
docs: explain lifecycle session handoffs (#513)

### DIFF
--- a/docs/adoption-guide.md
+++ b/docs/adoption-guide.md
@@ -43,7 +43,7 @@ Run the lifecycle in order for the project's first real feature:
 /ship   →  when going live     (shipping-and-launch)
 ```
 
-`/build auto` is a good fit for greenfield: you approve the plan once and every task still runs test-driven and commits individually. The spec and plan artifacts (`SPEC.md`, `tasks/`) are living documents, keep them in version control while the work is in flight.
+`/build auto` is a good fit for greenfield: you approve the plan once and every task still runs test-driven and commits individually. The spec and plan artifacts (`SPEC.md`, `tasks/`) are living documents, keep them in version control while the work is in flight. If the feature spans more than one session, those files are also the handoff, see [working across sessions](getting-started.md#working-across-sessions).
 
 ### From the start, treat these as always-on
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,6 +156,23 @@ The `/spec` and `/plan` commands create working artifacts (`SPEC.md`, `tasks/pla
 - Update them when scope or decisions change.
 - If your repo doesn’t want these files long‑term, delete them before merge or add the folder to `.gitignore` — the workflow doesn’t require them to be permanent.
 
+### Working across sessions
+
+The same artifacts are the handoff between sessions. For a small task, run the whole lifecycle in one session. For anything non-trivial, a fresh session per phase (spec → plan → build → review) keeps context focused — what carries the work forward is the approved files, not the conversation:
+
+- the spec — `SPEC.md`, or wherever your spec actually lives
+- `tasks/plan.md` and `tasks/todo.md` — or the external tracker the plan identifies, if you use one
+
+**Before switching**, make sure those files reflect the decisions that still apply, the scope you approved, the questions still open, the next task, and the current verification state (which tests ran, against what).
+
+**In the new session**, read the actual files and look at `git status` before doing anything. Don't assume approvals you can't see in the artifacts. Treat a recorded "tests pass" as a claim about a specific baseline: re-run the checks it covers if the code has moved since, if it doesn't say what was run against what, or if you're about to touch the area it covered. If the baseline still holds, take it and get on with the next task — the point is a check proportional to what changed, not a full suite at every handoff.
+
+This doesn't need the `/spec` and `/plan` wrappers — plain requests work in any agent, including a `npx skills add` install that only has the skills:
+
+> Read SPEC.md, then break it into small verifiable tasks with acceptance criteria and dependency order. Save them to tasks/plan.md and tasks/todo.md. No product code yet — show me the plan first.
+
+> Read SPEC.md, tasks/plan.md and tasks/todo.md, then check where things actually stand — `git status`, plus re-running whatever checks the recorded verification state no longer covers. Tell me the next unchecked task and anything still open, then stop: I'll confirm the scope before you start it. If the plan looks incomplete, say what's missing rather than rewriting it.
+
 ## Tips
 
 1. **Start with spec-driven-development** for any non-trivial work


### PR DESCRIPTION
Fixes #513.

The getting-started guide does not explain how to continue the lifecycle in a fresh session. Document the maintainer's guidance: one session is fine for small changes; use the approved spec and plan/task files to hand off non-trivial work between phases. Add concrete planning and resume prompts that also work with a skills-only installation, and link the guidance from the adoption guide.

The handoff records scope, open questions, the next task, and the verification baseline. The next session checks the actual files and working tree, reruns checks when their evidence no longer applies, and confirms scope before implementation. It does not promise measured token savings or import a commenter's private command workflow.

### Validation

- PASS: `node --test scripts/*-test.js scripts/lib/*-test.js` — 43 existing tests on this standalone branch.
- PASS: skill, command, artifact-path, reference-link, and version validators; `node scripts/run-evals.js --min-rank1 80`; local documentation links/anchors; `git diff --check`.
- PASS: independent read-only review of the final content.

Documentation only; no command or skill behavior changes. The incomplete-plan protection already present on main is preserved, and this does not modify the tool command files in #531.
