### PR TITLE
docs(spec): clarify external artifact ownership

### DIFF
--- a/skills/spec-driven-development/SKILL.md
+++ b/skills/spec-driven-development/SKILL.md
@@ -147,6 +147,12 @@ Don't silently fill in ambiguous requirements. The spec's entire purpose is to s
 [Anything unresolved that needs human input]
 ```
 
+**External spec tools:** This workflow is format-agnostic. If the project
+already uses OpenSpec or another specification system, keep that system's
+artifact format and storage conventions instead of creating a duplicate
+`SPEC.md`. This skill owns the clarification, content, and approval gates; the
+external tool owns how the approved spec is represented.
+
 **Reframe instructions as success criteria.** When receiving vague requirements, translate them into concrete conditions:
 
 ```


### PR DESCRIPTION
Closes #166.

## Summary

Clarify how `spec-driven-development` interoperates with OpenSpec and other external specification systems:

- keep the external tool's artifact format and storage conventions
- do not create a duplicate `SPEC.md`
- let this skill own clarification, spec content, and approval gates
- let the external tool own representation

This documents the tool-agnostic behavior already confirmed by the maintainer without adding an OpenSpec dependency or a second workflow.

## Verification

- `node scripts/validate-skills.js`: 25 skills passed, 0 errors, 0 warnings
- `node scripts/run-evals.js --min-rank1 80`: 140 checks passed; rank-1 86%
- `node scripts/validate-artifact-paths.js`: 7 guarded files passed
- `git diff --check`: passed

Behavioral model grading was not run; the change clarifies artifact ownership and does not alter routing/frontmatter.