### PR TITLE
fix(evals): reject null grader expectations without crashing

### DIFF
--- a/scripts/run-evals-test.js
+++ b/scripts/run-evals-test.js
@@ -90,6 +90,25 @@ test('rejects grader results that omit expectations', () => {
   assert.equal(parseGrading(raw, 2), null);
 });
 
+test('rejects null expectation entries without throwing', () => {
+  for (const expectations of [
+    [null],
+    [{ text: 'first expectation', passed: true, evidence: 'observed' }, null],
+  ]) {
+    const raw = JSON.stringify({
+      expectations,
+      summary: {
+        passed: expectations.length - 1,
+        failed: 1,
+        total: expectations.length,
+        pass_rate: (expectations.length - 1) / expectations.length,
+      },
+    });
+
+    assert.equal(parseGrading(raw, expectations.length), null);
+  }
+});
+
 test('rejects incomplete or inconsistent grader summaries', () => {
   const expectation = { text: 'expected behavior', passed: false, evidence: 'not observed' };
   const cases = [

--- a/scripts/run-evals.js
+++ b/scripts/run-evals.js
@@ -439,12 +439,13 @@ function parseGrading(raw, expectedCount) {
   const expectations = g.expectations;
   const summary = g.summary;
   const passed = Array.isArray(expectations)
-    ? expectations.filter((expectation) => expectation.passed === true).length
+    ? expectations.filter((expectation) => expectation?.passed === true).length
     : 0;
   const ok =
     Number.isInteger(expectedCount) && expectedCount > 0 &&
     Array.isArray(expectations) && expectations.length === expectedCount &&
     expectations.every((expectation) =>
+      expectation !== null &&
       typeof expectation.text === 'string' &&
       typeof expectation.passed === 'boolean' &&
       typeof expectation.evidence === 'string') &&


### PR DESCRIPTION
# fix(evals): reject null grader expectations without crashing

When a behavioral grader returns valid JSON containing a null expectation, `parseGrading` throws a `TypeError` while counting passed expectations. This aborts the batch before the invalid response is saved and prevents later evals from running.

Guard both expectation reads so the parser returns `null` for these malformed results. The existing caller then saves the raw response, counts the evaluation as failed, and continues. Valid grader responses retain their existing behavior.

The regression test covers an all-null expectation list and a mixed valid/null list. It failed with `Cannot read properties of null (reading 'passed')` before the fix and passes afterward.

Validation:

- All 44 JavaScript tests passed: `node --test scripts/*-test.js scripts/lib/*-test.js`.
- Deterministic evaluations passed: 140 checks; rank-1 routing 76/88 (86%), above the required 80%.
- Skill, version, reference-link, command, and artifact-path validators passed.
- A local CLI smoke test with a simulated grader verified raw invalid-response persistence, completion of a second evaluation, and exit code 1 for the batch. No live model calls were made.
- `git diff --check` passed.

This follows the validation added in https://github.com/addyosmani/agent-skills/pull/473 and addresses the remaining null-entry crash. No matching open fix was found in the PR search.
