### PR TITLE
docs: add curated community videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ Skills are plain Markdown - they work with any agent that accepts system prompts
 
 Already installed? How you roll the pack out depends on your codebase. The **[Adoption Guide](docs/adoption-guide.md)** covers two paths: the full lifecycle from day one for a greenfield project, or an incremental, verification-first rollout for an established codebase.
 
+Prefer to watch a complete run? See the **[community videos](docs/community-videos.md)**
+for an end-to-end build and a maintainer walkthrough.
+
 ---
 
 ## All 24 Skills

--- a/docs/community-videos.md
+++ b/docs/community-videos.md
@@ -1,0 +1,24 @@
+# Community Videos
+
+These community walkthroughs show agent-skills in real development workflows.
+They complement the written setup guides with complete runs and maintainer
+discussion.
+
+## End-to-end build
+
+- [One File In, One App Out: Building a React App with Addy Osmani's
+  agent-skills](https://www.youtube.com/watch?v=pJfXm4MFBXU) by Federico
+  Bartoli — builds a React app from an OpenAPI contract through spec, plan,
+  build, test, review, and ship.
+
+## Maintainer walkthrough
+
+- [Agent Skills | LIVE150](https://www.youtube.com/watch?v=Q6LR0mXArIQ) by
+  Microsoft Developer — a live overview and demonstration with Addy Osmani.
+
+## Suggest a video
+
+Add a link to [the community videos issue](https://github.com/addyosmani/agent-skills/issues/527)
+with the creator, agent or tool used, workflow phases covered, and a public
+example repository when one is available. Videos should demonstrate a real
+workflow rather than only describe the catalog.


### PR DESCRIPTION
Closes #527.

## Summary

Add a curated Community Videos page and link it from the README.

The first two entries come directly from the community video and demo issue threads:

- Federico Bartoli's end-to-end React build from an OpenAPI contract
- Microsoft Developer's live Agent Skills walkthrough with Addy Osmani

The page also gives future submissions a small evidence bar: identify the creator and tool, name the workflow phases covered, and include a public example repository when available.

## Verification

- verified both video titles and creators through YouTube's oEmbed endpoint on 2026-09-05
- verified the new README link resolves to `docs/community-videos.md`
- `git diff --check`: passed
- docs-only change; no executable tests were required