### PR TITLE
docs: link runnable workflow tutorials

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,11 @@
 
 agent-skills works with any AI coding agent that accepts Markdown instructions. This guide covers the universal approach. For tool-specific setup, see the dedicated guides.
 
+Want a worked example before setting up your own project? The
+[interactive tutorials](https://skills.addy.ie/tutorials/) walk through a
+greenfield build, a brownfield feature, and a safe automation loop with
+copyable prompts for Claude Code, Codex, or any other agent.
+
 ## How Skills Work
 
 Each skill is a Markdown file (`SKILL.md`) that describes a specific engineering workflow. When loaded into an agent's context, the agent follows the workflow — including verification steps, anti-patterns to avoid, and exit criteria.


### PR DESCRIPTION
Closes #262.

## Summary

Link the official runnable tutorials from the top of the universal getting-started guide.

The tutorial site now covers the practical gap described in the issue with three copyable walkthroughs:

- greenfield: build from an empty folder
- brownfield: add a feature to an existing codebase
- loop engineering: automate one verified change safely

The link is intentionally separate from the community-video catalog proposed in #527: this PR points readers to maintained, step-by-step exercises they can run themselves.

## Verification

- `curl -I https://skills.addy.ie/tutorials/`: HTTP 200 on 2026-09-05
- inspected the page and confirmed all three tutorial tracks and agent-specific instructions
- `git diff --check`: passed
- docs-only change; no executable tests were required