### PR TITLE
docs: clarify setup for existing projects

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,6 +39,18 @@ Copy the relevant `SKILL.md` content into your agent's system prompt, rules file
 
 Start with the `using-agent-skills` skill loaded. It contains a flowchart that maps task types to the appropriate skill.
 
+### Existing projects need no migration
+
+Install the pack from the existing project's root using the normal setup path
+for your agent, then keep working in that project. Skills activate for matching
+tasks; they do not require a new repository layout or a one-time conversion of
+existing code.
+
+Do not copy this repository's root `AGENTS.md` or `CLAUDE.md` into the project.
+Those files configure contributors to agent-skills itself. Add only the skills
+and any project-specific instructions your agent normally reads. For a gradual
+rollout in an established codebase, follow the [Adoption Guide](adoption-guide.md).
+
 ## Recommended Setup
 
 Rolling out to a real project? The **[Adoption Guide](adoption-guide.md)** covers two end-to-end paths: the full lifecycle from day one for a greenfield project, and an incremental, verification-first rollout for an established codebase. The setup below is the quick version.


### PR DESCRIPTION
Closes #208.

## Summary

Add an explicit existing-project setup section to the universal getting-started guide.

The new guidance makes the maintainer's issue answer durable:

- install from the existing project's root through the normal agent-specific path
- no repository-layout migration or code conversion is required
- skills activate for matching tasks
- do not copy this repository's contributor-only root `AGENTS.md` or `CLAUDE.md`
- use the existing adoption guide for a gradual rollout

## Verification

- `git diff --check`: passed
- verified the relative Adoption Guide link already resolves
- docs-only change; no executable tests were required