### PR TITLE
docs: define agent-first CLI support criteria

### DIFF
--- a/references/agent-first-clis.md
+++ b/references/agent-first-clis.md
@@ -1,0 +1,85 @@
+# Agent-First CLI Support Criteria
+
+Use this reference when a skill recommends a command-line tool or changes the flags used to call one. The goal is reliable automation, not a preferred terminal aesthetic.
+
+Last reviewed: 2026-09-05
+
+## Support Decision
+
+A CLI can be a documented default only when all of these are true:
+
+1. **Non-interactive:** It can complete without prompts, a TTY, a pager, or user input.
+2. **Parseable:** It has a documented structured or stable machine-readable format. Color, progress bars, and decorative output can be disabled.
+3. **Explicit exit semantics:** Success, an empty result, and an execution error can be distinguished without parsing prose.
+4. **Deterministic:** The same inputs produce stable ordering and fields, or the caller can request or apply a stable sort.
+5. **Safe to probe:** Read-only, dry-run, or idempotent use is available for discovery before mutation.
+6. **Maintained and compatible:** The upstream project is active, its license is acceptable, and the documented flags work on the minimum version the skill supports.
+
+If one of these is missing, treat the tool as an optional enhancement. Check for it first, provide a portable fallback, and do not make the workflow depend on it.
+
+## Required Documentation for a CLI Recommendation
+
+Record these facts next to the recommendation or in the contributing PR:
+
+- upstream documentation URL and review date;
+- minimum tested version, when a flag is version-dependent;
+- exact non-interactive and machine-readable flags;
+- exit-code meanings, including the code for an empty result;
+- read-only or dry-run mode, permissions required, and fallback command.
+
+Do not add a dependency only to make output prettier. Prefer the repository's installed tools, the standard library, and native platform commands first.
+
+## Patterns for Current Skills
+
+### Search and context collection
+
+- Use `rg --json` when a script will parse match events. For direct agent reading, concise `rg -n` output can cost less context than the JSON event stream.
+- Treat an empty search as data, not a crash. `rg` uses exit code 1 when no lines match and 2 for an error.
+- Use `--glob` or an explicit path to bound searches. Do not scan generated output or dependency trees unless the task requires it.
+
+See ripgrep's [`--json` flag documentation](https://github.com/BurntSushi/ripgrep/blob/master/crates/core/flags/defs.rs) and [exit status documentation](https://github.com/BurntSushi/ripgrep/blob/master/crates/core/flags/doc/template.rg.1).
+
+### Git inspection
+
+- Use stable formats when another command consumes the result: `git status --porcelain=v1`, `git diff --numstat`, or `git log --format=...`.
+- Disable presentation layers in captured output with `--no-pager` and `--no-color` where applicable.
+- Prefer read-only inspection before a mutation. A parseable status does not authorize `add`, `commit`, `push`, or history rewriting.
+
+See Git's [porcelain format guarantee](https://git-scm.com/docs/git-status#_porcelain_format_version_1) and [`git diff` output options](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---numstat).
+
+### GitHub operations
+
+- Request only needed fields with `gh ... --json <fields>` and filter locally with `--jq` or `--template`.
+- Run `gh auth status` before workflows that require authentication.
+- Use explicit repository and branch arguments in automation; do not depend on an interactive repository picker.
+
+See the GitHub CLI [JSON formatting reference](https://cli.github.com/manual/gh_help_formatting).
+
+### Static analysis and CI
+
+- Use the analyzer already configured by the repository. Prefer its documented JSON, JSON Lines, or SARIF mode when results feed another tool.
+- Preserve the analyzer's exit code and stderr. Do not convert a failed analysis into an empty findings list.
+- If no structured mode exists, keep the native text output and document its limits instead of adding a parser for unstable prose.
+
+## Preflight Pattern
+
+Before an optional CLI is used, verify that it is installed and can run:
+
+```bash
+if command -v tool-name >/dev/null 2>&1 && tool-name --version >/dev/null 2>&1; then
+  tool-name --machine-readable ...
+else
+  portable-fallback ...
+fi
+```
+
+Replace the placeholders with commands verified in that skill. Never invent a binary name, flag, or fallback from this generic pattern.
+
+## Review Checklist
+
+- [ ] The command is non-interactive in the environment where the skill runs.
+- [ ] Structured output and exit codes come from upstream documentation.
+- [ ] Empty results remain distinguishable from execution failures.
+- [ ] Mutating commands have an explicit authorization or confirmation boundary.
+- [ ] Optional tools have a preflight and a documented fallback.
+- [ ] The recommendation records the version and date that were verified.

--- a/skills/code-review-and-quality/SKILL.md
+++ b/skills/code-review-and-quality/SKILL.md
@@ -348,6 +348,7 @@ For triaging `npm audit` findings and supply-chain risk (typosquatting, compromi
 ```
 ## See Also
 
+- For choosing parseable, non-interactive static-analysis commands, see `../../references/agent-first-clis.md`
 - For detailed security review guidance, see `../../references/security-checklist.md`
 - For performance review checks, see `../../references/performance-checklist.md`
 

--- a/skills/context-engineering/SKILL.md
+++ b/skills/context-engineering/SKILL.md
@@ -89,6 +89,8 @@ Load the relevant spec section when starting a feature. Don't load the entire sp
 
 Before editing a file, read it. Before implementing a pattern, find an existing example in the codebase.
 
+For search commands used to collect context, follow `../../references/agent-first-clis.md`: bound the search, preserve empty-result exit semantics, and choose structured output only when another command will parse it.
+
 **Pre-task context loading:**
 1. Read the file(s) you'll modify
 2. Read related test files

--- a/skills/debugging-and-error-recovery/SKILL.md
+++ b/skills/debugging-and-error-recovery/SKILL.md
@@ -9,6 +9,8 @@ description: Guides systematic root-cause debugging. Use when tests fail, builds
 
 Systematic debugging with structured triage. When something breaks, stop adding features, preserve evidence, and follow a structured process to find and fix the root cause. Guessing wastes time. The triage checklist works for test failures, build errors, runtime bugs, and production incidents.
 
+When a CLI captures or transforms evidence, apply the support criteria and failure-preserving patterns in `../../references/agent-first-clis.md`.
+
 ## When to Use
 
 - Tests fail after a code change

--- a/skills/git-workflow-and-versioning/SKILL.md
+++ b/skills/git-workflow-and-versioning/SKILL.md
@@ -210,6 +210,8 @@ This pattern catches wrong assumptions early and gives reviewers a clear map of 
 
 ## Pre-Commit Hygiene
 
+For machine-consumed status, diff, and history output, use the stable Git formats and safety boundary in `../../references/agent-first-clis.md`.
+
 Before every commit:
 
 ```bash


### PR DESCRIPTION
## Summary

- add a shared decision reference for recommending agent-safe CLIs
- document non-interactive, parseable, deterministic, safe-probe, and maintenance requirements
- give concrete patterns for search, Git, GitHub, static-analysis, and CI commands
- link the reference from the four skills identified in the issue

## Verification

- `node scripts/validate-skills.js` (25 skills, 0 errors, 0 warnings)
- `node scripts/run-evals.js` (140 checks, 0 errors, rank-1 86%)
- `node scripts/validate-reference-links.js` (25 skills, 0 errors)
- `git diff --check`
- all five upstream documentation links returned HTTP 200 on 2026-09-05

Behavioral model grading was not run; descriptions and routing behavior are unchanged.

Closes #245